### PR TITLE
fix eosio.msig ABI definition for approvals_info struct

### DIFF
--- a/eosio.msig/abi/eosio.msig.abi
+++ b/eosio.msig/abi/eosio.msig.abi
@@ -125,6 +125,7 @@
       "name": "approvals_info",
       "base": "",
       "fields": [
+        {"name": "version", "type": "uint8"},
         {"name": "proposal_name", "type": "name"},
         {"name": "requested_approvals", "type": "approval[]"},
         {"name": "provided_approvals",  "type": "approval[]"}


### PR DESCRIPTION
Resolves #75.