### PR TITLE
Optionally assert multisig proposed transaction has particular ID as a condition for approval

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,8 @@
 cmake_minimum_required(VERSION 3.5)
 project(eosio_contracts VERSION 1.4.0)
 
-set(EOSIO_CDT_VERSION_MIN "1.3")
-set(EOSIO_CDT_VERSION_SOFT_MAX "1.3")
+set(EOSIO_CDT_VERSION_MIN "1.4")
+set(EOSIO_CDT_VERSION_SOFT_MAX "1.4")
 #set(EOSIO_CDT_VERSION_HARD_MAX "")
 
 find_package(eosio.cdt)

--- a/eosio.msig/include/eosio.msig/eosio.msig.hpp
+++ b/eosio.msig/include/eosio.msig/eosio.msig.hpp
@@ -13,7 +13,8 @@ namespace eosio {
          void propose(ignore<name> proposer, ignore<name> proposal_name,
                ignore<std::vector<permission_level>> requested, ignore<transaction> trx);
          [[eosio::action]]
-         void approve( name proposer, name proposal_name, permission_level level );
+         void approve( name proposer, name proposal_name, permission_level level,
+                       const eosio::binary_extension<eosio::digest256>& proposal_hash );
          [[eosio::action]]
          void unapprove( name proposer, name proposal_name, permission_level level );
          [[eosio::action]]

--- a/eosio.msig/include/eosio.msig/eosio.msig.hpp
+++ b/eosio.msig/include/eosio.msig/eosio.msig.hpp
@@ -14,7 +14,7 @@ namespace eosio {
                ignore<std::vector<permission_level>> requested, ignore<transaction> trx);
          [[eosio::action]]
          void approve( name proposer, name proposal_name, permission_level level,
-                       const eosio::binary_extension<eosio::digest256>& proposal_hash );
+                       const eosio::binary_extension<eosio::checksum256>& proposal_hash );
          [[eosio::action]]
          void unapprove( name proposer, name proposal_name, permission_level level );
          [[eosio::action]]

--- a/eosio.msig/src/eosio.msig.cpp
+++ b/eosio.msig/src/eosio.msig.cpp
@@ -59,7 +59,7 @@ void multisig::propose( ignore<name> proposer,
 }
 
 void multisig::approve( name proposer, name proposal_name, permission_level level,
-                        const eosio::binary_extension<eosio::digest256>& proposal_hash )
+                        const eosio::binary_extension<eosio::checksum256>& proposal_hash )
 {
    require_auth( level );
 

--- a/eosio.msig/src/eosio.msig.cpp
+++ b/eosio.msig/src/eosio.msig.cpp
@@ -1,6 +1,7 @@
 #include <eosio.msig/eosio.msig.hpp>
 #include <eosiolib/action.hpp>
 #include <eosiolib/permission.hpp>
+#include <eosiolib/crypto.hpp>
 
 namespace eosio {
 
@@ -57,8 +58,16 @@ void multisig::propose( ignore<name> proposer,
    });
 }
 
-void multisig::approve( name proposer, name proposal_name, permission_level level ) {
+void multisig::approve( name proposer, name proposal_name, permission_level level,
+                        const eosio::binary_extension<eosio::digest256>& proposal_hash )
+{
    require_auth( level );
+
+   if( proposal_hash ) {
+      proposals proptable( _self, proposer.value );
+      auto& prop = proptable.get( proposal_name.value, "proposal not found" );
+      assert_sha256( prop.packed_transaction.data(), prop.packed_transaction.size(), *proposal_hash );
+   }
 
    approvals apptable(  _self, proposer.value );
    auto apps_it = apptable.find( proposal_name.value );

--- a/tests/eosio.msig_tests.cpp
+++ b/tests/eosio.msig_tests.cpp
@@ -861,4 +861,90 @@ BOOST_FIXTURE_TEST_CASE( approve_by_two_old, eosio_msig_tester ) try {
 
 } FC_LOG_AND_RETHROW()
 
+BOOST_FIXTURE_TEST_CASE( approve_with_hash, eosio_msig_tester ) try {
+   auto trx = reqauth("alice", {permission_level{N(alice), config::active_name}}, abi_serializer_max_time );
+   auto trx_hash = fc::sha256::hash( trx );
+   auto not_trx_hash = fc::sha256::hash( trx_hash );
+
+   push_action( N(alice), N(propose), mvo()
+                  ("proposer",      "alice")
+                  ("proposal_name", "first")
+                  ("trx",           trx)
+                  ("requested", vector<permission_level>{{ N(alice), config::active_name }})
+   );
+
+   //fail to approve with incorrect hash
+   BOOST_REQUIRE_EXCEPTION( push_action( N(alice), N(approve), mvo()
+                                          ("proposer",      "alice")
+                                          ("proposal_name", "first")
+                                          ("level",         permission_level{ N(alice), config::active_name })
+                                          ("proposal_hash", not_trx_hash)
+                            ),
+                            eosio::chain::crypto_api_exception,
+                            fc_exception_message_is("hash mismatch")
+   );
+
+   //approve and execute
+   push_action( N(alice), N(approve), mvo()
+                  ("proposer",      "alice")
+                  ("proposal_name", "first")
+                  ("level",         permission_level{ N(alice), config::active_name })
+                  ("proposal_hash", trx_hash)
+   );
+
+   transaction_trace_ptr trace;
+   control->applied_transaction.connect([&]( const transaction_trace_ptr& t) { if (t->scheduled) { trace = t; } } );
+   push_action( N(alice), N(exec), mvo()
+                  ("proposer",      "alice")
+                  ("proposal_name", "first")
+                  ("executer",      "alice")
+   );
+
+   BOOST_REQUIRE( bool(trace) );
+   BOOST_REQUIRE_EQUAL( 1, trace->action_traces.size() );
+   BOOST_REQUIRE_EQUAL( transaction_receipt::executed, trace->receipt->status );
+} FC_LOG_AND_RETHROW()
+
+BOOST_FIXTURE_TEST_CASE( switch_proposal_and_fail_approve_with_hash, eosio_msig_tester ) try {
+   auto trx1 = reqauth("alice", {permission_level{N(alice), config::active_name}}, abi_serializer_max_time );
+   auto trx1_hash = fc::sha256::hash( trx1 );
+
+   push_action( N(alice), N(propose), mvo()
+                  ("proposer",      "alice")
+                  ("proposal_name", "first")
+                  ("trx",           trx1)
+                  ("requested", vector<permission_level>{{ N(alice), config::active_name }})
+   );
+
+   auto trx2 = reqauth("alice",
+                       { permission_level{N(alice), config::active_name},
+                         permission_level{N(alice), config::owner_name}  },
+                       abi_serializer_max_time );
+
+   push_action( N(alice), N(cancel), mvo()
+                  ("proposer",      "alice")
+                  ("proposal_name", "first")
+                  ("canceler",       "alice")
+   );
+
+   push_action( N(alice), N(propose), mvo()
+                  ("proposer",      "alice")
+                  ("proposal_name", "first")
+                  ("trx",           trx2)
+                  ("requested", vector<permission_level>{ { N(alice), config::active_name },
+                                                          { N(alice), config::owner_name } })
+   );
+
+   //fail to approve with hash meant for old proposal
+   BOOST_REQUIRE_EXCEPTION( push_action( N(alice), N(approve), mvo()
+                                          ("proposer",      "alice")
+                                          ("proposal_name", "first")
+                                          ("level",         permission_level{ N(alice), config::active_name })
+                                          ("proposal_hash", trx1_hash)
+                            ),
+                            eosio::chain::crypto_api_exception,
+                            fc_exception_message_is("hash mismatch")
+   );
+} FC_LOG_AND_RETHROW()
+
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Resolves #87.

This PR modifies the `eosio.msig::approve` action to take an optional `proposal_hash` argument (the new argument is a `binary_extension` which means it can be left off in the serialization without any problems, thus allowing for backwards compatibility of the `eosio.msig::approve` action). 

If and only if the `proposal_hash` is present, the action will assert that the digest provided in `proposal_hash` is identical to the SHA256 hash of the `packed_transaction` in the current referenced proposal (i.e. the ID of the proposed transaction).

Approvers can choose to use this new argument to protect against the proposer of the transaction switching the proposed transaction between the time the approver reviewed it and the time their approval transaction is retired in a block.