### PR TITLE
Add abi hash

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,4 @@
 *.app
 
 build/*
+.DS_Store

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.5)
 project(eosio_contracts VERSION 1.2.0)
 
-set(EOSIO_DEPENDENCY "1.1")
+set(EOSIO_DEPENDENCY "1.2")
 set(EOSIO_WASMSDK_DEPENDENCY "1.1")
 
 if(CMAKE_BUILD_TYPE STREQUAL "Debug")
@@ -30,6 +30,7 @@ if (NOT "${output}" EQUAL 0)
 endif()
 
 include_directories(AFTER ${BOOST_ROOT}/include)
+add_subdirectory(eosio.bios)
 add_subdirectory(eosio.msig)
 add_subdirectory(eosio.sudo)
 add_subdirectory(eosio.system)

--- a/eosio.bios/CMakeLists.txt
+++ b/eosio.bios/CMakeLists.txt
@@ -1,0 +1,10 @@
+add_executable(eosio.bios.wasm ${CMAKE_CURRENT_SOURCE_DIR}/src/eosio.bios.cpp)
+target_include_directories(eosio.bios.wasm
+   PUBLIC 
+   ${CMAKE_CURRENT_SOURCE_DIR}/include)
+
+set_target_properties(eosio.bios.wasm
+   PROPERTIES
+   RUNTIME_OUTPUT_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}")
+
+configure_file("${CMAKE_CURRENT_SOURCE_DIR}/abi/eosio.bios.abi" "${CMAKE_CURRENT_BINARY_DIR}" COPYONLY)

--- a/eosio.bios/abi/eosio.bios.abi
+++ b/eosio.bios/abi/eosio.bios.abi
@@ -1,0 +1,231 @@
+{
+   "version": "eosio::abi/1.0",
+   "types": [{
+      "new_type_name": "account_name",
+      "type": "name"
+   },{
+      "new_type_name": "permission_name",
+      "type": "name"
+   },{
+      "new_type_name": "action_name",
+      "type": "name"
+   },{
+      "new_type_name": "transaction_id_type",
+      "type": "checksum256"
+   },{
+      "new_type_name": "weight_type",
+      "type": "uint16"
+   }],
+   "structs": [{
+      "name": "permission_level",
+      "base": "",
+      "fields": [
+        {"name":"actor",      "type":"account_name"},
+        {"name":"permission", "type":"permission_name"}
+      ]
+    },{
+      "name": "key_weight",
+      "base": "",
+      "fields": [
+        {"name":"key",    "type":"public_key"},
+        {"name":"weight", "type":"weight_type"}
+      ]
+    },{
+      "name": "permission_level_weight",
+      "base": "",
+      "fields": [
+        {"name":"permission", "type":"permission_level"},
+        {"name":"weight",     "type":"weight_type"}
+      ]
+    },{
+      "name": "wait_weight",
+      "base": "",
+      "fields": [
+        {"name":"wait_sec", "type":"uint32"},
+        {"name":"weight",   "type":"weight_type"}
+      ]
+    },{
+      "name": "authority",
+      "base": "",
+      "fields": [
+        {"name":"threshold", "type":"uint32"},
+        {"name":"keys",      "type":"key_weight[]"},
+        {"name":"accounts",  "type":"permission_level_weight[]"},
+        {"name":"waits",     "type":"wait_weight[]"}
+      ]
+    },{
+      "name": "newaccount",
+      "base": "",
+      "fields": [
+        {"name":"creator", "type":"account_name"},
+        {"name":"name",    "type":"account_name"},
+        {"name":"owner",   "type":"authority"},
+        {"name":"active",  "type":"authority"}
+      ]
+    },{
+      "name": "setcode",
+      "base": "",
+      "fields": [
+        {"name":"account",   "type":"account_name"},
+        {"name":"vmtype",    "type":"uint8"},
+        {"name":"vmversion", "type":"uint8"},
+        {"name":"code",      "type":"bytes"}
+      ]
+    },{
+      "name": "setabi",
+      "base": "",
+      "fields": [
+        {"name":"account", "type":"account_name"},
+        {"name":"abi",     "type":"bytes"}
+      ]
+    },{
+      "name": "updateauth",
+      "base": "",
+      "fields": [
+        {"name":"account",    "type":"account_name"},
+        {"name":"permission", "type":"permission_name"},
+        {"name":"parent",     "type":"permission_name"},
+        {"name":"auth",       "type":"authority"}
+      ]
+    },{
+      "name": "deleteauth",
+      "base": "",
+      "fields": [
+        {"name":"account",    "type":"account_name"},
+        {"name":"permission", "type":"permission_name"}
+      ]
+    },{
+      "name": "linkauth",
+      "base": "",
+      "fields": [
+        {"name":"account",     "type":"account_name"},
+        {"name":"code",        "type":"account_name"},
+        {"name":"type",        "type":"action_name"},
+        {"name":"requirement", "type":"permission_name"}
+      ]
+    },{
+      "name": "unlinkauth",
+      "base": "",
+      "fields": [
+        {"name":"account",     "type":"account_name"},
+        {"name":"code",        "type":"account_name"},
+        {"name":"type",        "type":"action_name"}
+      ]
+    },{
+      "name": "canceldelay",
+      "base": "",
+      "fields": [
+        {"name":"canceling_auth", "type":"permission_level"},
+        {"name":"trx_id",         "type":"transaction_id_type"}
+      ]
+    },{
+      "name": "onerror",
+      "base": "",
+      "fields": [
+        {"name":"sender_id", "type":"uint128"},
+        {"name":"sent_trx",  "type":"bytes"}
+      ]
+    },{
+      "name": "set_account_limits",
+      "base": "",
+      "fields": [
+        {"name":"account",    "type":"account_name"},
+        {"name":"ram_bytes",  "type":"int64"},
+        {"name":"net_weight", "type":"int64"},
+        {"name":"cpu_weight", "type":"int64"}
+      ]
+    },{
+        "name": "setpriv",
+        "base": "",
+        "fields": [
+          {"name":"account",    "type":"account_name"},
+          {"name":"is_priv",    "type":"int8"}
+        ]
+      },{
+      "name": "set_global_limits",
+      "base": "",
+      "fields": [
+        {"name":"cpu_usec_per_period",    "type":"int64"}
+      ]
+    },{
+      "name": "producer_key",
+      "base": "",
+      "fields": [
+        {"name":"producer_name",      "type":"account_name"},
+        {"name":"block_signing_key",  "type":"public_key"}
+      ]
+    },{
+      "name": "set_producers",
+      "base": "",
+      "fields": [
+        {"name":"schedule",   "type":"producer_key[]"}
+      ]
+    },{
+      "name": "require_auth",
+      "base": "",
+      "fields": [
+        {"name":"from", "type":"account_name"}
+      ]
+    }],
+   "actions": [{
+      "name": "newaccount",
+      "type": "newaccount",
+      "ricardian_contract": ""
+    },{
+      "name": "setcode",
+      "type": "setcode",
+      "ricardian_contract": ""
+    },{
+      "name": "setabi",
+      "type": "setabi",
+      "ricardian_contract": ""
+    },{
+      "name": "updateauth",
+      "type": "updateauth",
+      "ricardian_contract": ""
+    },{
+      "name": "deleteauth",
+      "type": "deleteauth",
+      "ricardian_contract": ""
+    },{
+      "name": "linkauth",
+      "type": "linkauth",
+      "ricardian_contract": ""
+    },{
+      "name": "unlinkauth",
+      "type": "unlinkauth",
+      "ricardian_contract": ""
+    },{
+      "name": "canceldelay",
+      "type": "canceldelay",
+      "ricardian_contract": ""
+    },{
+      "name": "onerror",
+      "type": "onerror",
+      "ricardian_contract": ""
+    },{
+      "name": "setalimits",
+      "type": "set_account_limits",
+      "ricardian_contract": ""
+    },{
+      "name": "setglimits",
+      "type": "set_global_limits",
+      "ricardian_contract": ""
+    },{
+       "name": "setpriv",
+       "type": "setpriv",
+      "ricardian_contract": ""
+    },{
+      "name": "setprods",
+      "type": "set_producers",
+      "ricardian_contract": ""
+    },{
+      "name": "reqauth",
+      "type": "require_auth",
+      "ricardian_contract": ""
+    }
+   ],
+   "tables": [],
+   "ricardian_clauses": [],
+   "abi_extensions": []
+}

--- a/eosio.bios/abi/eosio.bios.abi
+++ b/eosio.bios/abi/eosio.bios.abi
@@ -79,6 +79,13 @@
         {"name":"abi",     "type":"bytes"}
       ]
     },{
+      "name": "abi_hash",
+      "base": "",
+      "fields": [
+         {"name":"owner",  "type":"account_name"},
+         {"name":"hash",   "type":"checksum256"}
+      ]
+    },{
       "name": "updateauth",
       "base": "",
       "fields": [
@@ -225,7 +232,13 @@
       "ricardian_contract": ""
     }
    ],
-   "tables": [],
+   "tables": [{
+      "name": "abihash",
+      "type": "abi_hash",
+      "index_type": "i64",
+      "key_names": ["owner"],
+      "key_types": ["account_name"]
+    }],
    "ricardian_clauses": [],
    "abi_extensions": []
 }

--- a/eosio.bios/include/eosio.bios/eosio.bios.hpp
+++ b/eosio.bios/include/eosio.bios/eosio.bios.hpp
@@ -1,0 +1,44 @@
+#pragma once
+#include <eosiolib/eosio.hpp>
+#include <eosiolib/privileged.hpp>
+
+namespace eosio {
+
+   class bios : public contract {
+      public:
+         bios( action_name self ):contract(self){}
+
+         void setpriv( account_name account, uint8_t ispriv ) {
+            require_auth( _self );
+            set_privileged( account, ispriv );
+         }
+
+         void setalimits( account_name account, int64_t ram_bytes, int64_t net_weight, int64_t cpu_weight ) {
+            require_auth( _self );
+            set_resource_limits( account, ram_bytes, net_weight, cpu_weight );
+         }
+
+         void setglimits( uint64_t ram, uint64_t net, uint64_t cpu ) {
+            (void)ram; (void)net; (void)cpu;
+            require_auth( _self );
+         }
+
+         void setprods( std::vector<eosio::producer_key> schedule ) {
+            (void)schedule; // schedule argument just forces the deserialization of the action data into vector<producer_key> (necessary check)
+            require_auth( _self );
+
+            constexpr size_t max_stack_buffer_size = 512;
+            size_t size = action_data_size();
+            char* buffer = (char*)( max_stack_buffer_size < size ? malloc(size) : alloca(size) );
+            read_action_data( buffer, size );
+            set_proposed_producers(buffer, size);
+         }
+
+         void reqauth( action_name from ) {
+            require_auth( from );
+         }
+
+      private:
+   };
+
+} /// namespace eosio

--- a/eosio.bios/src/eosio.bios.cpp
+++ b/eosio.bios/src/eosio.bios.cpp
@@ -1,0 +1,3 @@
+#include <eosio.bios/eosio.bios.hpp>
+
+EOSIO_ABI( eosio::bios, (setpriv)(setalimits)(setglimits)(setprods)(reqauth) )

--- a/eosio.bios/src/eosio.bios.cpp
+++ b/eosio.bios/src/eosio.bios.cpp
@@ -1,3 +1,3 @@
 #include <eosio.bios/eosio.bios.hpp>
 
-EOSIO_ABI( eosio::bios, (setpriv)(setalimits)(setglimits)(setprods)(reqauth) )
+EOSIO_ABI( eosio::bios, (setpriv)(setalimits)(setglimits)(setprods)(reqauth)(setabi) )

--- a/eosio.system/abi/eosio.system.abi
+++ b/eosio.system/abi/eosio.system.abi
@@ -25,6 +25,13 @@
         {"name":"permission", "type":"permission_name"}
       ]
     },{
+      "name": "abi_hash",
+      "base": "",
+      "fields": [
+         {"name":"owner", "type":"account_name"},
+         {"name":"hash",  "type":"checksum256"}
+      ]
+    },{
       "name": "key_weight",
       "base": "",
       "fields": [

--- a/eosio.system/include/eosio.system/eosio.system.hpp
+++ b/eosio.system/include/eosio.system/eosio.system.hpp
@@ -161,6 +161,7 @@ namespace eosiosystem {
          void onblock( block_timestamp timestamp, account_name producer );
                       // const block_header& header ); /// only parse first 3 fields of block header
 
+
          // functions defined in delegate_bandwidth.cpp
 
          /**

--- a/eosio.system/include/eosio.system/native.hpp
+++ b/eosio.system/include/eosio.system/native.hpp
@@ -61,6 +61,14 @@ namespace eosiosystem {
    };
 
 
+   struct abi_hash {
+      account_name owner;
+      checksum256  hash;
+      auto primary_key()const { return owner; }
+
+      EOSLIB_SERIALIZE( abi_hash, (owner)(hash) )
+   };
+
    /*
     * Method parameters commented out to prevent generation of code that parses input data.
     */
@@ -108,5 +116,6 @@ namespace eosiosystem {
 
          void onerror( /*const bytes&*/ ) {}
 
+         void setabi( account_name acnt, const bytes& abi );
    };
 }

--- a/eosio.system/src/eosio.system.cpp
+++ b/eosio.system/src/eosio.system.cpp
@@ -1,5 +1,6 @@
 #include <eosio.system/eosio.system.hpp>
 #include <eosiolib/dispatcher.hpp>
+#include <eosiolib/crypto.h>
 
 #include "producer_pay.cpp"
 #include "delegate_bandwidth.cpp"
@@ -217,12 +218,28 @@ namespace eosiosystem {
       set_resource_limits( newact, 0, 0, 0 );
    }
 
+   void native::setabi( account_name acnt, const bytes& abi ) {
+      eosio::multi_index< N(abihash), abi_hash>  table(_self,_self);
+
+      auto itr = table.find( acnt );
+      if( itr == table.end() ) {
+         table.emplace( acnt, [&]( auto& row ) {
+            row.owner= acnt;
+            sha256( const_cast<char*>(abi.data()), abi.size(), &row.hash ); 
+         });
+      } else {
+         table.modify( itr, 0, [&]( auto& row ) {
+            sha256( const_cast<char*>(abi.data()), abi.size(), &row.hash ); 
+         });
+      }
+   }
+
 } /// eosio.system
 
 
 EOSIO_ABI( eosiosystem::system_contract,
      // native.hpp (newaccount definition is actually in eosio.system.cpp)
-     (newaccount)(updateauth)(deleteauth)(linkauth)(unlinkauth)(canceldelay)(onerror)
+     (newaccount)(updateauth)(deleteauth)(linkauth)(unlinkauth)(canceldelay)(onerror)(setabi)
      // eosio.system.cpp
      (setram)(setramrate)(setparams)(setpriv)(rmvproducer)(bidname)
      // delegate_bandwidth.cpp

--- a/eosio.system/src/eosio.system.cpp
+++ b/eosio.system/src/eosio.system.cpp
@@ -220,7 +220,6 @@ namespace eosiosystem {
 
    void native::setabi( account_name acnt, const bytes& abi ) {
       eosio::multi_index< N(abihash), abi_hash>  table(_self,_self);
-
       auto itr = table.find( acnt );
       if( itr == table.end() ) {
          table.emplace( acnt, [&]( auto& row ) {

--- a/tests/contracts.hpp.in
+++ b/tests/contracts.hpp.in
@@ -16,6 +16,9 @@ struct contracts {
    static std::vector<uint8_t> sudo_wasm() { return read_wasm("${CMAKE_BINARY_DIR}/../eosio.sudo/eosio.sudo.wasm"); }
    static std::string          sudo_wast() { return read_wast("${CMAKE_BINARY_DIR}/../eosio.sudo/eosio.sudo.wast"); }
    static std::vector<char>    sudo_abi() { return read_abi("${CMAKE_BINARY_DIR}/../eosio.sudo/eosio.sudo.abi"); }
+   static std::vector<uint8_t> bios_wasm() { return read_wasm("${CMAKE_BINARY_DIR}/../eosio.bios/eosio.bios.wasm"); }
+   static std::string          bios_wast() { return read_wast("${CMAKE_BINARY_DIR}/../eosio.bios/eosio.bios.wast"); }
+   static std::vector<char>    bios_abi() { return read_abi("${CMAKE_BINARY_DIR}/../eosio.bios/eosio.bios.abi"); }
    
    struct util {
       static std::vector<uint8_t> test_api_wasm() { return read_wasm("${CMAKE_SOURCE_DIR}/test_contracts/test_api.wasm"); }

--- a/tests/eosio.system_tests.cpp
+++ b/tests/eosio.system_tests.cpp
@@ -2729,6 +2729,7 @@ BOOST_FIXTURE_TEST_CASE( setabi_bios, TESTER ) try {
    abi_serializer abi_ser(fc::json::from_string( (const char*)contracts::system_abi().data()).template as<abi_def>(), abi_serializer_max_time);
    set_code( config::system_account_name, contracts::bios_wasm() );
    set_abi( config::system_account_name, contracts::bios_abi().data() );
+   create_account(N(eosio.token));
    set_abi( N(eosio.token), contracts::token_abi().data() );
    { 
       auto res = get_row_by_account( config::system_account_name, config::system_account_name, N(abihash), N(eosio.token) ); 

--- a/tests/eosio.system_tests.cpp
+++ b/tests/eosio.system_tests.cpp
@@ -10,6 +10,11 @@
 #include <Runtime/Runtime.h>
 
 #include "eosio.system_tester.hpp"
+struct _abi_hash {
+   name owner;
+   fc::sha256 hash;
+};
+FC_REFLECT( _abi_hash, (owner)(hash) );
 
 using namespace eosio_system;
 
@@ -2720,4 +2725,58 @@ BOOST_FIXTURE_TEST_CASE( ram_gift, eosio_system_tester ) try {
 
 } FC_LOG_AND_RETHROW()
 
+BOOST_FIXTURE_TEST_CASE( setabi_bios, TESTER ) try {
+   abi_serializer abi_ser(fc::json::from_string( (const char*)contracts::system_abi().data()).template as<abi_def>(), abi_serializer_max_time);
+   set_code( config::system_account_name, contracts::bios_wasm() );
+   set_abi( config::system_account_name, contracts::bios_abi().data() );
+   set_abi( N(eosio.token), contracts::token_abi().data() );
+   { 
+      auto res = get_row_by_account( config::system_account_name, config::system_account_name, N(abihash), N(eosio.token) ); 
+      _abi_hash abi_hash;
+      auto abi_hash_var = abi_ser.binary_to_variant( "abi_hash", res, abi_serializer_max_time );
+      abi_serializer::from_variant( abi_hash_var, abi_hash, get_resolver(), abi_serializer_max_time);
+      auto abi = fc::raw::pack(fc::json::from_string( (const char*)contracts::token_abi().data()).template as<abi_def>());
+      auto result = fc::sha256::hash( (const char*)abi.data(), abi.size() );
+
+      BOOST_REQUIRE( abi_hash.hash == result );
+   }
+
+   set_abi( N(eosio.token), contracts::system_abi().data() );
+   { 
+      auto res = get_row_by_account( config::system_account_name, config::system_account_name, N(abihash), N(eosio.token) ); 
+      _abi_hash abi_hash;
+      auto abi_hash_var = abi_ser.binary_to_variant( "abi_hash", res, abi_serializer_max_time );
+      abi_serializer::from_variant( abi_hash_var, abi_hash, get_resolver(), abi_serializer_max_time);
+      auto abi = fc::raw::pack(fc::json::from_string( (const char*)contracts::system_abi().data()).template as<abi_def>());
+      auto result = fc::sha256::hash( (const char*)abi.data(), abi.size() );
+
+      BOOST_REQUIRE( abi_hash.hash == result );
+   }
+} FC_LOG_AND_RETHROW()
+
+BOOST_FIXTURE_TEST_CASE( setabi, eosio_system_tester ) try {
+   set_abi( N(eosio.token), contracts::token_abi().data() );
+   { 
+      auto res = get_row_by_account( config::system_account_name, config::system_account_name, N(abihash), N(eosio.token) ); 
+      _abi_hash abi_hash;
+      auto abi_hash_var = abi_ser.binary_to_variant( "abi_hash", res, abi_serializer_max_time );
+      abi_serializer::from_variant( abi_hash_var, abi_hash, get_resolver(), abi_serializer_max_time);
+      auto abi = fc::raw::pack(fc::json::from_string( (const char*)contracts::token_abi().data()).template as<abi_def>());
+      auto result = fc::sha256::hash( (const char*)abi.data(), abi.size() );
+
+      BOOST_REQUIRE( abi_hash.hash == result );
+   }
+
+   set_abi( N(eosio.token), contracts::system_abi().data() );
+   { 
+      auto res = get_row_by_account( config::system_account_name, config::system_account_name, N(abihash), N(eosio.token) ); 
+      _abi_hash abi_hash;
+      auto abi_hash_var = abi_ser.binary_to_variant( "abi_hash", res, abi_serializer_max_time );
+      abi_serializer::from_variant( abi_hash_var, abi_hash, get_resolver(), abi_serializer_max_time);
+      auto abi = fc::raw::pack(fc::json::from_string( (const char*)contracts::system_abi().data()).template as<abi_def>());
+      auto result = fc::sha256::hash( (const char*)abi.data(), abi.size() );
+
+      BOOST_REQUIRE( abi_hash.hash == result );
+   }
+} FC_LOG_AND_RETHROW()
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
The ABI hash table allows wallets to assert that the ABI is what they showed the user or the transaction can be rejected. This pull request merely adds the necessary tracking of ABI, another contract will read the system table and assert.