### PR TITLE
Fixes and improvements to setramrate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,5 @@
 *.exe
 *.out
 *.app
+
+build/*

--- a/eosio.system/include/eosio.system/eosio.system.hpp
+++ b/eosio.system/include/eosio.system/eosio.system.hpp
@@ -69,7 +69,7 @@ namespace eosiosystem {
 
       uint16_t          new_ram_per_block = 0;
       block_timestamp   last_ram_increase;
-      block_timestamp   last_block_num; /* unnecessary now; deprecated? */
+      block_timestamp   last_block_num; /* deprecated */
       double            reserved = 0;
       uint8_t           revision = 0; ///< used to track version updates in the future.
 

--- a/eosio.system/include/eosio.system/eosio.system.hpp
+++ b/eosio.system/include/eosio.system/eosio.system.hpp
@@ -67,9 +67,9 @@ namespace eosiosystem {
    struct eosio_global_state2 {
       eosio_global_state2(){}
 
-      uint16_t          new_ram_per_block = 0;  
+      uint16_t          new_ram_per_block = 0;
       block_timestamp   last_ram_increase;
-      block_timestamp   last_block_num;
+      block_timestamp   last_block_num; /* unnecessary now; deprecated? */
       double            reserved = 0;
       uint8_t           revision = 0; ///< used to track version updates in the future.
 
@@ -236,18 +236,19 @@ namespace eosiosystem {
 
          void bidname( account_name bidder, account_name newname, asset bid );
       private:
-         void update_elected_producers( block_timestamp timestamp );
-         void update_ram_supply();
-
          // Implementation details:
 
-         //defind in delegate_bandwidth.cpp
+         //defined in eosio.system.cpp
+         static eosio_global_state get_default_parameters();
+         static block_timestamp current_block_time();
+         void update_ram_supply();
+
+         //defined in delegate_bandwidth.cpp
          void changebw( account_name from, account_name receiver,
                         asset stake_net_quantity, asset stake_cpu_quantity, bool transfer );
 
          //defined in voting.hpp
-         static eosio_global_state get_default_parameters();
-
+         void update_elected_producers( block_timestamp timestamp );
          void update_votes( const account_name voter, const account_name proxy, const std::vector<account_name>& producers, bool voting );
 
          // defined in voting.cpp

--- a/eosio.system/src/delegate_bandwidth.cpp
+++ b/eosio.system/src/delegate_bandwidth.cpp
@@ -87,7 +87,7 @@ namespace eosiosystem {
     *  This action will buy an exact amount of ram and bill the payer the current market price.
     */
    void system_contract::buyrambytes( account_name payer, account_name receiver, uint32_t bytes ) {
-      
+
       auto itr = _rammarket.find(S(4,RAMCORE));
       auto tmp = *itr;
       auto eosout = tmp.convert( asset(bytes,S(0,RAM)), CORE_SYMBOL );
@@ -180,7 +180,7 @@ namespace eosiosystem {
           /// the cast to int64_t of bytes is safe because we certify bytes is <= quota which is limited by prior purchases
           tokens_out = es.convert( asset(bytes,S(0,RAM)), CORE_SYMBOL);
       });
-      
+
       eosio_assert( tokens_out.amount > 1, "token amount received from selling ram is too low" );
 
       _gstate.total_ram_bytes_reserved -= static_cast<decltype(_gstate.total_ram_bytes_reserved)>(bytes); // bytes > 0 is asserted above
@@ -272,7 +272,7 @@ namespace eosiosystem {
          eosio_assert( asset(0) <= tot_itr->cpu_weight, "insufficient staked total cpu bandwidth" );
 
          int64_t ram_bytes, net, cpu;
-         get_resource_limits( receiver, ram_bytes, net, cpu );
+         get_resource_limits( receiver, &ram_bytes, &net, &cpu );
 
          set_resource_limits( receiver, std::max( tot_itr->ram_bytes + ram_gift_bytes, ram_bytes ), tot_itr->net_weight.amount, tot_itr->cpu_weight.amount );
 
@@ -290,8 +290,8 @@ namespace eosiosystem {
          auto net_balance = stake_net_delta;
          auto cpu_balance = stake_cpu_delta;
          bool need_deferred_trx = false;
-         
-         
+
+
          // net and cpu are same sign by assertions in delegatebw and undelegatebw
          // redundant assertion also at start of changebw to protect against misuse of changebw
          bool is_undelegating = (net_balance.amount + cpu_balance.amount ) < 0;

--- a/eosio.system/src/eosio.system.cpp
+++ b/eosio.system/src/eosio.system.cpp
@@ -47,8 +47,7 @@ namespace eosiosystem {
    }
 
    block_timestamp system_contract::current_block_time() {
-      const /* static */ block_timestamp cbt{ time_point{ microseconds{ static_cast<int64_t>( current_time() ) } } };
-      // static causes linking errors: undefined symbols __cxa_guard_acquire and  __cxa_guard_release
+      const static block_timestamp cbt{ time_point{ microseconds{ static_cast<int64_t>( current_time() ) } } };
       return cbt;
    }
 

--- a/eosio.system/src/producer_pay.cpp
+++ b/eosio.system/src/producer_pay.cpp
@@ -22,6 +22,11 @@ namespace eosiosystem {
 
       require_auth(N(eosio));
 
+      // _gstate2.last_block_num is not used anywhere in the system contract code anymore.
+      // Although this field is deprecated, we will continue updating it for now until the last_block_num field
+      // is eventually completely removed, at which point this line can be removed.
+      _gstate2.last_block_num = timestamp;
+
       /** until activated stake crosses this threshold no new rewards are paid */
       if( _gstate.total_activated_stake < min_activated_stake )
          return;

--- a/eosio.system/src/producer_pay.cpp
+++ b/eosio.system/src/producer_pay.cpp
@@ -21,7 +21,7 @@ namespace eosiosystem {
       using namespace eosio;
 
       require_auth(N(eosio));
-      _gstate2.last_block_num = timestamp;
+      _gstate2.last_block_num = timestamp; // QUESTION: Should this be removed now that last_block_num is not neeeded?
 
       /** until activated stake crosses this threshold no new rewards are paid */
       if( _gstate.total_activated_stake < min_activated_stake )

--- a/eosio.system/src/producer_pay.cpp
+++ b/eosio.system/src/producer_pay.cpp
@@ -21,7 +21,6 @@ namespace eosiosystem {
       using namespace eosio;
 
       require_auth(N(eosio));
-      _gstate2.last_block_num = timestamp; // QUESTION: Should this be removed now that last_block_num is not neeeded?
 
       /** until activated stake crosses this threshold no new rewards are paid */
       if( _gstate.total_activated_stake < min_activated_stake )

--- a/tests/eosio.system_tests.cpp
+++ b/tests/eosio.system_tests.cpp
@@ -2608,12 +2608,15 @@ BOOST_FIXTURE_TEST_CASE( ram_inflation, eosio_system_tester ) try {
    BOOST_REQUIRE_EQUAL( success(), buyram( "alice1111111", "alice1111111", core_from_string("100.0000") ) );
    produce_blocks(3);
    BOOST_REQUIRE_EQUAL( init_max_ram_size, get_global_state()["max_ram_size"].as_uint64() );
-   const uint16_t rate = 1000;
+   uint16_t rate = 1000;
    BOOST_REQUIRE_EQUAL( success(), push_action( config::system_account_name, N(setramrate), mvo()("bytes_per_block", rate) ) );
    BOOST_REQUIRE_EQUAL( rate, get_global_state2()["new_ram_per_block"].as<uint16_t>() );
-   // last time update_ram_supply called is in buyram, num of blocks since then is 1 + 3 = 4
+   // last time update_ram_supply called is in buyram, num of blocks since then to
+   // the block that includes the setramrate action is 1 + 3 = 4.
+   // However, those 4 blocks were accumulating at a rate of 0, so the max_ram_size should not have changed.
+   BOOST_REQUIRE_EQUAL( init_max_ram_size, get_global_state()["max_ram_size"].as_uint64() );
+   // But with additional blocks, it should start accumulating at the new rate.
    uint64_t cur_ram_size = get_global_state()["max_ram_size"].as_uint64();
-   BOOST_REQUIRE_EQUAL( init_max_ram_size + 4 * rate, get_global_state()["max_ram_size"].as_uint64() );
    produce_blocks(10);
    BOOST_REQUIRE_EQUAL( success(), buyram( "alice1111111", "alice1111111", core_from_string("100.0000") ) );
    BOOST_REQUIRE_EQUAL( cur_ram_size + 11 * rate, get_global_state()["max_ram_size"].as_uint64() );
@@ -2629,6 +2632,16 @@ BOOST_FIXTURE_TEST_CASE( ram_inflation, eosio_system_tester ) try {
 
    BOOST_REQUIRE_EQUAL( error("missing authority of eosio"),
                         push_action( "alice1111111", N(setramrate), mvo()("bytes_per_block", rate) ) );
+
+   cur_ram_size = get_global_state()["max_ram_size"].as_uint64();
+   produce_blocks(10);
+   uint16_t old_rate = rate;
+   rate = 5000;
+   BOOST_REQUIRE_EQUAL( success(), push_action( config::system_account_name, N(setramrate), mvo()("bytes_per_block", rate) ) );
+   BOOST_REQUIRE_EQUAL( cur_ram_size + 11 * old_rate, get_global_state()["max_ram_size"].as_uint64() );
+   produce_blocks(5);
+   BOOST_REQUIRE_EQUAL( success(), buyrambytes( "alice1111111", "alice1111111", 100 ) );
+   BOOST_REQUIRE_EQUAL( cur_ram_size + 11 * old_rate + 6 * rate, get_global_state()["max_ram_size"].as_uint64() );
 
 } FC_LOG_AND_RETHROW()
 


### PR DESCRIPTION
Please merge PR #33 first.

This PR makes changes to the way `setramrate` works.

First, it fixes a bug which causes the `setramrate` action to retroactively behave as if the old rate was replaced by the new rate starting from the last time `update_ram_supply()` was called (i.e. going back to `_gstate2.last_ram_increase`). This was because the `_gstate2.new_ram_per_block` was changed prior to `update_ram_supply()` being called in the `setramrate` action handler.

Second, it avoids using the tracked `_gstate.last_block_num` field when it can instead calculate the more accurate `current_block_time()` using the `current_time()` intrinsic function. `current_block_time()` returns the current block's timestamp in `block_timestamp` form (i.e. number of half seconds since 2000). Assuming no slots were skipped between the current block and the previous block, and assuming that the onblock transaction does not fail for some reason, then `current_block_time()` should always be 500 milliseconds ahead of the now obsolete `_gstate.last_block_num`. In the situations where this relationship does not hold (e.g. slots were missed in between the current block and previous block), the new method does a better job (specifically more up-to-date) at accumulating the ram rate increase than the old method (note that the old method is effectively also accumulating over time, or block slots, rather than over actual blocks produced).

Furthermore, this new method actually simplifies the `setramrate` action handler code while at the same time handling a corner case which if triggered would cause improper initialization of the time variables prior to `update_ram_supply()` being called. This corner case was only triggered if the very first usage of the `setramrate` action occurred in the same block in which the system contract was upgraded to introduce the new `eosio_global_state2` table. In such a case, `_gstate2.last_ram_increase` would be initialized to 0, since `_gstate2.last_block_num` would also be 0 under these conditions. This would lead to problems later on if the very next time `update_ram_supply()` was called (i.e. when RAM was bought or sold) was after the current block but before the next time the `setramrate` action was called. While this may seem like an unusual corner case that would be unlikely to be triggered, it unfortunately would easily happen if the same atomic transaction that upgraded the system contract to introduce the `setramrate` action also exercised the new action immediately afterward, rather than spacing the two steps out into separate transactions.

Anyway, the new code is designed to get the correct current block time rather than assuming `_gstate2.last_block_num` was properly set by this point. If this code was used to upgrade from v1.0.0 of the system contract, then the first usage of `setramrate` action would always initialize `_gstate2.last_ram_increase` appropriately via `update_ram_supply()` (which would end up not adding any `new_ram` since `_gstate2.new_ram_per_block` would necessarily be zero at that point) prior to then changing `_gstate2.new_ram_per_block` to the new `bytes_per_block` value provided.
