### PR TITLE
fix update_votes

### DIFF
--- a/eosio.system/src/voting.cpp
+++ b/eosio.system/src/voting.cpp
@@ -275,7 +275,8 @@ namespace eosiosystem {
       for( const auto& pd : producer_deltas ) {
          auto pitr = _producers.find( pd.first.value );
          if( pitr != _producers.end() ) {
-            eosio_assert( !voting || pitr->active() || !pd.second.second /* not from new set */, "producer is not currently registered" );
+            eosio_assert( !voting || pitr->active() || !pd.second.second /* not from new set */,
+                          ( "producer " + pitr->owner.to_string() + " is not currently registered" ).data() );
             double init_total_votes = pitr->total_votes;
             _producers.modify( pitr, same_payer, [&]( auto& p ) {
                p.total_votes += pd.second.first;


### PR DESCRIPTION
output the producer name if approve new block producer failed.

If I voted 25 block producers, and one of these BP is unregistered, then I can't approve new block producer to my list, because that BP is not active.

So I have to check one by one to find out which BP is unregistered, then unapprove.

this change will help voter find out the unregistered BP easily.