### PR TITLE
add ricardian contract to eosio.sudo::exec

### DIFF
--- a/eosio.sudo/abi/eosio.sudo.abi
+++ b/eosio.sudo/abi/eosio.sudo.abi
@@ -64,7 +64,7 @@
   "actions": [{
       "name": "exec",
       "type": "exec",
-      "ricardian_contract": ""
+      "ricardian_contract": "Allows block producers to bypass authorization checks or run privileged actions with 15/21 producer approval"
     }
   ],
   "tables": [],


### PR DESCRIPTION
This is the Ricardian Contract included in the most current EOS mainnet eosio.wrap (sudo) proposal