### PR TITLE
Add functionality to explicitly manage account resources

### DIFF
--- a/eosio.system/include/eosio.system/eosio.system.hpp
+++ b/eosio.system/include/eosio.system/eosio.system.hpp
@@ -12,6 +12,8 @@
 #include <eosio.system/exchange_state.hpp>
 
 #include <string>
+#include <type_traits>
+#include <optional>
 
 namespace eosiosystem {
 
@@ -25,6 +27,25 @@ namespace eosiosystem {
    using eosio::time_point;
    using eosio::microseconds;
    using eosio::datastream;
+
+   template<typename E, typename F>
+   static inline auto has_field( F flags, E field )
+   -> std::enable_if_t< std::is_integral_v<F> && std::is_unsigned_v<F> &&
+                        std::is_enum_v<E> && std::is_same_v< F, std::underlying_type_t<E> >, bool>
+   {
+      return ( (flags & static_cast<F>(field)) != 0 );
+   }
+
+   template<typename E, typename F>
+   static inline auto set_field( F flags, E field, bool value = true )
+   -> std::enable_if_t< std::is_integral_v<F> && std::is_unsigned_v<F> &&
+                        std::is_enum_v<E> && std::is_same_v< F, std::underlying_type_t<E> >, F >
+   {
+      if( value )
+         return ( flags | static_cast<F>(field) );
+      else
+         return ( flags & ~static_cast<F>(field) );
+   }
 
    struct [[eosio::table, eosio::contract("eosio.system")]] name_bid {
      name            newname;
@@ -151,14 +172,20 @@ namespace eosiosystem {
       bool                is_proxy = 0; /// whether the voter is a proxy for others
 
 
-      uint32_t            reserved1 = 0;
+      uint32_t            flags1 = 0;
       uint32_t            reserved2 = 0;
       eosio::asset        reserved3;
 
       uint64_t primary_key()const { return owner.value; }
 
+      enum class flags1_fields : uint32_t {
+         ram_managed = 1,
+         net_managed = 2,
+         cpu_managed = 4
+      };
+
       // explicit serialization macro is not necessary, used here only to improve compilation time
-      EOSLIB_SERIALIZE( voter_info, (owner)(proxy)(producers)(staked)(last_vote_weight)(proxied_vote_weight)(is_proxy)(reserved1)(reserved2)(reserved3) )
+      EOSLIB_SERIALIZE( voter_info, (owner)(proxy)(producers)(staked)(last_vote_weight)(proxied_vote_weight)(is_proxy)(flags1)(reserved2)(reserved3) )
    };
 
    typedef eosio::multi_index< "voters"_n, voter_info >  voters_table;
@@ -219,6 +246,16 @@ namespace eosiosystem {
 
          [[eosio::action]]
          void setalimits( name account, int64_t ram_bytes, int64_t net_weight, int64_t cpu_weight );
+
+         [[eosio::action]]
+         void setacctram( name account, std::optional<int64_t> ram_bytes );
+
+         [[eosio::action]]
+         void setacctnet( name account, std::optional<int64_t> net_weight );
+
+         [[eosio::action]]
+         void setacctcpu( name account, std::optional<int64_t> cpu_weight );
+
          // functions defined in delegate_bandwidth.cpp
 
          /**

--- a/tests/eosio.system_tests.cpp
+++ b/tests/eosio.system_tests.cpp
@@ -5,6 +5,7 @@
 #include <eosio/chain/wast_to_wasm.hpp>
 #include <cstdlib>
 #include <iostream>
+#include <sstream>
 #include <fc/log/logger.hpp>
 #include <eosio/chain/exceptions.hpp>
 #include <Runtime/Runtime.h>
@@ -3442,6 +3443,145 @@ BOOST_FIXTURE_TEST_CASE( setabi, eosio_system_tester ) try {
 
       BOOST_REQUIRE( abi_hash.hash == result );
    }
+} FC_LOG_AND_RETHROW()
+
+BOOST_FIXTURE_TEST_CASE( change_limited_account_back_to_unlimited, eosio_system_tester ) try {
+   BOOST_REQUIRE( get_total_stake( "eosio" ).is_null() );
+
+   transfer( N(eosio), N(alice1111111), core_sym::from_string("1.0000") );
+
+   auto error_msg = stake( N(alice1111111), N(eosio), core_sym::from_string("0.0000"), core_sym::from_string("1.0000") );
+   auto semicolon_pos = error_msg.find(';');
+
+   BOOST_REQUIRE_EQUAL( error("account eosio has insufficient ram"),
+                        error_msg.substr(0, semicolon_pos) );
+
+   int64_t ram_bytes_needed = 0;
+   {
+      std::istringstream s( error_msg );
+      s.seekg( semicolon_pos + 7, std::ios_base::beg );
+      s >> ram_bytes_needed;
+      ram_bytes_needed += 256; // enough room to cover total_resources_table
+   }
+
+   push_action( N(eosio), N(setalimits), mvo()
+                                          ("account", "eosio")
+                                          ("ram_bytes", ram_bytes_needed)
+                                          ("net_weight", -1)
+                                          ("cpu_weight", -1)
+              );
+
+   stake( N(alice1111111), N(eosio), core_sym::from_string("0.0000"), core_sym::from_string("1.0000") );
+
+   REQUIRE_MATCHING_OBJECT( get_total_stake( "eosio" ), mvo()
+      ("owner", "eosio")
+      ("net_weight", core_sym::from_string("0.0000"))
+      ("cpu_weight", core_sym::from_string("1.0000"))
+      ("ram_bytes",  0)
+   );
+
+   BOOST_REQUIRE_EQUAL( wasm_assert_msg( "only supports unlimited accounts" ),
+                        push_action( N(eosio), N(setalimits), mvo()
+                                          ("account", "eosio")
+                                          ("ram_bytes", ram_bytes_needed)
+                                          ("net_weight", -1)
+                                          ("cpu_weight", -1)
+                        )
+   );
+
+   BOOST_REQUIRE_EQUAL( error( "transaction net usage is too high: 128 > 0" ),
+                        push_action( N(eosio), N(setalimits), mvo()
+                           ("account", "eosio.saving")
+                           ("ram_bytes", -1)
+                           ("net_weight", -1)
+                           ("cpu_weight", -1)
+                        )
+   );
+
+   BOOST_REQUIRE_EQUAL( success(),
+                        push_action( N(eosio), N(setacctnet), mvo()
+                           ("account", "eosio")
+                           ("net_weight", -1)
+                        )
+   );
+
+   BOOST_REQUIRE_EQUAL( success(),
+                        push_action( N(eosio), N(setacctcpu), mvo()
+                           ("account", "eosio")
+                           ("cpu_weight", -1)
+
+                        )
+   );
+
+   BOOST_REQUIRE_EQUAL( success(),
+                        push_action( N(eosio), N(setalimits), mvo()
+                                          ("account", "eosio.saving")
+                                          ("ram_bytes", ram_bytes_needed)
+                                          ("net_weight", -1)
+                                          ("cpu_weight", -1)
+                        )
+   );
+
+} FC_LOG_AND_RETHROW()
+
+BOOST_FIXTURE_TEST_CASE( buy_pin_sell_ram, eosio_system_tester ) try {
+   BOOST_REQUIRE( get_total_stake( "eosio" ).is_null() );
+
+   transfer( N(eosio), N(alice1111111), core_sym::from_string("1020.0000") );
+
+   auto error_msg = stake( N(alice1111111), N(eosio), core_sym::from_string("10.0000"), core_sym::from_string("10.0000") );
+   auto semicolon_pos = error_msg.find(';');
+
+   BOOST_REQUIRE_EQUAL( error("account eosio has insufficient ram"),
+                        error_msg.substr(0, semicolon_pos) );
+
+   int64_t ram_bytes_needed = 0;
+   {
+      std::istringstream s( error_msg );
+      s.seekg( semicolon_pos + 7, std::ios_base::beg );
+      s >> ram_bytes_needed;
+      ram_bytes_needed += ram_bytes_needed/10; // enough buffer to make up for buyrambytes estimation errors
+   }
+
+   auto alice_original_balance = get_balance( N(alice1111111) );
+
+   BOOST_REQUIRE_EQUAL( success(), buyrambytes( N(alice1111111), N(eosio), static_cast<uint32_t>(ram_bytes_needed) ) );
+
+   auto tokens_paid_for_ram = alice_original_balance - get_balance( N(alice1111111) );
+
+   auto total_res = get_total_stake( "eosio" );
+
+   REQUIRE_MATCHING_OBJECT( total_res, mvo()
+      ("owner", "eosio")
+      ("net_weight", core_sym::from_string("0.0000"))
+      ("cpu_weight", core_sym::from_string("0.0000"))
+      ("ram_bytes",  total_res["ram_bytes"].as_int64() )
+   );
+
+   BOOST_REQUIRE_EQUAL( wasm_assert_msg( "only supports unlimited accounts" ),
+                        push_action( N(eosio), N(setalimits), mvo()
+                                          ("account", "eosio")
+                                          ("ram_bytes", ram_bytes_needed)
+                                          ("net_weight", -1)
+                                          ("cpu_weight", -1)
+                        )
+   );
+
+   BOOST_REQUIRE_EQUAL( success(),
+                        push_action( N(eosio), N(setacctram), mvo()
+                           ("account", "eosio")
+                           ("ram_bytes", total_res["ram_bytes"].as_int64() )
+                        )
+   );
+
+   auto eosio_original_balance = get_balance( N(eosio) );
+
+   BOOST_REQUIRE_EQUAL( success(), sellram( N(eosio), total_res["ram_bytes"].as_int64() ) );
+
+   auto tokens_received_by_selling_ram = get_balance( N(eosio) ) - eosio_original_balance;
+
+   BOOST_REQUIRE( double(tokens_paid_for_ram.get_amount() - tokens_received_by_selling_ram.get_amount()) / tokens_paid_for_ram.get_amount() < 0.01 );
+
 } FC_LOG_AND_RETHROW()
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
This PR adds three new actions to the system contract: `setacctram`, `setacctnet`, and `setacctcpu`. These actions allow a specific resource quota of a particular account to be set to a prescribed value regardless of the other changes that happen with that account that would normally affect their resource quotas. All three of these actions require authorization by the `eosio` account, and so are only relevant to the privileged operators of the network, e.g. a two-thirds supermajority of the active block producers if a particular blockchain was configured to unilaterally satisfy the `eosio@active` permission with the `eosio.prods@active` permission. 

For example, `setacctram` can be used to pin the RAM quota of an account to a prescribed value. When the account's RAM quota is pinned in this manner, they can sell RAM all the way down to 0 without violating the RAM requires of the native EOSIO system, because as far as that system is concerned the account's RAM quota is still at the prescribed value. The `setacctram` action can then be used to change to value to something else or to even unpin the resource such that it is governed by the regular RAM market mechanism; however, such changes need to still satisfy the requirement that the new RAM quota is not less than the current RAM usage otherwise the action will fail.

Similarly, the `setacctnet` and `setacctcpu` actions can be used to pin the network and CPU bandwidth quotas of an account, respectively, to specific values. A value of -1 is allowed to represent an unlimited quota. Regardless of how the tracked resources of the account changes in the `userres` table due to the `delegatebw`/`undelegatebw` actions, the bandwidth quota of that account will remain pinned at the specified value from the perspective of the native EOSIO resource management algorithm. Again, the actions allow unpinning the resources of an account and switching back to determining the bandwidth quotas for the account through the regular staking/delegating mechanics.
