### PR TITLE
REX enhancements and bug fixes - 2

### DIFF
--- a/contracts/eosio.system/CMakeLists.txt
+++ b/contracts/eosio.system/CMakeLists.txt
@@ -8,3 +8,13 @@ target_include_directories(eosio.system
 set_target_properties(eosio.system
    PROPERTIES
    RUNTIME_OUTPUT_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}")
+
+add_contract(rex.results rex.results ${CMAKE_CURRENT_SOURCE_DIR}/src/rex.results.cpp)
+
+target_include_directories(rex.results
+   PUBLIC
+   ${CMAKE_CURRENT_SOURCE_DIR}/include)
+
+set_target_properties(rex.results
+   PROPERTIES
+   RUNTIME_OUTPUT_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/.rex")

--- a/contracts/eosio.system/include/eosio.system/eosio.system.hpp
+++ b/contracts/eosio.system/include/eosio.system/eosio.system.hpp
@@ -601,6 +601,7 @@ namespace eosiosystem {
          using defnetloan_action = eosio::action_wrapper<"defnetloan"_n, &system_contract::defnetloan>;
          using updaterex_action = eosio::action_wrapper<"updaterex"_n, &system_contract::updaterex>;
          using rexexec_action = eosio::action_wrapper<"rexexec"_n, &system_contract::rexexec>;
+         using setrex_action = eosio::action_wrapper<"setrex"_n, &system_contract::setrex>;
          using mvtosavings_action = eosio::action_wrapper<"mvtosavings"_n, &system_contract::mvtosavings>;
          using mvfrsavings_action = eosio::action_wrapper<"mvfrsavings"_n, &system_contract::mvfrsavings>;
          using consolidate_action = eosio::action_wrapper<"consolidate"_n, &system_contract::consolidate>;

--- a/contracts/eosio.system/include/eosio.system/eosio.system.hpp
+++ b/contracts/eosio.system/include/eosio.system/eosio.system.hpp
@@ -372,6 +372,12 @@ namespace eosiosystem {
                           asset stake_net_quantity, asset stake_cpu_quantity, bool transfer );
 
          /**
+          * Sets total_rent balance of REX pool to the passed value
+          */
+         [[eosio::action]]
+         void setrex( const asset& balance );
+
+         /**
           * Deposits core tokens to user REX fund. All proceeds and expenses related to REX are added to
           * or taken out of this fund. Inline token transfer from user balance is executed.
           */

--- a/contracts/eosio.system/include/eosio.system/eosio.system.hpp
+++ b/contracts/eosio.system/include/eosio.system/eosio.system.hpp
@@ -654,7 +654,7 @@ namespace eosiosystem {
          void defund_rex_loan( T& table, const name& from, uint64_t loan_num, const asset& amount );
          void transfer_from_fund( const name& owner, const asset& amount );
          void transfer_to_fund( const name& owner, const asset& amount );
-         bool rex_loans_available()const { return _rexorders.begin() == _rexorders.end() && rex_available(); }
+         bool rex_loans_available()const;
          bool rex_system_initialized()const { return _rexpool.begin() != _rexpool.end(); }
          bool rex_available()const { return rex_system_initialized() && _rexpool.begin()->total_rex.amount > 0; }
          static time_point_sec get_rex_maturity();

--- a/contracts/eosio.system/include/eosio.system/eosio.system.hpp
+++ b/contracts/eosio.system/include/eosio.system/eosio.system.hpp
@@ -667,6 +667,11 @@ namespace eosiosystem {
          void put_rex_savings( const rex_balance_table::const_iterator& bitr, int64_t rex );
          void update_rex_stake( const name& voter );
 
+         void add_loan_to_rex_pool( const asset& payment, int64_t rented_tokens, bool new_loan );
+         void remove_loan_from_rex_pool( const rex_loan& loan );
+         template <typename Index, typename Iterator>
+         int64_t update_renewed_loan( Index& idx, const Iterator& itr, int64_t rented_tokens );
+
          // defined in delegate_bandwidth.cpp
          void changebw( name from, name receiver,
                         asset stake_net_quantity, asset stake_cpu_quantity, bool transfer );
@@ -687,12 +692,12 @@ namespace eosiosystem {
             public:
                template <auto system_contract::*P, auto system_contract::*...Ps>
                struct for_each {
-                     template <typename... Args>
-                     static constexpr void call( system_contract* this_contract, Args&&... args )
-                     {
-                        std::invoke( P, this_contract, std::forward<Args>(args)... );
-                        for_each<Ps...>::call( this_contract, std::forward<Args>(args)... );
-                     }
+                  template <typename... Args>
+                  static constexpr void call( system_contract* this_contract, Args&&... args )
+                  {
+                     std::invoke( P, this_contract, std::forward<Args>(args)... );
+                     for_each<Ps...>::call( this_contract, std::forward<Args>(args)... );
+                  }
                };
                template <auto system_contract::*P>
                struct for_each<P> {

--- a/contracts/eosio.system/include/eosio.system/rex.results.hpp
+++ b/contracts/eosio.system/include/eosio.system/rex.results.hpp
@@ -1,0 +1,24 @@
+#pragma once
+
+#include <eosiolib/eosio.hpp>
+#include <eosiolib/name.hpp>
+#include <eosiolib/asset.hpp>
+
+using eosio::name;
+using eosio::asset;
+
+class [[eosio::contract("rex.results")]] rex_results {
+   public:
+      [[eosio::action]]
+      void buyresult( const asset& rex_received );
+      
+      [[eosio::action]]
+      void sellresult( const asset& proceeds );
+   
+      [[eosio::action]]
+      void orderresult( const name& owner, const asset& proceeds );
+   
+      using buyresult_action   = eosio::action_wrapper<"buyresult"_n, &rex_results::buyresult>;
+      using sellresult_action  = eosio::action_wrapper<"sellresult"_n, &rex_results::sellresult>;
+      using orderresult_action = eosio::action_wrapper<"orderresult"_n, &rex_results::orderresult>;
+};

--- a/contracts/eosio.system/src/eosio.system.cpp
+++ b/contracts/eosio.system/src/eosio.system.cpp
@@ -467,7 +467,7 @@ EOSIO_DISPATCH( eosiosystem::system_contract,
      (rmvproducer)(updtrevision)(bidname)(bidrefund)
      // rex.cpp
      (deposit)(withdraw)(buyrex)(unstaketorex)(sellrex)(cnclrexorder)(rentcpu)(rentnet)(fundcpuloan)(fundnetloan)
-     (defcpuloan)(defnetloan)(updaterex)(consolidate)(mvtosavings)(mvfrsavings)(rexexec)(closerex)
+     (defcpuloan)(defnetloan)(updaterex)(consolidate)(mvtosavings)(mvfrsavings)(setrex)(rexexec)(closerex)
      // delegate_bandwidth.cpp
      (buyrambytes)(buyram)(sellram)(delegatebw)(undelegatebw)(refund)
      // voting.cpp

--- a/contracts/eosio.system/src/rex.cpp
+++ b/contracts/eosio.system/src/rex.cpp
@@ -561,6 +561,23 @@ namespace eosiosystem {
       check( vitr != _voters.end() && ( vitr->proxy || 21 <= vitr->producers.size() ), error_msg );
    }
 
+   bool system_contract::rex_loans_available()const
+   {
+      if ( !rex_available() ) {
+         return false;
+      } else if ( _rexorders.begin() == _rexorders.end() ) { // rex_available() && _rexorders.begin() == _rexorders.end()
+         return true;
+      } else {                                               // rex_available() && _rexorders.begin() != _rexorders.end()
+         auto idx = _rexorders.get_index<"bytime"_n>();
+         auto begin = idx.begin();
+         if ( begin->is_open ) {
+            return false;
+         } else {
+            return true;
+         }
+      }
+   }
+
    /**
     * @brief Updates rex_pool balances upon creating a new loan or renewing an existing one
     */

--- a/contracts/eosio.system/src/rex.cpp
+++ b/contracts/eosio.system/src/rex.cpp
@@ -1040,7 +1040,7 @@ namespace eosiosystem {
        * If precision of CORE_SYMBOL is 4, that corresponds to a maximum supply of 40 billion tokens.
        */
       const int64_t rex_ratio = 10000;
-      const asset   init_total_rent( 1000 * 10000, core_symbol() ); /// base balance prevents renting profitably until at least a minimum number of core_symbol() is made available
+      const asset   init_total_rent( 20'000'0000, core_symbol() ); /// base balance prevents renting profitably until at least a minimum number of core_symbol() is made available
       asset rex_received( 0, rex_symbol );
       auto itr = _rexpool.begin();
       if ( !rex_system_initialized() ) {

--- a/contracts/eosio.system/src/rex.cpp
+++ b/contracts/eosio.system/src/rex.cpp
@@ -787,7 +787,7 @@ namespace eosiosystem {
 
       check( proceeds.amount > 0, "proceeds are negligible" );
 
-      const int64_t unlent_lower_bound = rexitr->total_lent.amount;
+      const int64_t unlent_lower_bound = ( uint128_t(2) * rexitr->total_lent.amount ) / 10;
       const int64_t available_unlent   = rexitr->total_unlent.amount - unlent_lower_bound; // available_unlent <= 0 is possible
       if ( proceeds.amount <= available_unlent ) {
          const int64_t init_vote_stake_amount = bitr->vote_stake.amount;
@@ -1026,8 +1026,8 @@ namespace eosiosystem {
        * to exceed that limit, maximum amount of indivisible units cannot be set to a value larger than 4 * 10^14.
        * If precision of CORE_SYMBOL is 4, that corresponds to a maximum supply of 40 billion tokens.
        */
-      const int64_t rex_ratio       = 10000;
-      const asset   init_total_rent( 20'000'0000, core_symbol() ); /// base balance prevents renting profitably until at least a minimum number of core_symbol() is made available
+      const int64_t rex_ratio = 10000;
+      const asset   init_total_rent( 200 * 10000, core_symbol() ); /// base balance prevents renting profitably until at least a minimum number of core_symbol() is made available
       asset rex_received( 0, rex_symbol );
       auto itr = _rexpool.begin();
       if ( !rex_system_initialized() ) {

--- a/contracts/eosio.system/src/rex.cpp
+++ b/contracts/eosio.system/src/rex.cpp
@@ -3,6 +3,7 @@
  */
 
 #include <eosio.system/eosio.system.hpp>
+#include <eosio.system/rex.results.hpp>
 
 namespace eosiosystem {
 
@@ -61,7 +62,8 @@ namespace eosiosystem {
       runrex(2);
       update_rex_account( from, asset( 0, core_symbol() ), delta_rex_stake );
       // dummy action added so that amount of REX tokens purchased shows up in action trace 
-      dispatch_inline( null_account, "buyresult"_n, { }, std::make_tuple( rex_received ) );
+      rex_results::buyresult_action buyrex_act( rex_account, std::vector<eosio::permission_level>{ } );
+      buyrex_act.send( rex_received );
    }
 
    /**
@@ -105,7 +107,8 @@ namespace eosiosystem {
       runrex(2);
       update_rex_account( owner, asset( 0, core_symbol() ), asset( 0, core_symbol() ), true );
       // dummy action added so that amount of REX tokens purchased shows up in action trace
-      dispatch_inline( null_account, "buyresult"_n, { }, std::make_tuple( rex_received ) );
+      rex_results::buyresult_action buyrex_act( rex_account, std::vector<eosio::permission_level>{ } );
+      buyrex_act.send( rex_received );
    }
 
    /**
@@ -153,7 +156,8 @@ namespace eosiosystem {
       check( pending_sell_order.amount <= bitr->matured_rex, "insufficient funds for current and scheduled orders" );
       // dummy action added so that sell order proceeds show up in action trace
       if ( current_order.success ) {
-         dispatch_inline( null_account, "sellresult"_n, { }, std::make_tuple( current_order.proceeds ) );
+         rex_results::sellresult_action sellrex_act( rex_account, std::vector<eosio::permission_level>{ } );
+         sellrex_act.send( current_order.proceeds );
       }
    }
 
@@ -721,7 +725,8 @@ namespace eosiosystem {
                      order.close();
                   });
                   /// send dummy action to show and owner and proceeds of filled sellrex order
-                  dispatch_inline( null_account, "orderresult"_n, { }, std::make_tuple( order_owner, result.proceeds ) );
+                  rex_results::orderresult_action order_act( rex_account, std::vector<eosio::permission_level>{ } );
+                  order_act.send( order_owner, result.proceeds );
                }
             }
             oitr = next;
@@ -1172,7 +1177,7 @@ namespace eosiosystem {
          });
          delta_stake = current_vote_stake.amount - init_vote_stake.amount;
       }
-      
+
       if ( delta_stake != 0 ) {
          auto vitr = _voters.find( voter.value );
          if ( vitr != _voters.end() ) {

--- a/contracts/eosio.system/src/rex.cpp
+++ b/contracts/eosio.system/src/rex.cpp
@@ -1028,7 +1028,7 @@ namespace eosiosystem {
        * If precision of CORE_SYMBOL is 4, that corresponds to a maximum supply of 40 billion tokens.
        */
       const int64_t rex_ratio = 10000;
-      const asset   init_total_rent( 200 * 10000, core_symbol() ); /// base balance prevents renting profitably until at least a minimum number of core_symbol() is made available
+      const asset   init_total_rent( 1000 * 10000, core_symbol() ); /// base balance prevents renting profitably until at least a minimum number of core_symbol() is made available
       asset rex_received( 0, rex_symbol );
       auto itr = _rexpool.begin();
       if ( !rex_system_initialized() ) {

--- a/contracts/eosio.system/src/rex.cpp
+++ b/contracts/eosio.system/src/rex.cpp
@@ -551,8 +551,8 @@ namespace eosiosystem {
    }
 
    /**
-    * @brief Checks if account voting requirements (voting for a proxy or 21 producers) when
-    * buying REX
+    * @brief Checks if account satisfies voting requirement (voting for a proxy or 21 producers)
+    * for buying REX
     *
     * @param owner - account buying or already holding REX tokens
     * @err_msg - error message

--- a/contracts/eosio.system/src/rex.cpp
+++ b/contracts/eosio.system/src/rex.cpp
@@ -311,6 +311,23 @@ namespace eosiosystem {
    }
 
    /**
+    * @brief Sets total_rent balance of REX pool to the passed value
+    *
+    * @param balance - the value to which total_rent will be set
+    */
+   void system_contract::setrex( const asset& balance )
+   {
+      require_auth( "eosio"_n );
+
+      check( balance.amount > 0, "balance must be set to have a positive amount" );
+      check( balance.symbol == core_symbol(), "balance symbol must be core symbol" );
+      check( rex_system_initialized(), "rex system is not initialized" );
+      _rexpool.modify( _rexpool.begin(), same_payer, [&]( auto& pool ) {
+         pool.total_rent = balance;
+      });
+   }
+
+   /**
     * @brief Performs REX maintenance by processing a specified number of REX sell orders
     * and expired loans
     *

--- a/contracts/eosio.system/src/rex.results.cpp
+++ b/contracts/eosio.system/src/rex.results.cpp
@@ -1,0 +1,9 @@
+#include <eosio.system/rex.results.hpp>
+
+void rex_results::buyresult( const asset& rex_received ) { }
+
+void rex_results::sellresult( const asset& proceeds ) { }
+
+void rex_results::orderresult( const name& owner, const asset& proceeds ) { }
+
+extern "C" void apply( uint64_t, uint64_t, uint64_t ) { }

--- a/tests/eosio.system_tests.cpp
+++ b/tests/eosio.system_tests.cpp
@@ -3393,7 +3393,7 @@ BOOST_FIXTURE_TEST_CASE( ram_gift, eosio_system_tester ) try {
 BOOST_FIXTURE_TEST_CASE( buy_sell_rex, eosio_system_tester ) try {
 
    const int64_t ratio        = 10000;
-   const asset   init_rent    = core_sym::from_string("200.0000");
+   const asset   init_rent    = core_sym::from_string("1000.0000");
    const asset   init_balance = core_sym::from_string("1000.0000");
    const std::vector<account_name> accounts = { N(aliceaccount), N(bobbyaccount), N(carolaccount), N(emilyaccount), N(frankaccount) };
    account_name alice = accounts[0], bob = accounts[1], carol = accounts[2], emily = accounts[3], frank = accounts[4];
@@ -3455,12 +3455,12 @@ BOOST_FIXTURE_TEST_CASE( buy_sell_small_rex, eosio_system_tester ) try {
 
    const int64_t ratio        = 10000;
    const asset   init_rent    = core_sym::from_string("100000.0000");
-   const asset   init_balance = core_sym::from_string("1000.0000");
+   const asset   init_balance = core_sym::from_string("5000.0000");
    const std::vector<account_name> accounts = { N(aliceaccount), N(bobbyaccount), N(carolaccount) };
    account_name alice = accounts[0], bob = accounts[1], carol = accounts[2];
    setup_rex_accounts( accounts, init_balance );
 
-   const asset payment = core_sym::from_string("500.0000");
+   const asset payment = core_sym::from_string("2000.0000");
    BOOST_REQUIRE_EQUAL( ratio * payment.get_amount(),               get_buyrex_result( alice, payment ).get_amount() );
 
    produce_blocks(2);
@@ -3615,8 +3615,8 @@ BOOST_FIXTURE_TEST_CASE( buy_rent_rex, eosio_system_tester ) try {
    // bob tries to rent rex
    BOOST_REQUIRE_EQUAL( wasm_assert_msg("rex system not initialized yet"), rentcpu( bob, carol, core_sym::from_string("5.0000") ) );
    // alice lends rex
-   BOOST_REQUIRE_EQUAL( success(), buyrex( alice, core_sym::from_string("265.0000") ) );
-   BOOST_REQUIRE_EQUAL( init_balance - core_sym::from_string("265.0000"), get_rex_fund(alice) );
+   BOOST_REQUIRE_EQUAL( success(), buyrex( alice, core_sym::from_string("5265.0000") ) );
+   BOOST_REQUIRE_EQUAL( init_balance - core_sym::from_string("5265.0000"), get_rex_fund(alice) );
    auto rex_pool = get_rex_pool();
    const asset   init_tot_unlent   = rex_pool["total_unlent"].as<asset>();
    const asset   init_tot_lendable = rex_pool["total_lendable"].as<asset>();
@@ -3672,9 +3672,9 @@ BOOST_FIXTURE_TEST_CASE( buy_rent_rex, eosio_system_tester ) try {
    {
       const int64_t init_net_limit = get_net_limit( emily );
       BOOST_REQUIRE_EQUAL( 0,         get_rex_balance(alice).get_amount() );
-      BOOST_REQUIRE_EQUAL( success(), buyrex( alice, core_sym::from_string("210.0000") ) );
+      BOOST_REQUIRE_EQUAL( success(), buyrex( alice, core_sym::from_string("1050.0000") ) );
       rex_pool = get_rex_pool();
-      const asset fee = core_sym::from_string("2.4560");
+      const asset fee = core_sym::from_string("0.4560");
       int64_t expected_net = bancor_convert( rex_pool["total_rent"].as<asset>().get_amount(),
                                              rex_pool["total_unlent"].as<asset>().get_amount(),
                                              fee.get_amount() );
@@ -3699,7 +3699,7 @@ BOOST_FIXTURE_TEST_CASE( buy_sell_sell_rex, eosio_system_tester ) try {
    const int64_t init_net_limit = get_net_limit( alice );
 
    // alice lends rex
-   const asset payment = core_sym::from_string("650.0000");
+   const asset payment = core_sym::from_string("3250.0000");
    BOOST_REQUIRE_EQUAL( success(),              buyrex( alice, payment ) );
    BOOST_REQUIRE_EQUAL( success(),              buyrex( bob, core_sym::from_string("0.0005") ) );
    BOOST_REQUIRE_EQUAL( init_balance - payment, get_rex_fund(alice) );
@@ -3754,9 +3754,9 @@ BOOST_FIXTURE_TEST_CASE( buy_sell_claim_rex, eosio_system_tester ) try {
    account_name alice = accounts[0], bob = accounts[1], carol = accounts[2], emily = accounts[3], frank = accounts[4];
    setup_rex_accounts( accounts, init_balance );
 
-   const auto purchase1  = core_sym::from_string("100000.0000");
-   const auto purchase2  = core_sym::from_string("471000.0000");
-   const auto purchase3  = core_sym::from_string("469000.0000");
+   const auto purchase1  = core_sym::from_string("2500.0000");
+   const auto purchase2  = core_sym::from_string("11775.0000");
+   const auto purchase3  = core_sym::from_string("11725.0000");
    const auto init_stake = get_voter_info(alice)["staked"].as<int64_t>();
    BOOST_REQUIRE_EQUAL( success(), buyrex( alice, purchase1) );
    BOOST_REQUIRE_EQUAL( success(), buyrex( bob,   purchase2) );
@@ -3772,9 +3772,14 @@ BOOST_FIXTURE_TEST_CASE( buy_sell_claim_rex, eosio_system_tester ) try {
    auto init_bob_rex   = get_rex_balance(bob);
    auto init_carol_rex = get_rex_balance(carol);
 
-   BOOST_REQUIRE_EQUAL(core_sym::from_string("200.0000"), get_rex_pool()["total_rent"].as<asset>() );
+   BOOST_REQUIRE_EQUAL( core_sym::from_string("1000.0000"), get_rex_pool()["total_rent"].as<asset>() );
 
-   const asset rent_payment = core_sym::from_string("1100000.0000");
+   for (uint8_t i = 0; i < 4; ++i) {
+      BOOST_REQUIRE_EQUAL( success(), rentcpu( emily, emily, core_sym::from_string("1000.0000") ) );
+   }
+
+   const asset rent_payment = core_sym::from_string("2000.0000");
+
    BOOST_REQUIRE_EQUAL( success(), rentcpu( frank, frank, rent_payment, rent_payment ) );
 
    const auto    init_rex_pool        = get_rex_pool();
@@ -3783,11 +3788,11 @@ BOOST_FIXTURE_TEST_CASE( buy_sell_claim_rex, eosio_system_tester ) try {
 
    produce_block( fc::days(5) );
 
-   BOOST_REQUIRE_EQUAL( success(), sellrex( alice, asset( get_rex_balance(alice).get_amount() / 4, symbol(SY(4,REX)) ) ) );
+   BOOST_REQUIRE_EQUAL( success(), sellrex( alice, asset( 3 * get_rex_balance(alice).get_amount() / 4, symbol(SY(4,REX)) ) ) );
 
-   BOOST_TEST_REQUIRE( within_one( 3 * init_alice_rex.get_amount() / 4, get_rex_balance(alice).get_amount() ) );
-   BOOST_TEST_REQUIRE( within_one( 3 * init_alice_rex_stake / 4,        get_rex_vote_stake( alice ).get_amount() ) );
-   BOOST_TEST_REQUIRE( within_one( 3 * init_alice_rex_stake / 4,        get_voter_info(alice)["staked"].as<int64_t>() - init_stake ) );
+   BOOST_TEST_REQUIRE( within_one( init_alice_rex.get_amount() / 4, get_rex_balance(alice).get_amount() ) );
+   BOOST_TEST_REQUIRE( within_one( init_alice_rex_stake / 4,        get_rex_vote_stake( alice ).get_amount() ) );
+   BOOST_TEST_REQUIRE( within_one( init_alice_rex_stake / 4,        get_voter_info(alice)["staked"].as<int64_t>() - init_stake ) );
 
    produce_block( fc::days(5) );
 
@@ -3829,11 +3834,9 @@ BOOST_FIXTURE_TEST_CASE( buy_sell_claim_rex, eosio_system_tester ) try {
       auto trace = base_tester::push_action( N(eosio), N(buyrex), frank,
                                              mvo()("from", frank)("amount", core_sym::from_string("0.0001")) );
       auto output = get_rexorder_result( trace );
-      BOOST_REQUIRE_EQUAL( output.size(),    2 );
+      BOOST_REQUIRE_EQUAL( output.size(),    1 );
       BOOST_REQUIRE_EQUAL( output[0].first,  bob );
       BOOST_REQUIRE_EQUAL( output[0].second, get_rex_order(bob)["proceeds"].as<asset>() );
-      BOOST_REQUIRE_EQUAL( output[1].first,  carol );
-      BOOST_REQUIRE_EQUAL( output[1].second, get_rex_order(carol)["proceeds"].as<asset>() );
    }
 
    BOOST_REQUIRE_EQUAL( true,           get_rex_order(alice)["is_open"].as<bool>() );
@@ -3844,9 +3847,9 @@ BOOST_FIXTURE_TEST_CASE( buy_sell_claim_rex, eosio_system_tester ) try {
    BOOST_REQUIRE_EQUAL( init_bob_rex,   get_rex_order(bob)["rex_requested"].as<asset>() );
    BOOST_REQUIRE      ( 0 <             get_rex_order(bob)["proceeds"].as<asset>().get_amount() );
 
-   BOOST_REQUIRE_EQUAL( false,          get_rex_order(carol)["is_open"].as<bool>() );
+   BOOST_REQUIRE_EQUAL( true,           get_rex_order(carol)["is_open"].as<bool>() );
    BOOST_REQUIRE_EQUAL( init_carol_rex, get_rex_order(carol)["rex_requested"].as<asset>() );
-   BOOST_REQUIRE      ( 0 <             get_rex_order(carol)["proceeds"].as<asset>().get_amount() );
+   BOOST_REQUIRE_EQUAL( 0,              get_rex_order(carol)["proceeds"].as<asset>().get_amount() );
 
    BOOST_REQUIRE_EQUAL( success(),      updaterex( bob ) );
    BOOST_REQUIRE_EQUAL( 0,              get_rex_vote_stake( bob ).get_amount() );
@@ -3858,6 +3861,13 @@ BOOST_FIXTURE_TEST_CASE( buy_sell_claim_rex, eosio_system_tester ) try {
    {
       auto trace = base_tester::push_action( N(eosio), N(buyrex), frank,
                                              mvo()("from", frank)("amount", core_sym::from_string("0.0001")) );
+      auto output = get_rexorder_result( trace );
+      BOOST_REQUIRE_EQUAL( output.size(), 0 );
+      BOOST_REQUIRE_EQUAL( true,           get_rex_order(carol)["is_open"].as<bool>() );
+   }
+
+   {
+      auto trace = base_tester::push_action( N(eosio), N(rexexec), frank, mvo()("user", frank)("max", 4) );
       auto output = get_rexorder_result( trace );
       BOOST_REQUIRE_EQUAL( output.size(), 0 );
    }
@@ -3873,7 +3883,7 @@ BOOST_FIXTURE_TEST_CASE( rex_loans, eosio_system_tester ) try {
    account_name alice = accounts[0], bob = accounts[1], carol = accounts[2], emily = accounts[3], frank = accounts[4];
    setup_rex_accounts( accounts, init_balance  );
 
-   BOOST_REQUIRE_EQUAL( success(), buyrex( alice, core_sym::from_string("500.0000") ) );
+   BOOST_REQUIRE_EQUAL( success(), buyrex( alice, core_sym::from_string("2500.0000") ) );
 
    auto rex_pool            = get_rex_pool();
    const asset payment      = core_sym::from_string("30.0000");
@@ -3994,12 +4004,12 @@ BOOST_FIXTURE_TEST_CASE( rex_loans, eosio_system_tester ) try {
 BOOST_FIXTURE_TEST_CASE( rex_loan_checks, eosio_system_tester ) try {
 
    const int64_t ratio        = 10000;
-   const asset   init_balance = core_sym::from_string("10000.0000");
+   const asset   init_balance = core_sym::from_string("20000.0000");
    const std::vector<account_name> accounts = { N(aliceaccount), N(bobbyaccount) };
    account_name alice = accounts[0], bob = accounts[1];
    setup_rex_accounts( accounts, init_balance );
 
-   const asset payment1 = core_sym::from_string("200.0000");
+   const asset payment1 = core_sym::from_string("1000.0000");
    const asset payment2 = core_sym::from_string("2.0000");
    const asset fee      = core_sym::from_string("1.0000");
    BOOST_REQUIRE_EQUAL( success(), buyrex( alice, payment1 ) );
@@ -4545,7 +4555,7 @@ BOOST_FIXTURE_TEST_CASE( update_rex_vote, eosio_system_tester, * boost::unit_tes
    const int64_t init_stake_amount = get_voter_info( alice )["staked"].as<int64_t>();
    const asset init_stake( init_stake_amount, symbol{CORE_SYM} );
 
-   const asset purchase = core_sym::from_string("500.0000");
+   const asset purchase = core_sym::from_string("2500.0000");
    BOOST_REQUIRE_EQUAL( success(),                              buyrex( alice, purchase ) );
    BOOST_REQUIRE_EQUAL( purchase,                               get_rex_pool()["total_lendable"].as<asset>() );
    BOOST_REQUIRE_EQUAL( purchase,                               get_rex_vote_stake(alice) );
@@ -4622,15 +4632,15 @@ BOOST_FIXTURE_TEST_CASE( deposit_rex_fund, eosio_system_tester ) try {
 
 BOOST_FIXTURE_TEST_CASE( rex_lower_bound, eosio_system_tester ) try {
 
-   const asset init_balance = core_sym::from_string("500.0000");
+   const asset init_balance = core_sym::from_string("2500.0000");
    const std::vector<account_name> accounts = { N(aliceaccount), N(bobbyaccount) };
    account_name alice = accounts[0], bob = accounts[1];
    setup_rex_accounts( accounts, init_balance );
    const symbol rex_sym( SY(4, REX) );
 
-   const asset payment = core_sym::from_string("500.0000");
+   const asset payment = core_sym::from_string("2500.0000");
    BOOST_REQUIRE_EQUAL( success(), buyrex( alice, payment ) );
-   const asset fee = core_sym::from_string("5.0000");
+   const asset fee = core_sym::from_string("25.0000");
    BOOST_REQUIRE_EQUAL( success(), rentcpu( bob, bob, fee ) );
 
    const auto rex_pool = get_rex_pool();

--- a/tests/eosio.system_tests.cpp
+++ b/tests/eosio.system_tests.cpp
@@ -3390,6 +3390,42 @@ BOOST_FIXTURE_TEST_CASE( ram_gift, eosio_system_tester ) try {
 } FC_LOG_AND_RETHROW()
 
 
+BOOST_FIXTURE_TEST_CASE( rex_auth, eosio_system_tester ) try {
+
+   const std::vector<account_name> accounts = { N(aliceaccount), N(bobbyaccount) };
+   const account_name alice = accounts[0], bob = accounts[1];
+   const asset init_balance = core_sym::from_string("1000.0000");
+   const asset one_eos      = core_sym::from_string("1.0000");
+   const asset one_rex      = asset::from_string("1.0000 REX");
+   setup_rex_accounts( accounts, init_balance );
+
+   const std::string error_msg("missing authority of aliceaccount");
+   BOOST_REQUIRE_EQUAL( error(error_msg), push_action( bob, N(deposit), mvo()("owner", alice)("amount", one_eos) ) );
+   BOOST_REQUIRE_EQUAL( error(error_msg), push_action( bob, N(withdraw), mvo()("owner", alice)("amount", one_eos) ) );
+   BOOST_REQUIRE_EQUAL( error(error_msg), push_action( bob, N(buyrex), mvo()("from", alice)("amount", one_eos) ) );
+   BOOST_REQUIRE_EQUAL( error(error_msg),
+                        push_action( bob, N(unstaketorex), mvo()("owner", alice)("receiver", alice)("from_net", one_eos)("from_cpu", one_eos) ) );
+   BOOST_REQUIRE_EQUAL( error(error_msg), push_action( bob, N(sellrex), mvo()("from", alice)("rex", one_rex) ) );
+   BOOST_REQUIRE_EQUAL( error(error_msg), push_action( bob, N(cnclrexorder), mvo()("owner", alice) ) );
+   BOOST_REQUIRE_EQUAL( error(error_msg),
+                        push_action( bob, N(rentcpu), mvo()("from", alice)("receiver", alice)("loan_payment", one_eos)("loan_fund", one_eos) ) );
+   BOOST_REQUIRE_EQUAL( error(error_msg),
+                        push_action( bob, N(rentnet), mvo()("from", alice)("receiver", alice)("loan_payment", one_eos)("loan_fund", one_eos) ) );
+   BOOST_REQUIRE_EQUAL( error(error_msg), push_action( bob, N(fundcpuloan), mvo()("from", alice)("loan_num", 1)("payment", one_eos) ) );
+   BOOST_REQUIRE_EQUAL( error(error_msg), push_action( bob, N(fundnetloan), mvo()("from", alice)("loan_num", 1)("payment", one_eos) ) );
+   BOOST_REQUIRE_EQUAL( error(error_msg), push_action( bob, N(defcpuloan), mvo()("from", alice)("loan_num", 1)("amount", one_eos) ) );
+   BOOST_REQUIRE_EQUAL( error(error_msg), push_action( bob, N(defnetloan), mvo()("from", alice)("loan_num", 1)("amount", one_eos) ) );
+   BOOST_REQUIRE_EQUAL( error(error_msg), push_action( bob, N(updaterex), mvo()("owner", alice) ) );
+   BOOST_REQUIRE_EQUAL( error(error_msg), push_action( bob, N(rexexec), mvo()("user", alice)("max", 1) ) );
+   BOOST_REQUIRE_EQUAL( error(error_msg), push_action( bob, N(consolidate), mvo()("owner", alice) ) );
+   BOOST_REQUIRE_EQUAL( error(error_msg), push_action( bob, N(mvtosavings), mvo()("owner", alice)("rex", one_rex) ) );
+   BOOST_REQUIRE_EQUAL( error(error_msg), push_action( bob, N(mvfrsavings), mvo()("owner", alice)("rex", one_rex) ) );
+   BOOST_REQUIRE_EQUAL( error(error_msg), push_action( bob, N(closerex), mvo()("owner", alice) ) );
+
+   BOOST_REQUIRE_EQUAL( error("missing authority of eosio"), push_action( alice, N(setrex), mvo()("balance", one_eos) ) );
+
+} FC_LOG_AND_RETHROW()
+
 BOOST_FIXTURE_TEST_CASE( buy_sell_rex, eosio_system_tester ) try {
 
    const int64_t ratio        = 10000;

--- a/tests/eosio.system_tests.cpp
+++ b/tests/eosio.system_tests.cpp
@@ -3393,7 +3393,7 @@ BOOST_FIXTURE_TEST_CASE( ram_gift, eosio_system_tester ) try {
 BOOST_FIXTURE_TEST_CASE( buy_sell_rex, eosio_system_tester ) try {
 
    const int64_t ratio        = 10000;
-   const asset   init_rent    = core_sym::from_string("20000.0000");
+   const asset   init_rent    = core_sym::from_string("200.0000");
    const asset   init_balance = core_sym::from_string("1000.0000");
    const std::vector<account_name> accounts = { N(aliceaccount), N(bobbyaccount), N(carolaccount), N(emilyaccount), N(frankaccount) };
    account_name alice = accounts[0], bob = accounts[1], carol = accounts[2], emily = accounts[3], frank = accounts[4];
@@ -3460,7 +3460,7 @@ BOOST_FIXTURE_TEST_CASE( buy_sell_small_rex, eosio_system_tester ) try {
    account_name alice = accounts[0], bob = accounts[1], carol = accounts[2];
    setup_rex_accounts( accounts, init_balance );
 
-   const asset payment = core_sym::from_string("10.0000");
+   const asset payment = core_sym::from_string("500.0000");
    BOOST_REQUIRE_EQUAL( ratio * payment.get_amount(),               get_buyrex_result( alice, payment ).get_amount() );
 
    produce_blocks(2);
@@ -3477,7 +3477,7 @@ BOOST_FIXTURE_TEST_CASE( buy_sell_small_rex, eosio_system_tester ) try {
    BOOST_REQUIRE_EQUAL( get_rex_vote_stake( alice ),                init_rex_stake - core_sym::from_string("0.0006") );
 
    BOOST_REQUIRE_EQUAL( success(),                                  rentcpu( carol, bob, core_sym::from_string("10.0000") ) );
-   BOOST_REQUIRE_EQUAL( success(),                                  sellrex( alice, asset::from_string("0.9000 REX") ) );
+   BOOST_REQUIRE_EQUAL( success(),                                  sellrex( alice, asset::from_string("1.0000 REX") ) );
    BOOST_REQUIRE_EQUAL( wasm_assert_msg("proceeds are negligible"), sellrex( alice, asset::from_string("0.4000 REX") ) );
 
 } FC_LOG_AND_RETHROW()
@@ -3615,8 +3615,8 @@ BOOST_FIXTURE_TEST_CASE( buy_rent_rex, eosio_system_tester ) try {
    // bob tries to rent rex
    BOOST_REQUIRE_EQUAL( wasm_assert_msg("rex system not initialized yet"), rentcpu( bob, carol, core_sym::from_string("5.0000") ) );
    // alice lends rex
-   BOOST_REQUIRE_EQUAL( success(), buyrex( alice, core_sym::from_string("65.0000") ) );
-   BOOST_REQUIRE_EQUAL( init_balance - core_sym::from_string("65.0000"), get_rex_fund(alice) );
+   BOOST_REQUIRE_EQUAL( success(), buyrex( alice, core_sym::from_string("265.0000") ) );
+   BOOST_REQUIRE_EQUAL( init_balance - core_sym::from_string("265.0000"), get_rex_fund(alice) );
    auto rex_pool = get_rex_pool();
    const asset   init_tot_unlent   = rex_pool["total_unlent"].as<asset>();
    const asset   init_tot_lendable = rex_pool["total_lendable"].as<asset>();
@@ -3672,9 +3672,9 @@ BOOST_FIXTURE_TEST_CASE( buy_rent_rex, eosio_system_tester ) try {
    {
       const int64_t init_net_limit = get_net_limit( emily );
       BOOST_REQUIRE_EQUAL( 0,         get_rex_balance(alice).get_amount() );
-      BOOST_REQUIRE_EQUAL( success(), buyrex( alice, core_sym::from_string("110.0000") ) );
+      BOOST_REQUIRE_EQUAL( success(), buyrex( alice, core_sym::from_string("210.0000") ) );
       rex_pool = get_rex_pool();
-      const asset fee = core_sym::from_string("132.4560");
+      const asset fee = core_sym::from_string("2.4560");
       int64_t expected_net = bancor_convert( rex_pool["total_rent"].as<asset>().get_amount(),
                                              rex_pool["total_unlent"].as<asset>().get_amount(),
                                              fee.get_amount() );
@@ -3699,7 +3699,7 @@ BOOST_FIXTURE_TEST_CASE( buy_sell_sell_rex, eosio_system_tester ) try {
    const int64_t init_net_limit = get_net_limit( alice );
 
    // alice lends rex
-   const asset payment = core_sym::from_string("65.0000");
+   const asset payment = core_sym::from_string("650.0000");
    BOOST_REQUIRE_EQUAL( success(),              buyrex( alice, payment ) );
    BOOST_REQUIRE_EQUAL( success(),              buyrex( bob, core_sym::from_string("0.0005") ) );
    BOOST_REQUIRE_EQUAL( init_balance - payment, get_rex_fund(alice) );
@@ -3772,7 +3772,7 @@ BOOST_FIXTURE_TEST_CASE( buy_sell_claim_rex, eosio_system_tester ) try {
    auto init_bob_rex   = get_rex_balance(bob);
    auto init_carol_rex = get_rex_balance(carol);
 
-   BOOST_REQUIRE_EQUAL(core_sym::from_string("20000.0000"), get_rex_pool()["total_rent"].as<asset>() );
+   BOOST_REQUIRE_EQUAL(core_sym::from_string("200.0000"), get_rex_pool()["total_rent"].as<asset>() );
 
    const asset rent_payment = core_sym::from_string("1100000.0000");
    BOOST_REQUIRE_EQUAL( success(), rentcpu( frank, frank, rent_payment, rent_payment ) );
@@ -3819,8 +3819,8 @@ BOOST_FIXTURE_TEST_CASE( buy_sell_claim_rex, eosio_system_tester ) try {
    BOOST_REQUIRE_EQUAL( true,           get_rex_order(carol)["is_open"].as<bool>() );
 
    // wait for 2 more hours, by now frank's loan has expired and there is enough balance in
-   // total_unlent to close some sellrex orders. only two are processed, bob's and carol's
-   // alices's order is still open
+   // total_unlent to close some sellrex orders. only two are processed, bob's and carol's.
+   // alices's order is still open.
    // an action is needed to trigger queue processing
    produce_block( fc::hours(2) );
    BOOST_REQUIRE_EQUAL( wasm_assert_msg("rex loans are currently not available"),
@@ -3987,6 +3987,37 @@ BOOST_FIXTURE_TEST_CASE( rex_loans, eosio_system_tester ) try {
    cur_frank_balance = get_rex_fund( frank );
    BOOST_REQUIRE_EQUAL( fund - payment,     cur_frank_balance - old_frank_balance );
    BOOST_REQUIRE      ( old_frank_balance < cur_frank_balance );
+
+} FC_LOG_AND_RETHROW()
+
+
+BOOST_FIXTURE_TEST_CASE( rex_loan_checks, eosio_system_tester ) try {
+
+   const int64_t ratio        = 10000;
+   const asset   init_balance = core_sym::from_string("10000.0000");
+   const std::vector<account_name> accounts = { N(aliceaccount), N(bobbyaccount) };
+   account_name alice = accounts[0], bob = accounts[1];
+   setup_rex_accounts( accounts, init_balance );
+
+   const asset payment1 = core_sym::from_string("200.0000");
+   const asset payment2 = core_sym::from_string("2.0000");
+   const asset fee      = core_sym::from_string("1.0000");
+   BOOST_REQUIRE_EQUAL( success(), buyrex( alice, payment1 ) );
+   BOOST_REQUIRE_EQUAL( wasm_assert_msg("loan price does not favor renting"),
+                        rentcpu( bob, bob, fee ) );
+   BOOST_REQUIRE_EQUAL( success(),            buyrex( alice, payment2 ) );
+   BOOST_REQUIRE_EQUAL( success(),            rentcpu( bob, bob, fee, fee + fee + fee ) );
+   BOOST_REQUIRE_EQUAL( true,                 !get_cpu_loan(1).is_null() );
+   BOOST_REQUIRE_EQUAL( 3 * fee.get_amount(), get_last_cpu_loan()["balance"].as<asset>().get_amount() );
+   
+   produce_block( fc::days(31) );
+   BOOST_REQUIRE_EQUAL( success(),            rexexec( alice, 3) );
+   BOOST_REQUIRE_EQUAL( 2 * fee.get_amount(), get_last_cpu_loan()["balance"].as<asset>().get_amount() );
+
+   BOOST_REQUIRE_EQUAL( success(),            sellrex( alice, asset::from_string("1000000.0000 REX") ) );
+   produce_block( fc::days(31) );
+   BOOST_REQUIRE_EQUAL( success(),            rexexec( alice, 3) );
+   BOOST_REQUIRE_EQUAL( true,                 get_cpu_loan(1).is_null() );
 
 } FC_LOG_AND_RETHROW()
 
@@ -4174,7 +4205,7 @@ BOOST_FIXTURE_TEST_CASE( rex_maturity, eosio_system_tester ) try {
       auto rex_balance = get_rex_balance_obj( bob );
       BOOST_REQUIRE_EQUAL( tot_rex,                  rex_balance["rex_balance"].as<asset>() );
       BOOST_REQUIRE_EQUAL( rex_bucket1.get_amount(), rex_balance["matured_rex"].as<int64_t>() );
-      BOOST_REQUIRE_EQUAL( success(),                rentcpu( alice, alice, core_sym::from_string("800000.0000") ) );
+      BOOST_REQUIRE_EQUAL( success(),                rentcpu( alice, alice, core_sym::from_string("8000.0000") ) );
       BOOST_REQUIRE_EQUAL( success(),                sellrex( bob, asset( rex_bucket1.get_amount() - 20, rex_sym ) ) );
       rex_balance = get_rex_balance_obj( bob );
       BOOST_REQUIRE_EQUAL( rex_bucket1.get_amount(), get_rex_order( bob )["rex_requested"].as<asset>().get_amount() + 20 );
@@ -4418,13 +4449,15 @@ BOOST_FIXTURE_TEST_CASE( update_rex, eosio_system_tester, * boost::unit_test::to
 
    const int64_t init_stake = get_voter_info( alice )["staked"].as<int64_t>();
 
-   BOOST_REQUIRE_EQUAL( success(),                              buyrex( alice, core_sym::from_string("250.0000") ) );
-   BOOST_REQUIRE_EQUAL( core_sym::from_string("250.0000"),      get_rex_vote_stake(alice) );
+   const asset payment = core_sym::from_string("2500.0000");
+   BOOST_REQUIRE_EQUAL( success(),                              buyrex( alice, payment ) );
+   BOOST_REQUIRE_EQUAL( payment,                                get_rex_vote_stake(alice) );
    BOOST_REQUIRE_EQUAL( get_rex_vote_stake(alice).get_amount(), get_voter_info(alice)["staked"].as<int64_t>() - init_stake );
 
-   BOOST_REQUIRE_EQUAL( success(),                              rentcpu( frank, bob, core_sym::from_string("50.0000") ) );
+   const asset fee = core_sym::from_string("50.0000");
+   BOOST_REQUIRE_EQUAL( success(),                              rentcpu( frank, bob, fee ) );
    BOOST_REQUIRE_EQUAL( success(),                              updaterex( alice ) );
-   BOOST_REQUIRE_EQUAL( core_sym::from_string("300.0000"),      get_rex_vote_stake(alice) );
+   BOOST_REQUIRE_EQUAL( payment + fee,                          get_rex_vote_stake(alice) );
    BOOST_REQUIRE_EQUAL( get_rex_vote_stake(alice).get_amount(), get_voter_info( alice )["staked"].as<int64_t>() - init_stake );
 
    // create accounts {defproducera, defproducerb, ..., defproducerz} and register as producers
@@ -4512,8 +4545,8 @@ BOOST_FIXTURE_TEST_CASE( update_rex_vote, eosio_system_tester, * boost::unit_tes
    const int64_t init_stake_amount = get_voter_info( alice )["staked"].as<int64_t>();
    const asset init_stake( init_stake_amount, symbol{CORE_SYM} );
 
-   const asset purchase = core_sym::from_string("250.0000");
-   BOOST_REQUIRE_EQUAL( success(),                              buyrex( alice, core_sym::from_string("250.0000") ) );
+   const asset purchase = core_sym::from_string("500.0000");
+   BOOST_REQUIRE_EQUAL( success(),                              buyrex( alice, purchase ) );
    BOOST_REQUIRE_EQUAL( purchase,                               get_rex_pool()["total_lendable"].as<asset>() );
    BOOST_REQUIRE_EQUAL( purchase,                               get_rex_vote_stake(alice) );
    BOOST_REQUIRE_EQUAL( get_rex_vote_stake(alice).get_amount(), get_voter_info(alice)["staked"].as<int64_t>() - init_stake_amount );
@@ -4589,15 +4622,16 @@ BOOST_FIXTURE_TEST_CASE( deposit_rex_fund, eosio_system_tester ) try {
 
 BOOST_FIXTURE_TEST_CASE( rex_lower_bound, eosio_system_tester ) try {
 
-   const asset init_balance = core_sym::from_string("200.0000");
+   const asset init_balance = core_sym::from_string("500.0000");
    const std::vector<account_name> accounts = { N(aliceaccount), N(bobbyaccount) };
    account_name alice = accounts[0], bob = accounts[1];
    setup_rex_accounts( accounts, init_balance );
    const symbol rex_sym( SY(4, REX) );
 
-   const asset payment = core_sym::from_string("50.0000");
+   const asset payment = core_sym::from_string("500.0000");
    BOOST_REQUIRE_EQUAL( success(), buyrex( alice, payment ) );
-   BOOST_REQUIRE_EQUAL( success(), rentcpu( bob, bob, payment ) );
+   const asset fee = core_sym::from_string("5.0000");
+   BOOST_REQUIRE_EQUAL( success(), rentcpu( bob, bob, fee ) );
 
    const auto rex_pool = get_rex_pool();
    const int64_t tot_rex      = rex_pool["total_rex"].as<asset>().get_amount();
@@ -4605,11 +4639,11 @@ BOOST_FIXTURE_TEST_CASE( rex_lower_bound, eosio_system_tester ) try {
    const int64_t tot_lent     = rex_pool["total_lent"].as<asset>().get_amount();
    const int64_t tot_lendable = rex_pool["total_lendable"].as<asset>().get_amount();
    double rex_per_eos = double(tot_rex) / double(tot_lendable);
-   int64_t sell_amount = rex_per_eos * ( tot_unlent - 0.99 * tot_lent );
+   int64_t sell_amount = rex_per_eos * ( tot_unlent - 0.19 * tot_lent );
    produce_block( fc::days(5) );
    BOOST_REQUIRE_EQUAL( success(), sellrex( alice, asset( sell_amount, rex_sym ) ) );
    BOOST_REQUIRE_EQUAL( success(), cancelrexorder( alice ) );
-   sell_amount = rex_per_eos * ( tot_unlent - tot_lent );
+   sell_amount = rex_per_eos * ( tot_unlent - 0.2 * tot_lent );
    BOOST_REQUIRE_EQUAL( success(), sellrex( alice, asset( sell_amount, rex_sym ) ) );
    BOOST_REQUIRE_EQUAL( wasm_assert_msg("no sellrex order is scheduled"),
                         cancelrexorder( alice ) );
@@ -4619,24 +4653,24 @@ BOOST_FIXTURE_TEST_CASE( rex_lower_bound, eosio_system_tester ) try {
 
 BOOST_FIXTURE_TEST_CASE( close_rex, eosio_system_tester ) try {
 
-   const asset init_balance = core_sym::from_string("200.0000");
-   const std::vector<account_name> accounts = { N(aliceaccount), N(bobbyaccount), N(carolaccount), N(emilyaccount), N(frankaccount) };
-   account_name alice = accounts[0], bob = accounts[1], carol = accounts[2], emily = accounts[3], frank = accounts[4];
+   const asset init_balance = core_sym::from_string("2000.0000");
+   const std::vector<account_name> accounts = { N(aliceaccount), N(bobbyaccount), N(carolaccount), N(emilyaccount) };
+   account_name alice = accounts[0], bob = accounts[1], carol = accounts[2], emily = accounts[3];
    setup_rex_accounts( accounts, init_balance );
 
-   BOOST_REQUIRE_EQUAL( false,             get_rex_fund_obj( alice ).is_null() );
+   BOOST_REQUIRE_EQUAL( true,              !get_rex_fund_obj( alice ).is_null() );
    BOOST_REQUIRE_EQUAL( init_balance,      get_rex_fund( alice ) );
    BOOST_REQUIRE_EQUAL( success(),         closerex( alice ) );
    BOOST_REQUIRE_EQUAL( success(),         withdraw( alice, init_balance ) );
    BOOST_REQUIRE_EQUAL( success(),         closerex( alice ) );
-   BOOST_REQUIRE_EQUAL( true,              get_rex_fund_obj( alice).is_null() );
+   BOOST_REQUIRE_EQUAL( true,              get_rex_fund_obj( alice ).is_null() );
    BOOST_REQUIRE_EQUAL( success(),         deposit( alice, init_balance ) );
-   BOOST_REQUIRE_EQUAL( false,             get_rex_fund_obj( alice).is_null() );
+   BOOST_REQUIRE_EQUAL( true,              !get_rex_fund_obj( alice ).is_null() );
 
    BOOST_REQUIRE_EQUAL( true,              get_rex_balance_obj( bob ).is_null() );
    BOOST_REQUIRE_EQUAL( success(),         buyrex( bob, init_balance ) );
-   BOOST_REQUIRE_EQUAL( false,             get_rex_balance_obj( bob ).is_null() );
-   BOOST_REQUIRE_EQUAL( false,             get_rex_fund_obj( bob ).is_null() );
+   BOOST_REQUIRE_EQUAL( true,              !get_rex_balance_obj( bob ).is_null() );
+   BOOST_REQUIRE_EQUAL( true,              !get_rex_fund_obj( bob ).is_null() );
    BOOST_REQUIRE_EQUAL( 0,                 get_rex_fund( bob ).get_amount() );
    BOOST_REQUIRE_EQUAL( closerex( bob ),   wasm_assert_msg("account has remaining REX balance, must sell first") );
    produce_block( fc::days(5) );
@@ -4650,11 +4684,16 @@ BOOST_FIXTURE_TEST_CASE( close_rex, eosio_system_tester ) try {
    BOOST_REQUIRE_EQUAL( success(),         deposit( bob, init_balance ) );
    BOOST_REQUIRE_EQUAL( success(),         buyrex( bob, init_balance ) );
 
-   BOOST_REQUIRE_EQUAL( success(),         rentcpu( carol, emily, init_balance ) );
+   const asset fee = core_sym::from_string("1.0000");
+   BOOST_REQUIRE_EQUAL( success(),         rentcpu( carol, emily, fee ) );
+   BOOST_REQUIRE_EQUAL( wasm_assert_msg("insufficient funds"),
+                        withdraw( carol, init_balance ) );
+   BOOST_REQUIRE_EQUAL( success(),         withdraw( carol, init_balance - fee ) );
 
    produce_block( fc::days(20) );
 
    BOOST_REQUIRE_EQUAL( success(),         closerex( carol ) );
+   BOOST_REQUIRE_EQUAL( true,              !get_rex_fund_obj( carol ).is_null() );
 
    produce_block( fc::days(10) );
 
@@ -4662,8 +4701,10 @@ BOOST_FIXTURE_TEST_CASE( close_rex, eosio_system_tester ) try {
    BOOST_REQUIRE_EQUAL( true,              get_rex_balance_obj( carol ).is_null() );
    BOOST_REQUIRE_EQUAL( true,              get_rex_fund_obj( carol ).is_null() );
 
-   BOOST_REQUIRE_EQUAL( success(),         rentnet( emily, emily, init_balance ) );
+   BOOST_REQUIRE_EQUAL( success(),         rentnet( emily, emily, fee ) );
+   BOOST_REQUIRE_EQUAL( true,              !get_rex_fund_obj( emily ).is_null() );
    BOOST_REQUIRE_EQUAL( success(),         closerex( emily ) );
+   BOOST_REQUIRE_EQUAL( true,              !get_rex_fund_obj( emily ).is_null() );
 
    BOOST_REQUIRE_EQUAL( success(),         sellrex( bob, get_rex_balance( bob ) ) );
    BOOST_REQUIRE_EQUAL( closerex( bob ),   wasm_assert_msg("account has remaining REX balance, must sell first") );
@@ -4680,7 +4721,7 @@ BOOST_FIXTURE_TEST_CASE( close_rex, eosio_system_tester ) try {
    BOOST_REQUIRE_EQUAL( 0,                 get_rex_pool()["total_rex"].as<asset>().get_amount() );
    BOOST_REQUIRE_EQUAL( 0,                 get_rex_pool()["total_lendable"].as<asset>().get_amount() );
    BOOST_REQUIRE_EQUAL( wasm_assert_msg("rex loans are currently not available"),
-                        rentcpu( frank, frank, core_sym::from_string("1.0000") ) );
+                        rentcpu( emily, emily, core_sym::from_string("1.0000") ) );
 
 } FC_LOG_AND_RETHROW()
 

--- a/tests/eosio.system_tests.cpp
+++ b/tests/eosio.system_tests.cpp
@@ -3393,13 +3393,15 @@ BOOST_FIXTURE_TEST_CASE( ram_gift, eosio_system_tester ) try {
 BOOST_FIXTURE_TEST_CASE( buy_sell_rex, eosio_system_tester ) try {
 
    const int64_t ratio        = 10000;
-   const asset   init_rent    = core_sym::from_string("1000.0000");
+   const asset   init_rent    = core_sym::from_string("20000.0000");
    const asset   init_balance = core_sym::from_string("1000.0000");
    const std::vector<account_name> accounts = { N(aliceaccount), N(bobbyaccount), N(carolaccount), N(emilyaccount), N(frankaccount) };
    account_name alice = accounts[0], bob = accounts[1], carol = accounts[2], emily = accounts[3], frank = accounts[4];
    setup_rex_accounts( accounts, init_balance );
 
-   BOOST_REQUIRE_EQUAL( asset::from_string("25000.0000 REX"), get_buyrex_result( alice, core_sym::from_string("2.5000") ) );
+   const asset one_unit = core_sym::from_string("0.0001");
+   BOOST_REQUIRE_EQUAL( wasm_assert_msg("insufficient funds"), buyrex( alice, init_balance + one_unit ) );
+   BOOST_REQUIRE_EQUAL( asset::from_string("25000.0000 REX"),  get_buyrex_result( alice, core_sym::from_string("2.5000") ) );
    produce_blocks(2);
    produce_block(fc::days(5));
    BOOST_REQUIRE_EQUAL( core_sym::from_string("2.5000"),     get_sellrex_result( alice, asset::from_string("25000.0000 REX") ) );
@@ -3454,13 +3456,12 @@ BOOST_FIXTURE_TEST_CASE( buy_sell_rex, eosio_system_tester ) try {
 BOOST_FIXTURE_TEST_CASE( buy_sell_small_rex, eosio_system_tester ) try {
 
    const int64_t ratio        = 10000;
-   const asset   init_rent    = core_sym::from_string("100000.0000");
-   const asset   init_balance = core_sym::from_string("5000.0000");
+   const asset   init_balance = core_sym::from_string("50000.0000");
    const std::vector<account_name> accounts = { N(aliceaccount), N(bobbyaccount), N(carolaccount) };
    account_name alice = accounts[0], bob = accounts[1], carol = accounts[2];
    setup_rex_accounts( accounts, init_balance );
 
-   const asset payment = core_sym::from_string("2000.0000");
+   const asset payment = core_sym::from_string("40000.0000");
    BOOST_REQUIRE_EQUAL( ratio * payment.get_amount(),               get_buyrex_result( alice, payment ).get_amount() );
 
    produce_blocks(2);
@@ -3602,7 +3603,7 @@ BOOST_FIXTURE_TEST_CASE( unstake_buy_rex, eosio_system_tester, * boost::unit_tes
 BOOST_FIXTURE_TEST_CASE( buy_rent_rex, eosio_system_tester ) try {
 
    const int64_t ratio        = 10000;
-   const asset   init_balance = core_sym::from_string("10000.0000");
+   const asset   init_balance = core_sym::from_string("60000.0000");
    const asset   init_net     = core_sym::from_string("70.0000");
    const asset   init_cpu     = core_sym::from_string("90.0000");
    const std::vector<account_name> accounts = { N(aliceaccount), N(bobbyaccount), N(carolaccount), N(emilyaccount), N(frankaccount) };
@@ -3615,8 +3616,8 @@ BOOST_FIXTURE_TEST_CASE( buy_rent_rex, eosio_system_tester ) try {
    // bob tries to rent rex
    BOOST_REQUIRE_EQUAL( wasm_assert_msg("rex system not initialized yet"), rentcpu( bob, carol, core_sym::from_string("5.0000") ) );
    // alice lends rex
-   BOOST_REQUIRE_EQUAL( success(), buyrex( alice, core_sym::from_string("5265.0000") ) );
-   BOOST_REQUIRE_EQUAL( init_balance - core_sym::from_string("5265.0000"), get_rex_fund(alice) );
+   BOOST_REQUIRE_EQUAL( success(), buyrex( alice, core_sym::from_string("50265.0000") ) );
+   BOOST_REQUIRE_EQUAL( init_balance - core_sym::from_string("50265.0000"), get_rex_fund(alice) );
    auto rex_pool = get_rex_pool();
    const asset   init_tot_unlent   = rex_pool["total_unlent"].as<asset>();
    const asset   init_tot_lendable = rex_pool["total_lendable"].as<asset>();
@@ -3672,7 +3673,7 @@ BOOST_FIXTURE_TEST_CASE( buy_rent_rex, eosio_system_tester ) try {
    {
       const int64_t init_net_limit = get_net_limit( emily );
       BOOST_REQUIRE_EQUAL( 0,         get_rex_balance(alice).get_amount() );
-      BOOST_REQUIRE_EQUAL( success(), buyrex( alice, core_sym::from_string("1050.0000") ) );
+      BOOST_REQUIRE_EQUAL( success(), buyrex( alice, core_sym::from_string("20050.0000") ) );
       rex_pool = get_rex_pool();
       const asset fee = core_sym::from_string("0.4560");
       int64_t expected_net = bancor_convert( rex_pool["total_rent"].as<asset>().get_amount(),
@@ -3688,7 +3689,7 @@ BOOST_FIXTURE_TEST_CASE( buy_rent_rex, eosio_system_tester ) try {
 BOOST_FIXTURE_TEST_CASE( buy_sell_sell_rex, eosio_system_tester ) try {
 
    const int64_t ratio        = 10000;
-   const asset   init_balance = core_sym::from_string("10000.0000");
+   const asset   init_balance = core_sym::from_string("40000.0000");
    const asset   init_net     = core_sym::from_string("70.0000");
    const asset   init_cpu     = core_sym::from_string("90.0000");
    const std::vector<account_name> accounts = { N(aliceaccount), N(bobbyaccount), N(carolaccount) };
@@ -3699,7 +3700,7 @@ BOOST_FIXTURE_TEST_CASE( buy_sell_sell_rex, eosio_system_tester ) try {
    const int64_t init_net_limit = get_net_limit( alice );
 
    // alice lends rex
-   const asset payment = core_sym::from_string("3250.0000");
+   const asset payment = core_sym::from_string("30250.0000");
    BOOST_REQUIRE_EQUAL( success(),              buyrex( alice, payment ) );
    BOOST_REQUIRE_EQUAL( success(),              buyrex( bob, core_sym::from_string("0.0005") ) );
    BOOST_REQUIRE_EQUAL( init_balance - payment, get_rex_fund(alice) );
@@ -3754,9 +3755,9 @@ BOOST_FIXTURE_TEST_CASE( buy_sell_claim_rex, eosio_system_tester ) try {
    account_name alice = accounts[0], bob = accounts[1], carol = accounts[2], emily = accounts[3], frank = accounts[4];
    setup_rex_accounts( accounts, init_balance );
 
-   const auto purchase1  = core_sym::from_string("2500.0000");
-   const auto purchase2  = core_sym::from_string("11775.0000");
-   const auto purchase3  = core_sym::from_string("11725.0000");
+   const auto purchase1  = core_sym::from_string("50000.0000");
+   const auto purchase2  = core_sym::from_string("235500.0000");
+   const auto purchase3  = core_sym::from_string("234500.0000");
    const auto init_stake = get_voter_info(alice)["staked"].as<int64_t>();
    BOOST_REQUIRE_EQUAL( success(), buyrex( alice, purchase1) );
    BOOST_REQUIRE_EQUAL( success(), buyrex( bob,   purchase2) );
@@ -3772,19 +3773,20 @@ BOOST_FIXTURE_TEST_CASE( buy_sell_claim_rex, eosio_system_tester ) try {
    auto init_bob_rex   = get_rex_balance(bob);
    auto init_carol_rex = get_rex_balance(carol);
 
-   BOOST_REQUIRE_EQUAL( core_sym::from_string("1000.0000"), get_rex_pool()["total_rent"].as<asset>() );
+   BOOST_REQUIRE_EQUAL( core_sym::from_string("20000.0000"), get_rex_pool()["total_rent"].as<asset>() );
 
    for (uint8_t i = 0; i < 4; ++i) {
-      BOOST_REQUIRE_EQUAL( success(), rentcpu( emily, emily, core_sym::from_string("1000.0000") ) );
+      BOOST_REQUIRE_EQUAL( success(), rentcpu( emily, emily, core_sym::from_string("20000.0000") ) );
    }
 
-   const asset rent_payment = core_sym::from_string("2000.0000");
+   const asset rent_payment = core_sym::from_string("40000.0000");
 
    BOOST_REQUIRE_EQUAL( success(), rentcpu( frank, frank, rent_payment, rent_payment ) );
 
    const auto    init_rex_pool        = get_rex_pool();
-   const int64_t init_alice_rex_stake = ( eosio::chain::uint128_t(init_alice_rex.get_amount()) * init_rex_pool["total_lendable"].as<asset>().get_amount() )
-                                         / init_rex_pool["total_rex"].as<asset>().get_amount();
+   const int64_t total_lendable       = init_rex_pool["total_lendable"].as<asset>().get_amount();
+   const int64_t total_rex            = init_rex_pool["total_rex"].as<asset>().get_amount();
+   const int64_t init_alice_rex_stake = ( eosio::chain::uint128_t(init_alice_rex.get_amount()) * total_lendable ) / total_rex;
 
    produce_block( fc::days(5) );
 
@@ -3877,7 +3879,7 @@ BOOST_FIXTURE_TEST_CASE( buy_sell_claim_rex, eosio_system_tester ) try {
       BOOST_REQUIRE_EQUAL( wasm_assert_msg("rex loans are currently not available"),
                            rentcpu( frank, frank, core_sym::from_string("1.0000") ) );
 
-      BOOST_REQUIRE_EQUAL( success(),      buyrex( emily, core_sym::from_string("1100.0000") ) );
+      BOOST_REQUIRE_EQUAL( success(),      buyrex( emily, core_sym::from_string("22000.0000") ) );
       BOOST_REQUIRE_EQUAL( false,          get_rex_order_obj(alice).is_null() );
       BOOST_REQUIRE_EQUAL( false,          get_rex_order(alice)["is_open"].as<bool>() );
 
@@ -3890,12 +3892,13 @@ BOOST_FIXTURE_TEST_CASE( buy_sell_claim_rex, eosio_system_tester ) try {
 BOOST_FIXTURE_TEST_CASE( rex_loans, eosio_system_tester ) try {
 
    const int64_t ratio        = 10000;
-   const asset   init_balance = core_sym::from_string("10000.0000");
+   const asset   init_balance = core_sym::from_string("40000.0000");
+   const asset   one_unit     = core_sym::from_string("0.0001");
    const std::vector<account_name> accounts = { N(aliceaccount), N(bobbyaccount), N(carolaccount), N(emilyaccount), N(frankaccount) };
    account_name alice = accounts[0], bob = accounts[1], carol = accounts[2], emily = accounts[3], frank = accounts[4];
    setup_rex_accounts( accounts, init_balance  );
 
-   BOOST_REQUIRE_EQUAL( success(), buyrex( alice, core_sym::from_string("2500.0000") ) );
+   BOOST_REQUIRE_EQUAL( success(), buyrex( alice, core_sym::from_string("25000.0000") ) );
 
    auto rex_pool            = get_rex_pool();
    const asset payment      = core_sym::from_string("30.0000");
@@ -3940,6 +3943,7 @@ BOOST_FIXTURE_TEST_CASE( rex_loans, eosio_system_tester ) try {
 
    // frank funds his loan enough to be renewed once
    const asset fund = core_sym::from_string("35.0000");
+   BOOST_REQUIRE_EQUAL( fundcpuloan( frank, 1, cur_frank_balance + one_unit), wasm_assert_msg("insufficient funds") );
    BOOST_REQUIRE_EQUAL( fundnetloan( frank, 1, fund ), wasm_assert_msg("loan not found") );
    BOOST_REQUIRE_EQUAL( fundcpuloan( alice, 1, fund ), wasm_assert_msg("user must be loan creator") );
    BOOST_REQUIRE_EQUAL( success(),                     fundcpuloan( frank, 1, fund ) );
@@ -4016,13 +4020,13 @@ BOOST_FIXTURE_TEST_CASE( rex_loans, eosio_system_tester ) try {
 BOOST_FIXTURE_TEST_CASE( rex_loan_checks, eosio_system_tester ) try {
 
    const int64_t ratio        = 10000;
-   const asset   init_balance = core_sym::from_string("20000.0000");
+   const asset   init_balance = core_sym::from_string("40000.0000");
    const std::vector<account_name> accounts = { N(aliceaccount), N(bobbyaccount) };
    account_name alice = accounts[0], bob = accounts[1];
    setup_rex_accounts( accounts, init_balance );
 
-   const asset payment1 = core_sym::from_string("1000.0000");
-   const asset payment2 = core_sym::from_string("2.0000");
+   const asset payment1 = core_sym::from_string("20000.0000");
+   const asset payment2 = core_sym::from_string("4.0000");
    const asset fee      = core_sym::from_string("1.0000");
    BOOST_REQUIRE_EQUAL( success(), buyrex( alice, payment1 ) );
    BOOST_REQUIRE_EQUAL( wasm_assert_msg("loan price does not favor renting"),
@@ -4391,7 +4395,7 @@ BOOST_FIXTURE_TEST_CASE( rex_savings, eosio_system_tester ) try {
    }
 
    {
-      const asset payment = core_sym::from_string("20000.0000");
+      const asset payment = core_sym::from_string("40000.0000");
       const int64_t rex_bucket_amount = rex_ratio * payment.get_amount();
       const asset rex_bucket( rex_bucket_amount, rex_sym );
       BOOST_REQUIRE_EQUAL( success(),  buyrex( alice, payment ) );
@@ -4464,20 +4468,20 @@ BOOST_FIXTURE_TEST_CASE( rex_savings, eosio_system_tester ) try {
 
 BOOST_FIXTURE_TEST_CASE( update_rex, eosio_system_tester, * boost::unit_test::tolerance(1e-10) ) try {
 
-   const asset init_balance = core_sym::from_string("10000.0000");
-   const std::vector<account_name> accounts = { N(aliceaccount), N(bobbyaccount), N(carolaccount), N(emilyaccount), N(frankaccount) };
-   account_name alice = accounts[0], bob = accounts[1], carol = accounts[2], emily = accounts[3], frank = accounts[4];
+   const asset init_balance = core_sym::from_string("30000.0000");
+   const std::vector<account_name> accounts = { N(aliceaccount), N(bobbyaccount), N(carolaccount), N(emilyaccount) };
+   account_name alice = accounts[0], bob = accounts[1], carol = accounts[2], emily = accounts[3];
    setup_rex_accounts( accounts, init_balance );
 
    const int64_t init_stake = get_voter_info( alice )["staked"].as<int64_t>();
 
-   const asset payment = core_sym::from_string("2500.0000");
+   const asset payment = core_sym::from_string("25000.0000");
    BOOST_REQUIRE_EQUAL( success(),                              buyrex( alice, payment ) );
    BOOST_REQUIRE_EQUAL( payment,                                get_rex_vote_stake(alice) );
    BOOST_REQUIRE_EQUAL( get_rex_vote_stake(alice).get_amount(), get_voter_info(alice)["staked"].as<int64_t>() - init_stake );
 
    const asset fee = core_sym::from_string("50.0000");
-   BOOST_REQUIRE_EQUAL( success(),                              rentcpu( frank, bob, fee ) );
+   BOOST_REQUIRE_EQUAL( success(),                              rentcpu( emily, bob, fee ) );
    BOOST_REQUIRE_EQUAL( success(),                              updaterex( alice ) );
    BOOST_REQUIRE_EQUAL( payment + fee,                          get_rex_vote_stake(alice) );
    BOOST_REQUIRE_EQUAL( get_rex_vote_stake(alice).get_amount(), get_voter_info( alice )["staked"].as<int64_t>() - init_stake );
@@ -4518,8 +4522,9 @@ BOOST_FIXTURE_TEST_CASE( update_rex, eosio_system_tester, * boost::unit_test::to
 
    const asset   init_rex             = get_rex_balance( alice );
    const auto    current_rex_pool     = get_rex_pool();
-   const int64_t init_alice_rex_stake = ( init_rex.get_amount() * current_rex_pool["total_lendable"].as<asset>().get_amount() )
-                                          / current_rex_pool["total_rex"].as<asset>().get_amount();
+   const int64_t total_lendable       = current_rex_pool["total_lendable"].as<asset>().get_amount();
+   const int64_t total_rex            = current_rex_pool["total_rex"].as<asset>().get_amount();
+   const int64_t init_alice_rex_stake = ( eosio::chain::uint128_t(init_rex.get_amount()) * total_lendable ) / total_rex;
    produce_block( fc::days(5) );
    const asset rex_sell_amount( get_rex_balance(alice).get_amount() / 4, symbol( SY(4,REX) ) );
    BOOST_REQUIRE_EQUAL( success(),                                       sellrex( alice, rex_sell_amount ) );
@@ -4559,15 +4564,15 @@ BOOST_FIXTURE_TEST_CASE( update_rex_vote, eosio_system_tester, * boost::unit_tes
       }
    }
 
-   const asset init_balance = core_sym::from_string("10000.0000");
-   const std::vector<account_name> accounts = { N(aliceaccount), N(bobbyaccount), N(carolaccount), N(emilyaccount), N(frankaccount) };
-   account_name alice = accounts[0], bob = accounts[1], carol = accounts[2], emily = accounts[3], frank = accounts[4];
+   const asset init_balance = core_sym::from_string("30000.0000");
+   const std::vector<account_name> accounts = { N(aliceaccount), N(bobbyaccount), N(carolaccount), N(emilyaccount) };
+   account_name alice = accounts[0], bob = accounts[1], carol = accounts[2], emily = accounts[3];
    setup_rex_accounts( accounts, init_balance );
 
    const int64_t init_stake_amount = get_voter_info( alice )["staked"].as<int64_t>();
    const asset init_stake( init_stake_amount, symbol{CORE_SYM} );
 
-   const asset purchase = core_sym::from_string("2500.0000");
+   const asset purchase = core_sym::from_string("25000.0000");
    BOOST_REQUIRE_EQUAL( success(),                              buyrex( alice, purchase ) );
    BOOST_REQUIRE_EQUAL( purchase,                               get_rex_pool()["total_lendable"].as<asset>() );
    BOOST_REQUIRE_EQUAL( purchase,                               get_rex_vote_stake(alice) );
@@ -4581,7 +4586,7 @@ BOOST_FIXTURE_TEST_CASE( update_rex_vote, eosio_system_tester, * boost::unit_tes
 
    const auto init_rex_pool = get_rex_pool();
    const asset rent = core_sym::from_string("25.0000");
-   BOOST_REQUIRE_EQUAL( success(),                              rentcpu( frank, bob, rent ) );
+   BOOST_REQUIRE_EQUAL( success(),                              rentcpu( emily, bob, rent ) );
    const auto curr_rex_pool = get_rex_pool();
    BOOST_REQUIRE_EQUAL( curr_rex_pool["total_lendable"].as<asset>(), init_rex_pool["total_lendable"].as<asset>() + rent );
    BOOST_REQUIRE_EQUAL( success(),
@@ -4596,12 +4601,12 @@ BOOST_FIXTURE_TEST_CASE( update_rex_vote, eosio_system_tester, * boost::unit_tes
    const asset to_net_stake = core_sym::from_string("60.0000");
    const asset to_cpu_stake = core_sym::from_string("40.0000");
    transfer( config::system_account_name, alice, to_net_stake + to_cpu_stake, config::system_account_name );
-   BOOST_REQUIRE_EQUAL( success(),                              rentcpu( frank, bob, rent ) );
+   BOOST_REQUIRE_EQUAL( success(),                              rentcpu( emily, bob, rent ) );
    BOOST_REQUIRE_EQUAL( success(),                              stake( alice, alice, to_net_stake, to_cpu_stake ) );
    BOOST_REQUIRE_EQUAL( purchase + rent + rent,                 get_rex_vote_stake(alice) );
    BOOST_TEST_REQUIRE ( stake2votes(init_stake + purchase + rent + rent + to_net_stake + to_cpu_stake) ==
                         get_producer_info(producer_names[0])["total_votes"].as_double() );
-   BOOST_REQUIRE_EQUAL( success(),                              rentcpu( frank, bob, rent ) );
+   BOOST_REQUIRE_EQUAL( success(),                              rentcpu( emily, bob, rent ) );
    BOOST_REQUIRE_EQUAL( success(),                              unstake( alice, alice, to_net_stake, to_cpu_stake ) );
    BOOST_REQUIRE_EQUAL( purchase + rent + rent + rent,          get_rex_vote_stake(alice) );
    BOOST_TEST_REQUIRE ( stake2votes(init_stake + purchase + rent + rent + rent) ==
@@ -4644,13 +4649,13 @@ BOOST_FIXTURE_TEST_CASE( deposit_rex_fund, eosio_system_tester ) try {
 
 BOOST_FIXTURE_TEST_CASE( rex_lower_bound, eosio_system_tester ) try {
 
-   const asset init_balance = core_sym::from_string("2500.0000");
+   const asset init_balance = core_sym::from_string("25000.0000");
    const std::vector<account_name> accounts = { N(aliceaccount), N(bobbyaccount) };
    account_name alice = accounts[0], bob = accounts[1];
    setup_rex_accounts( accounts, init_balance );
    const symbol rex_sym( SY(4, REX) );
 
-   const asset payment = core_sym::from_string("2500.0000");
+   const asset payment = core_sym::from_string("25000.0000");
    BOOST_REQUIRE_EQUAL( success(), buyrex( alice, payment ) );
    const asset fee = core_sym::from_string("25.0000");
    BOOST_REQUIRE_EQUAL( success(), rentcpu( bob, bob, fee ) );
@@ -4675,7 +4680,7 @@ BOOST_FIXTURE_TEST_CASE( rex_lower_bound, eosio_system_tester ) try {
 
 BOOST_FIXTURE_TEST_CASE( close_rex, eosio_system_tester ) try {
 
-   const asset init_balance = core_sym::from_string("2000.0000");
+   const asset init_balance = core_sym::from_string("25000.0000");
    const std::vector<account_name> accounts = { N(aliceaccount), N(bobbyaccount), N(carolaccount), N(emilyaccount) };
    account_name alice = accounts[0], bob = accounts[1], carol = accounts[2], emily = accounts[3];
    setup_rex_accounts( accounts, init_balance );


### PR DESCRIPTION
<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->

## Change Description
<!-- Describe your changes, their justification, AND their impact. Reference issues or pull requests where possible (use '#XX' or 'GH-XX' where XX is the issue or pull request number). -->
1. Added a check to ensure that REX loan price is in favor of renting as opposed to staking tokens directly to CPU or Network resources. If the condition is not satisfied, renting actions fail and loans are not renewed.
2. Fixed error in `rex_loans_available()` function. If the queue is non-empty but all the orders have been filled, users can rent CPU and Network resources again.
3. Added ABI support to inline dummy actions. In order for the data of these actions to be deserialized, the ABI of contract `rex.results` which is in file `rex.results.abi` must be deployed on account `eosio.rex`. The actions `buyresult`, `sellresult`, and `orderresult` of `rex.results` are all no-ops. The corresponding contract `rex.results.wasm` must _NOT_ be deployed.
4. Created action `setrex` which allows producers to reset `total_rent` balance of the REX pool to a given value, if the need arises. It is important to note that this action is _NOT_ required to initialize the REX system and is not recommended to be used more than once. It is a backup mechanism that allows to balance the renting market prices in case the initial settings were impractical and not in line with the amount of tokens lent to REX. `total_rent` is a virtual balance and no real tokens will be added or removed in this action.
5. Decreased the lower bound of `total_unlent` balance of REX pool back to the value set in RC1 following the results of testing RC2.
6. Minor code refactoring.

## Deployment Changes
- [x] Deployment Changes
<!-- checked [x] = Deployment changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces a change to the contracts that causes deployment to change, please describe the impact. -->
ABI file `rex.results.abi` (generated automatically) needs to be deployed on account `eosio.rex`.

## API Changes
- [x] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->
Added action `setrex` described above.

## Documentation Additions
- [ ] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
