### PR TITLE
add lock, unlock actions to token contract

### DIFF
--- a/eosio.token/include/eosio.token/eosio.token.hpp
+++ b/eosio.token/include/eosio.token/eosio.token.hpp
@@ -6,6 +6,7 @@
 
 #include <eosiolib/asset.hpp>
 #include <eosiolib/eosio.hpp>
+#include <eosiolib/time.hpp>
 
 #include <string>
 
@@ -16,6 +17,7 @@ namespace eosiosystem {
 namespace eosio {
 
    using std::string;
+   using eosio::permission_level;
 
    class [[eosio::contract("eosio.token")]] token : public contract {
       public:
@@ -42,6 +44,15 @@ namespace eosio {
 
          [[eosio::action]]
          void close( name owner, const symbol& symbol );
+
+         [[eosio::action]]
+         void lock( name owner, asset quantity, uint32_t unlock_delay_sec );
+
+         [[eosio::action]]      
+         void unlock( name owner, asset quantity );
+
+         [[eosio::action]]
+         void dounlock( name owner, asset quantity );
 
          static asset get_supply( name token_contract_account, symbol_code sym_code )
          {
@@ -72,8 +83,17 @@ namespace eosio {
             uint64_t primary_key()const { return supply.symbol.code().raw(); }
          };
 
+         struct [[eosio::table]] locked_account {
+               asset balance;
+               uint32_t unlock_delay_sec;
+               time_point_sec unlock_request_time;
+
+               uint64_t primary_key()const { return balance.symbol.code().raw(); }
+         };
+
          typedef eosio::multi_index< "accounts"_n, account > accounts;
          typedef eosio::multi_index< "stat"_n, currency_stats > stats;
+         typedef eosio::multi_index< "locked"_n, locked_account > locked_accounts;
 
          void sub_balance( name owner, asset value );
          void add_balance( name owner, asset value, name ram_payer );

--- a/eosio.token/src/eosio.token.cpp
+++ b/eosio.token/src/eosio.token.cpp
@@ -4,6 +4,8 @@
  */
 
 #include <eosio.token/eosio.token.hpp>
+#include <eosiolib/action.hpp>
+#include <eosiolib/transaction.hpp>
 
 namespace eosio {
 
@@ -104,10 +106,107 @@ void token::transfer( name    from,
     eosio_assert( quantity.symbol == st.supply.symbol, "symbol precision mismatch" );
     eosio_assert( memo.size() <= 256, "memo has more than 256 bytes" );
 
+    locked_accounts locked_acnts( _self, from.value );
+    auto target = locked_acnts.find( quantity.symbol.code().raw() );
+    if ( target != locked_acnts.end() ) {
+       // check if sufficient amount is not locked for this transfer
+       accounts from_acnts( _self, from.value );
+       const auto& from = from_acnts.get( quantity.symbol.code().raw(), "no balance object found" );
+       eosio_assert( from.balance.amount - target->balance.amount >= quantity.amount, "locked balance" );
+    }
+
     auto payer = has_auth( to ) ? to : from;
 
     sub_balance( from, quantity );
     add_balance( to, quantity, payer );
+}
+
+void token::lock( name owner, asset quantity, uint32_t unlock_delay_sec )
+{
+    require_auth( owner );
+
+    auto sym = quantity.symbol.code();
+    stats statstable( _self, sym.raw() );
+    const auto& st = statstable.get( sym.raw() );
+
+    eosio_assert( quantity.is_valid(), "invalid quantity" );
+    eosio_assert( quantity.amount > 0, "must lock positive quantity" );
+    eosio_assert( quantity.symbol == st.supply.symbol, "symbol precision mismatch" );
+
+    eosio_assert( unlock_delay_sec > 0, "must set unlock delay");
+    eosio_assert( unlock_delay_sec > 3*24*3600, "must set unlock delay less than refund delay");
+
+    accounts acnts( _self, owner.value );
+    const auto& acnt = acnts.get( quantity.symbol.code().raw(), "no balance object found" );
+    eosio_assert( quantity.amount <= acnt.balance.amount, "quantity to lock is larger than current balance" );
+
+    locked_accounts locked_acnts( _self, owner.value );
+    auto target = locked_acnts.find( quantity.symbol.code().raw() );
+    if( target == locked_acnts.end() ) {
+       locked_acnts.emplace( owner, [&]( auto& a ) {
+          a.balance = quantity;
+          a.unlock_delay_sec = unlock_delay_sec;
+          a.unlock_request_time = time_point_sec::min();
+       });
+    } else {
+       eosio_assert( quantity.amount + target->balance.amount < acnt.balance.amount, "increased quantity to lock is larger than current balance" );
+       locked_acnts.modify( target, same_payer, [&]( auto& a ) {
+          a.balance.amount += quantity.amount;
+          if (a.unlock_delay_sec < unlock_delay_sec)
+             // can only increase unlock delay 
+             a.unlock_delay_sec = unlock_delay_sec;
+       });
+    }
+}
+
+void token::unlock( name owner, asset quantity )
+{
+   require_auth( owner );
+
+   auto sym = quantity.symbol.code();
+   stats statstable( _self, sym.raw() );
+   const auto& st = statstable.get( sym.raw() );
+
+   eosio_assert( quantity.is_valid(), "invalid quantity" );
+   eosio_assert( quantity.amount > 0, "must unlock positive quantity" );
+   eosio_assert( quantity.symbol == st.supply.symbol, "symbol precision mismatch" );
+
+   locked_accounts locked_acnts( _self, owner.value );
+   auto target = locked_acnts.find( quantity.symbol.code().raw() );
+   eosio_assert( target != locked_acnts.end(), "no locked balance object found" );
+   eosio_assert( quantity.amount <= target->balance.amount, "quantity to unlock is larger than current balance" );
+
+   eosio::transaction out;
+   out.actions.emplace_back( permission_level{owner, "active"_n},
+                             _self, "dounlock"_n,
+                             std::make_tuple(owner, quantity)
+   );
+   out.delay_sec = target->unlock_delay_sec;
+   locked_acnts.modify( target, same_payer, [&]( auto& a ) {
+      a.unlock_request_time = time_point_sec(current_time());
+   });
+
+//   cancel_deferred( from.value ); // check if needed
+   out.send( owner.value, owner, true );
+}
+
+void token::dounlock( name owner, asset quantity )
+{
+   locked_accounts locked_acnts( _self, owner.value );
+   auto target = locked_acnts.find( quantity.symbol.code().raw() );
+   eosio_assert( target != locked_acnts.end(), "no locked balance object found" );
+   eosio_assert( target->unlock_request_time > time_point_sec::min(), "unlock is not requested" );
+   eosio_assert( time_point_sec(target->unlock_request_time + seconds(target->unlock_delay_sec)) <= time_point_sec(current_time()),
+                 "unlock is not avalialbe yet");
+   eosio_assert( quantity.amount <= target->balance.amount, "quantity to unlock is larger than current balance" );
+
+   if (target->balance.amount > quantity.amount) {
+      locked_acnts.modify( target, same_payer, [&]( auto& a ) {
+         a.balance.amount -= quantity.amount;
+      });
+   } else {
+      locked_acnts.erase( target );
+   }
 }
 
 void token::sub_balance( name owner, asset value ) {
@@ -167,4 +266,4 @@ void token::close( name owner, const symbol& symbol )
 
 } /// namespace eosio
 
-EOSIO_DISPATCH( eosio::token, (create)(issue)(transfer)(open)(close)(retire) )
+EOSIO_DISPATCH( eosio::token, (create)(issue)(transfer)(open)(close)(retire)(lock)(unlock)(dounlock) )


### PR DESCRIPTION
This PR is to add lock and unlock actions to the token contract for locking given amount of tokens not to be transferred.

Locking can be used as a lightweight security measure preventing unwanted token transfer without explicit unlock action which takes some time to perform actual unlock similar to unstake. You can specify time delay to unlock at lock action. For example, if unlock delay time is set as 3 hours, you can leave your tokens locked in most of times but to unlock 3 hours before you need to transfer it. In addition, you can lock additional tokens if your balance increased while some tokens are locked. Of course, you can transfer freely for unlocked amount of your balance.

Specific interface for each action is as follows:

lock(name owner, asset quantity, uint32_t unlock_delay_time)
unlock(name owner, asset quantity)