### PR TITLE
Added ctest Error Handling

### DIFF
--- a/docker/unit-test.sh
+++ b/docker/unit-test.sh
@@ -6,5 +6,14 @@ cd /eosio.contracts/build/tests
 TEST_COUNT=$(ctest -N | grep -i 'Total Tests: ' | cut -d ':' -f 2 | awk '{print $1}')
 [[ $TEST_COUNT > 0 ]] && echo "$TEST_COUNT tests found." || (echo "ERROR: No tests registered with ctest! Exiting..." && exit 1)
 echo "$ ctest -j $CPU_CORES --output-on-failure -T Test"
+set +e # defer ctest error handling to end
 ctest -j $CPU_CORES --output-on-failure -T Test
+EXIT_STATUS=$?
+[[ "$EXIT_STATUS" == 0 ]] && set -e
 mv /eosio.contracts/build/tests/Testing/$(ls /eosio.contracts/build/tests/Testing/ | grep '20' | tail -n 1)/Test.xml /artifacts/Test.xml
+# ctest error handling
+if [[ "$EXIT_STATUS" != 0 ]]; then
+    echo "Failing due to non-zero exit status from ctest: $EXIT_STATUS"
+    echo '    ^^^ scroll up for more information ^^^'
+    exit $EXIT_STATUS
+fi


### PR DESCRIPTION
## Change Description
Currently, if ctest executes some tests and then exits with a non-zero exit status, the xUnit-formatted XML file it produces will not be uploaded as a Buildkite artifact because those instructions occur after ctest fails the job, stopping execution.     
   
Now the unit test script disables fail-on-error, runs ctest, saves the ctest exit status, attempts to attach the XML as an artifact, and then re-throws the ctest errors, if one occurred.   
  
Tested working in eosio.contracts [build 152](https://buildkite.com/EOSIO/eosio-dot-contracts/builds/152#5f956070-2fdd-4709-8b2b-80e253566f56/22-65).  
  
## Deployment Changes
- [ ] Deployment Changes
None.

## API Changes
- [ ] API Changes
None.

## Documentation Additions
- [ ] Documentation Additions
None.