### PR TITLE
Add abihash table to system contract ABI

### DIFF
--- a/eosio.system/abi/eosio.system.abi
+++ b/eosio.system/abi/eosio.system.abi
@@ -638,6 +638,12 @@
        "index_type": "i64",
        "key_names" : ["newname"],
        "key_types" : ["account_name"]
+    },{
+      "name": "abihash",
+      "type": "abi_hash",
+      "index_type": "i64",
+      "key_names": ["owner"],
+      "key_types": ["account_name"]
     }
    ],
    "ricardian_clauses": [],


### PR DESCRIPTION
It was added into the bios contract's ABI but missing from the system contract's ABI.