### PR TITLE
bug fix in `eosio.token::close` action; add `eosio.token::open` action

### DIFF
--- a/eosio.token/abi/eosio.token.abi
+++ b/eosio.token/abi/eosio.token.abi
@@ -36,6 +36,14 @@
         {"name":"memo", "type":"string"}
      ]
   },{
+     "name": "open",
+     "base": "",
+     "fields": [
+        {"name":"owner", "type":"account_name"},
+        {"name":"symbol", "type":"symbol"},
+        {"name":"ram_payer", "type":"account_name"}
+     ]
+  },{
      "name": "close",
      "base": "",
      "fields": [
@@ -73,6 +81,10 @@
     }, {
       "name": "create",
       "type": "create",
+      "ricardian_contract": ""
+    }, {
+      "name": "open",
+      "type": "open",
       "ricardian_contract": ""
     }, {
       "name": "close",

--- a/eosio.token/include/eosio.token/eosio.token.hpp
+++ b/eosio.token/include/eosio.token/eosio.token.hpp
@@ -33,10 +33,12 @@ namespace eosio {
                         asset        quantity,
                         string       memo );
 
+         void open( account_name owner, symbol_type symbol, account_name payer );
+
          void close( account_name owner, symbol_type symbol );
 
          inline asset get_supply( symbol_name sym )const;
-         
+
          inline asset get_balance( account_name owner, symbol_name sym )const;
 
       private:

--- a/eosio.token/src/eosio.token.cpp
+++ b/eosio.token/src/eosio.token.cpp
@@ -136,7 +136,9 @@ void token::add_balance( account_name owner, asset value, account_name ram_payer
    }
 }
 
-void token::close( account_name owner, symbol_type symbol ) {
+void token::close( account_name owner, symbol_type symbol )
+{
+   require_auth( owner );
    accounts acnts( _self, owner );
    auto it = acnts.find( symbol.name() );
    eosio_assert( it != acnts.end(), "Balance row already deleted or never existed. Action won't have any effect." );

--- a/eosio.token/src/eosio.token.cpp
+++ b/eosio.token/src/eosio.token.cpp
@@ -136,6 +136,18 @@ void token::add_balance( account_name owner, asset value, account_name ram_payer
    }
 }
 
+void token::open( account_name owner, symbol_type symbol, account_name ram_payer )
+{
+   require_auth( ram_payer );
+   accounts acnts( _self, owner );
+   auto it = acnts.find( symbol.name() );
+   if( it == acnts.end() ) {
+      acnts.emplace( ram_payer, [&]( auto& a ){
+        a.balance = asset{0, symbol};
+      });
+   }
+}
+
 void token::close( account_name owner, symbol_type symbol )
 {
    require_auth( owner );
@@ -148,4 +160,4 @@ void token::close( account_name owner, symbol_type symbol )
 
 } /// namespace eosio
 
-EOSIO_ABI( eosio::token, (create)(issue)(transfer)(close)(retire) )
+EOSIO_ABI( eosio::token, (create)(issue)(transfer)(open)(close)(retire) )

--- a/tests/eosio.token_tests.cpp
+++ b/tests/eosio.token_tests.cpp
@@ -100,6 +100,16 @@ public:
       );
    }
 
+   action_result open( account_name owner,
+                       const string& symbolname,
+                       account_name ram_payer    ) {
+      return push_action( ram_payer, N(open), mvo()
+           ( "owner", owner )
+           ( "symbol", "0,CERO" )
+           ( "ram_payer", ram_payer )
+      );
+   }
+
    action_result close( account_name owner,
                         const string& symbolname ) {
       return push_action( owner, N(close), mvo()
@@ -336,6 +346,38 @@ BOOST_FIXTURE_TEST_CASE( transfer_tests, eosio_token_tester ) try {
 
 } FC_LOG_AND_RETHROW()
 
+BOOST_FIXTURE_TEST_CASE( open_tests, eosio_token_tester ) try {
+
+   auto token = create( N(alice), asset::from_string("1000 CERO"));
+
+   auto alice_balance = get_account(N(alice), "0,CERO");
+   BOOST_REQUIRE_EQUAL(true, alice_balance.is_null() );
+
+   BOOST_REQUIRE_EQUAL( success(), issue( N(alice), N(alice), asset::from_string("1000 CERO"), "issue" ) );
+
+   alice_balance = get_account(N(alice), "0,CERO");
+   REQUIRE_MATCHING_OBJECT( alice_balance, mvo()
+      ("balance", "1000 CERO")
+   );
+
+   auto bob_balance = get_account(N(bob), "0,CERO");
+   BOOST_REQUIRE_EQUAL(true, bob_balance.is_null() );
+
+   BOOST_REQUIRE_EQUAL( success(), open( N(bob), "0,CERO", N(alice) ) );
+
+   bob_balance = get_account(N(bob), "0,CERO");
+   REQUIRE_MATCHING_OBJECT( bob_balance, mvo()
+      ("balance", "0 CERO")
+   );
+
+   BOOST_REQUIRE_EQUAL( success(), transfer( N(alice), N(bob), asset::from_string("200 CERO"), "hola" ) );
+
+   bob_balance = get_account(N(bob), "0,CERO");
+   REQUIRE_MATCHING_OBJECT( bob_balance, mvo()
+      ("balance", "200 CERO")
+   );
+
+} FC_LOG_AND_RETHROW()
 
 BOOST_FIXTURE_TEST_CASE( close_tests, eosio_token_tester ) try {
 


### PR DESCRIPTION
This PR makes two changes:

- It requires authorization of the owner of the zero-balance token row to be closed via `eosio.token::close`.
- It adds the `eosio.token::open` action which resolves #61.