### PR TITLE
Ensure symbol actually exists in eosio.token::open

### DIFF
--- a/eosio.token/src/eosio.token.cpp
+++ b/eosio.token/src/eosio.token.cpp
@@ -139,8 +139,15 @@ void token::add_balance( name owner, asset value, name ram_payer )
 void token::open( name owner, const symbol& symbol, name ram_payer )
 {
    require_auth( ram_payer );
+
+   auto sym_code_raw = symbol.code().raw();
+
+   stats statstable( _self, sym_code_raw );
+   const auto& st = statstable.get( sym_code_raw, "symbol does not exist" );
+   eosio_assert( st.supply.symbol == symbol, "symbol precision mismatch" );
+
    accounts acnts( _self, owner.value );
-   auto it = acnts.find( symbol.code().raw() );
+   auto it = acnts.find( sym_code_raw );
    if( it == acnts.end() ) {
       acnts.emplace( ram_payer, [&]( auto& a ){
         a.balance = asset{0, symbol};

--- a/tests/eosio.token_tests.cpp
+++ b/tests/eosio.token_tests.cpp
@@ -105,7 +105,7 @@ public:
                        account_name ram_payer    ) {
       return push_action( ram_payer, N(open), mvo()
            ( "owner", owner )
-           ( "symbol", "0,CERO" )
+           ( "symbol", symbolname )
            ( "ram_payer", ram_payer )
       );
    }
@@ -376,6 +376,12 @@ BOOST_FIXTURE_TEST_CASE( open_tests, eosio_token_tester ) try {
    REQUIRE_MATCHING_OBJECT( bob_balance, mvo()
       ("balance", "200 CERO")
    );
+
+   BOOST_REQUIRE_EQUAL( wasm_assert_msg( "symbol does not exist" ),
+                        open( N(carol), "0,INVALID", N(alice) ) );
+
+   BOOST_REQUIRE_EQUAL( wasm_assert_msg( "symbol precision mismatch" ),
+                        open( N(carol), "1,CERO", N(alice) ) );
 
 } FC_LOG_AND_RETHROW()
 


### PR DESCRIPTION
Resolves #93.

Special shoutout to @znebby who actually had a PR (#101) with a proper bug fix out more than half an hour before I started working on this implementation that I unfortunately did not see. Nevertheless we will be merging in this version since it includes unit tests and we want to get a release out soon.