### PR TITLE
Not allow to push `open` when balance row already exists

### DIFF
--- a/contracts/eosio.token/src/eosio.token.cpp
+++ b/contracts/eosio.token/src/eosio.token.cpp
@@ -148,11 +148,10 @@ void token::open( name owner, const symbol& symbol, name ram_payer )
 
    accounts acnts( _self, owner.value );
    auto it = acnts.find( sym_code_raw );
-   if( it == acnts.end() ) {
-      acnts.emplace( ram_payer, [&]( auto& a ){
-        a.balance = asset{0, symbol};
-      });
-   }
+   check( it == acnts.end(), "Balance row already exists" );
+   acnts.emplace( ram_payer, [&]( auto& a ){
+     a.balance = asset{0, symbol};
+   });
 }
 
 void token::close( name owner, const symbol& symbol )

--- a/tests/eosio.token_tests.cpp
+++ b/tests/eosio.token_tests.cpp
@@ -383,6 +383,9 @@ BOOST_FIXTURE_TEST_CASE( open_tests, eosio_token_tester ) try {
    BOOST_REQUIRE_EQUAL( wasm_assert_msg( "symbol precision mismatch" ),
                         open( N(carol), "1,CERO", N(alice) ) );
 
+   BOOST_REQUIRE_EQUAL( wasm_assert_msg( "Balance row already exists" ),
+                        open( N(bob), "0,CERO", N(alice) ) );
+
 } FC_LOG_AND_RETHROW()
 
 BOOST_FIXTURE_TEST_CASE( close_tests, eosio_token_tester ) try {


### PR DESCRIPTION
## Change Description

Even though balance row already exists, `open` action can be pushed in `eosio.token` contract. It doesn't need to include meaningless transaction in block.

## Deployment Changes
- [ ] Deployment Changes

## API Changes
- [ ] API Changes

## Documentation Additions
- [ ] Documentation Additions
