### PR TITLE
Transparent / Gradual Increase to RAM Supply

### DIFF
--- a/eosio.system/abi/eosio.system.abi
+++ b/eosio.system/abi/eosio.system.abi
@@ -488,6 +488,10 @@
       "type": "setram",
       "ricardian_contract": ""
    },{
+      "name": "setramrate",
+      "type": "setramrate",
+      "ricardian_contract": "Sets the number of new bytes of ram to create per block and resyncs bancor connector balances and weights to eosio.ram and 50% CRR"
+   },{
       "name": "bidname",
       "type": "bidname",
       "ricardian_contract": ""

--- a/eosio.system/abi/eosio.system.abi
+++ b/eosio.system/abi/eosio.system.abi
@@ -247,6 +247,7 @@
          {"name":"new_ram_per_block",   "type":"uint16"},
          {"name":"last_ram_increase",   "type":"block_timestamp_type"},
          {"name":"last_block_num",      "type":"block_timestamp_type"},
+         {"name":"reserved",            "type":"float64"},
          {"name":"revision",            "type":"uint8"}
       ]
     },{

--- a/eosio.system/abi/eosio.system.abi
+++ b/eosio.system/abi/eosio.system.abi
@@ -245,9 +245,9 @@
       "name": "eosio_global_state2",
       "fields": [
          {"name":"new_ram_per_block",   "type":"uint16"},
-         {"name":"last_ram_increase",   "type":"block_timestamp"},
-         {"name":"last_block_num",      "type":"block_timestamp"},
-         {"name":"revision",            "type":"uint8_t"}
+         {"name":"last_ram_increase",   "type":"block_timestamp_type"},
+         {"name":"last_block_num",      "type":"block_timestamp_type"},
+         {"name":"revision",            "type":"uint8"}
       ]
     },{
       "name": "eosio_global_state",

--- a/eosio.system/abi/eosio.system.abi
+++ b/eosio.system/abi/eosio.system.abi
@@ -240,7 +240,14 @@
          {"name":"max_inline_action_size",              "type":"uint32"},
          {"name":"max_inline_action_depth",             "type":"uint16"},
          {"name":"max_authority_depth",                 "type":"uint16"}
-
+      ]
+    },{
+      "name": "eosio_global_state2",
+      "fields": [
+         {"name":"new_ram_per_block",   "type":"uint16"},
+         {"name":"last_ram_increase",   "type":"block_timestamp"},
+         {"name":"last_block_num",      "type":"block_timestamp"},
+         {"name":"revision",            "type":"uint8_t"}
       ]
     },{
       "name": "eosio_global_state",
@@ -293,6 +300,12 @@
       "base": "",
       "fields": [
         {"name":"max_ram_size",     "type":"uint64"}
+      ]
+    },{
+      "name": "setramrate",
+      "base": "",
+      "fields": [
+        {"name":"bytes_per_block",   "type":"uint16"}
       ]
     },{
       "name": "regproxy",
@@ -532,6 +545,12 @@
     },{
       "name": "global",
       "type": "eosio_global_state",
+      "index_type": "i64",
+      "key_names" : [],
+      "key_types" : []
+    },{
+      "name": "global2",
+      "type": "eosio_global_state2",
       "index_type": "i64",
       "key_names" : [],
       "key_types" : []

--- a/eosio.system/include/eosio.system/eosio.system.hpp
+++ b/eosio.system/include/eosio.system/eosio.system.hpp
@@ -70,10 +70,11 @@ namespace eosiosystem {
       uint16_t          new_ram_per_block = 0;  
       block_timestamp   last_ram_increase;
       block_timestamp   last_block_num;
+      double            reserved = 0;
       uint8_t           revision = 0; ///< used to track version updates in the future.
 
 
-      EOSLIB_SERIALIZE( eosio_global_state2, (new_ram_per_block)(last_ram_increase)(last_block_num)(revision) )
+      EOSLIB_SERIALIZE( eosio_global_state2, (new_ram_per_block)(last_ram_increase)(last_block_num)(reserved)(revision) )
    };
 
    struct producer_info {

--- a/eosio.system/include/eosio.system/eosio.system.hpp
+++ b/eosio.system/include/eosio.system/eosio.system.hpp
@@ -61,6 +61,21 @@ namespace eosiosystem {
                                 (last_producer_schedule_size)(total_producer_vote_weight)(last_name_close) )
    };
 
+   /**
+    * Defines new global state parameters added after version 1.0
+    */
+   struct eosio_global_state2 {
+      eosio_global_state2(){}
+
+      uint16_t          new_ram_per_block = 0;  
+      block_timestamp   last_ram_increase;
+      block_timestamp   last_block_num;
+      uint8_t           revision = 0; ///< used to track version updates in the future.
+
+
+      EOSLIB_SERIALIZE( eosio_global_state2, (new_ram_per_block)(last_ram_increase)(last_block_num)(revision) )
+   };
+
    struct producer_info {
       account_name          owner;
       double                total_votes = 0;
@@ -120,6 +135,7 @@ namespace eosiosystem {
                                >  producers_table;
 
    typedef eosio::singleton<N(global), eosio_global_state> global_state_singleton;
+   typedef eosio::singleton<N(global2), eosio_global_state2> global_state2_singleton;
 
    //   static constexpr uint32_t     max_inflation_rate = 5;  // 5% annual inflation
    static constexpr uint32_t     seconds_per_day = 24 * 3600;
@@ -127,11 +143,13 @@ namespace eosiosystem {
 
    class system_contract : public native {
       private:
-         voters_table           _voters;
-         producers_table        _producers;
-         global_state_singleton _global;
+         voters_table            _voters;
+         producers_table         _producers;
+         global_state_singleton  _global;
+         global_state2_singleton _global2;
 
          eosio_global_state     _gstate;
+         eosio_global_state2    _gstate2;
          rammarket              _rammarket;
 
       public:
@@ -200,6 +218,7 @@ namespace eosiosystem {
          void unregprod( const account_name producer );
 
          void setram( uint64_t max_ram_size );
+         void setramrate( uint16_t bytes_per_block );
 
          void voteproducer( const account_name voter, const account_name proxy, const std::vector<account_name>& producers );
 
@@ -217,6 +236,7 @@ namespace eosiosystem {
          void bidname( account_name bidder, account_name newname, asset bid );
       private:
          void update_elected_producers( block_timestamp timestamp );
+         void update_ram_supply();
 
          // Implementation details:
 

--- a/eosio.system/src/delegate_bandwidth.cpp
+++ b/eosio.system/src/delegate_bandwidth.cpp
@@ -86,6 +86,7 @@ namespace eosiosystem {
     *  This action will buy an exact amount of ram and bill the payer the current market price.
     */
    void system_contract::buyrambytes( account_name payer, account_name receiver, uint32_t bytes ) {
+      
       auto itr = _rammarket.find(S(4,RAMCORE));
       auto tmp = *itr;
       auto eosout = tmp.convert( asset(bytes,S(0,RAM)), CORE_SYMBOL );
@@ -105,6 +106,8 @@ namespace eosiosystem {
    void system_contract::buyram( account_name payer, account_name receiver, asset quant )
    {
       require_auth( payer );
+      update_ram_supply();
+
       eosio_assert( quant.amount > 0, "must purchase a positive amount" );
 
       auto fee = quant;
@@ -161,6 +164,8 @@ namespace eosiosystem {
     */
    void system_contract::sellram( account_name account, int64_t bytes ) {
       require_auth( account );
+      update_ram_supply();
+
       eosio_assert( bytes > 0, "cannot sell negative byte" );
 
       user_resources_table  userres( _self, account );

--- a/eosio.system/src/eosio.system.cpp
+++ b/eosio.system/src/eosio.system.cpp
@@ -103,6 +103,8 @@ namespace eosiosystem {
     *  and weights to the actual CORE_SYMBOL held in the eosio.ram account.
     */
    void system_contract::setramrate( uint16_t bytes_per_block ) {
+      require_auth( _self );
+
       _gstate2.new_ram_per_block = bytes_per_block;
       if( _gstate2.last_ram_increase == block_timestamp() ) {
          _gstate2.last_ram_increase = _gstate2.last_block_num;

--- a/eosio.system/src/eosio.system.cpp
+++ b/eosio.system/src/eosio.system.cpp
@@ -86,8 +86,6 @@ namespace eosiosystem {
        */
       _rammarket.modify( itr, 0, [&]( auto& m ) {
          m.base.balance.amount += new_ram;
-         m.base.weight = 500;
-         m.quote.weight = 500;
       });
       _gstate2.last_ram_increase = _gstate2.last_block_num;
    }
@@ -111,17 +109,6 @@ namespace eosiosystem {
       } else {
          update_ram_supply();
       }
-
-      auto itr = _rammarket.find(S(4,RAMCORE));
-
-      /**
-       * Resync the connector state with the eosio.ram CORE token balance.
-       */
-      _rammarket.modify( itr, 0, [&]( auto& m ) {
-         m.quote.balance = eosio::token(N(eosio.token)).get_balance(N(eosio.ram),eosio::symbol_type(system_token_symbol).name());
-         m.base.weight = 500; /// use a connector weight of 50% which minimizes volatility
-         m.quote.weight = 500;/// use a connector weight of 50% which minimizes volatility
-      });
    }
 
    void system_contract::setparams( const eosio::blockchain_parameters& params ) {

--- a/eosio.system/src/producer_pay.cpp
+++ b/eosio.system/src/producer_pay.cpp
@@ -21,6 +21,7 @@ namespace eosiosystem {
       using namespace eosio;
 
       require_auth(N(eosio));
+      _gstate2.last_block_num = timestamp;
 
       /** until activated stake crosses this threshold no new rewards are paid */
       if( _gstate.total_activated_stake < min_activated_stake )


### PR DESCRIPTION
    Add setramrate method for gradual increase

     - this change allows the elected producers to set the ramrate as bytes
     per block
     - this will also resync the bancor parameters to current eosio.ram
     balance plus reduce the volatility of the market maker
     - added revision field so that future updates to system contract can
     reference it if necessary.
     - updated ABI