### PR TITLE
fix assertion in create_core_token; clean up inconsistent license references - v1.7.x

### DIFF
--- a/contracts/eosio.system/include/eosio.system/eosio.system.hpp
+++ b/contracts/eosio.system/include/eosio.system/eosio.system.hpp
@@ -1,7 +1,3 @@
-/**
- *  @file
- *  @copyright defined in eos/LICENSE.txt
- */
 #pragma once
 
 #include <eosio.system/native.hpp>

--- a/contracts/eosio.system/include/eosio.system/native.hpp
+++ b/contracts/eosio.system/include/eosio.system/native.hpp
@@ -1,7 +1,3 @@
-/**
- *  @file
- *  @copyright defined in eos/LICENSE.txt
- */
 #pragma once
 
 #include <eosiolib/action.hpp>
@@ -52,9 +48,9 @@ namespace eosiosystem {
     * @{
     */
    /**
-    * A weighted permission. 
-    * 
-    * @details Defines a weighted permission, that is a permission which has a weight associated. 
+    * A weighted permission.
+    *
+    * @details Defines a weighted permission, that is a permission which has a weight associated.
     * A permission is defined by an account name plus a permission name.
     */
    struct permission_level_weight {
@@ -67,7 +63,7 @@ namespace eosiosystem {
 
    /**
     * Weighted key.
-    * 
+    *
     * @details A weighted key is defined by a public key and an associated weight.
     */
    struct key_weight {
@@ -80,7 +76,7 @@ namespace eosiosystem {
 
    /**
     * Wait weight.
-    * 
+    *
     * @details A wait weight is defined by a number of seconds to wait for and a weight.
     */
    struct wait_weight {
@@ -93,7 +89,7 @@ namespace eosiosystem {
 
    /**
     * Blockchain authority.
-    * 
+    *
     * @details An authority is defined by:
     * - a vector of key_weights (a key_weight is a public key plus a wieght),
     * - a vector of permission_level_weights, (a permission_level is an account name plus a permission name)
@@ -112,7 +108,7 @@ namespace eosiosystem {
 
    /**
     * Blockchain block header.
-    * 
+    *
     * @details A block header is defined by:
     * - a timestamp,
     * - the producer that created it,
@@ -140,7 +136,7 @@ namespace eosiosystem {
 
    /**
     * abi_hash
-    * 
+    *
     * @details abi_hash is the structure underlying the abihash table and consists of:
     * - `owner`: the account owner of the contract's abi
     * - `hash`: is the sha256 hash of the abi/binary
@@ -156,7 +152,7 @@ namespace eosiosystem {
    // Method parameters commented out to prevent generation of code that parses input data.
    /**
     * The EOSIO core native contract that governs authorization and contracts' abi.
-    * 
+    *
     * @details
     */
    class [[eosio::contract("eosio.system")]] native : public eosio::contract {
@@ -166,15 +162,15 @@ namespace eosiosystem {
 
          /**
           * @{
-          * These actions map one-on-one with the ones defined in 
+          * These actions map one-on-one with the ones defined in
           * [Native Action Handlers](@ref native_action_handlers) section.
           * They are present here so they can show up in the abi file and thus user can send them
-          * to this contract, but they have no specific implementation at this contract level, 
+          * to this contract, but they have no specific implementation at this contract level,
           * they will execute the implementation at the core level and nothing else.
           */
          /**
-          * New account action 
-          * 
+          * New account action
+          *
           * @details Called after a new account is created. This code enforces resource-limits rules
           * for new accounts as well as new account naming conventions.
           *
@@ -194,9 +190,9 @@ namespace eosiosystem {
 
          /**
           * Update authorization action.
-          * 
+          *
           * @details Updates pemission for an account
-          * 
+          *
           * @param account - the account for which the permission is updated
           * @param pemission - the permission name which is updated
           * @param parem - the parent of the permission which is updated
@@ -210,9 +206,9 @@ namespace eosiosystem {
 
          /**
           * Delete authorization action.
-          * 
+          *
           * @details Deletes the authorization for an account's permision.
-          * 
+          *
           * @param account - the account for which the permission authorization is deleted,
           * @param permission - the permission name been deleted.
           */
@@ -222,16 +218,16 @@ namespace eosiosystem {
 
          /**
           * Link authorization action.
-          * 
-          * @details Assigns a specific action from a contract to a permission you have created. Five system 
+          *
+          * @details Assigns a specific action from a contract to a permission you have created. Five system
           * actions can not be linked `updateauth`, `deleteauth`, `linkauth`, `unlinkauth`, and `canceldelay`.
-          * This is useful because when doing authorization checks, the EOSIO based blockchain starts with the 
-          * action needed to be authorized (and the contract belonging to), and looks up which permission 
-          * is needed to pass authorization validation. If a link is set, that permission is used for authoraization 
+          * This is useful because when doing authorization checks, the EOSIO based blockchain starts with the
+          * action needed to be authorized (and the contract belonging to), and looks up which permission
+          * is needed to pass authorization validation. If a link is set, that permission is used for authoraization
           * validation otherwise then active is the default, with the exception of `eosio.any`.
           * `eosio.any` is an implicit permission which exists on every account; you can link actions to `eosio.any`
-          * and that will make it so linked actions are accessible to any permissions defined for the account. 
-          * 
+          * and that will make it so linked actions are accessible to any permissions defined for the account.
+          *
           * @param account - the permission's owner to be linked and the payer of the RAM needed to store this link,
           * @param code - the owner of the action to be linked,
           * @param type - the action to be linked,
@@ -245,9 +241,9 @@ namespace eosiosystem {
 
          /**
           * Unlink authorization action.
-          * 
+          *
           * @details It's doing the reverse of linkauth action, by unlinking the given action.
-          * 
+          *
           * @param account - the owner of the permission to be unlinked and the receiver of the freed RAM,
           * @param code - the owner of the action to be unlinked,
           * @param type - the action to be unlinked.
@@ -259,9 +255,9 @@ namespace eosiosystem {
 
          /**
           * Cancel delay action.
-          * 
+          *
           * @details Cancels a deferred transaction.
-          * 
+          *
           * @param canceling_auth - the permission that authorizes this action,
           * @param trx_id - the deferred transaction id to be cancelled.
           */
@@ -270,9 +266,9 @@ namespace eosiosystem {
 
          /**
           * On error action.
-          * 
+          *
           * @details Called every time an error occurs while a transaction was processed.
-          * 
+          *
           * @param sender_id - the id of the sender,
           * @param sent_trx - the transaction that failed.
           */
@@ -281,9 +277,9 @@ namespace eosiosystem {
 
          /**
           * Set abi action.
-          * 
+          *
           * @details Sets the contract abi for an account.
-          * 
+          *
           * @param account - the account for which to set the contract abi.
           * @param abi - the abi content to be set, in the form of a blob binary.
           */
@@ -292,9 +288,9 @@ namespace eosiosystem {
 
          /**
           * Set code action.
-          * 
+          *
           * @details Sets the contract code for an account.
-          * 
+          *
           * @param account - the account for which to set the contract code.
           * @param vmtype - reserved, set it to zero.
           * @param vmversion - reserved, set it to zero.

--- a/contracts/eosio.system/src/delegate_bandwidth.cpp
+++ b/contracts/eosio.system/src/delegate_bandwidth.cpp
@@ -1,7 +1,3 @@
-/**
- *  @file
- *  @copyright defined in eos/LICENSE.txt
- */
 #include <eosio.system/eosio.system.hpp>
 
 #include <eosiolib/eosio.hpp>
@@ -135,7 +131,7 @@ namespace eosiosystem {
 
       const auto& market = _rammarket.get(ramcore_symbol.raw(), "ram market does not exist");
       _rammarket.modify( market, same_payer, [&]( auto& es ) {
-         bytes_out = es.direct_convert( quant_after_fee,  ram_symbol ).amount; 
+         bytes_out = es.direct_convert( quant_after_fee,  ram_symbol ).amount;
       });
 
       check( bytes_out > 0, "must reserve a positive amount" );
@@ -208,7 +204,7 @@ namespace eosiosystem {
          get_resource_limits( res_itr->owner.value, &ram_bytes, &net, &cpu );
          set_resource_limits( res_itr->owner.value, res_itr->ram_bytes + ram_gift_bytes, net, cpu );
       }
-      
+
       {
          token::transfer_action transfer_act{ token_account, { {ram_account, active_permission}, {account, active_permission} } };
          transfer_act.send( ram_account, account, asset(tokens_out), "sell ram" );

--- a/contracts/eosio.system/src/rex.cpp
+++ b/contracts/eosio.system/src/rex.cpp
@@ -1,7 +1,3 @@
-/**
- *  @copyright defined in eos/LICENSE.txt
- */
-
 #include <eosio.system/eosio.system.hpp>
 #include <eosio.system/rex.results.hpp>
 
@@ -48,7 +44,7 @@ namespace eosiosystem {
       const asset delta_rex_stake = add_to_rex_balance( from, amount, rex_received );
       runrex(2);
       update_rex_account( from, asset( 0, core_symbol() ), delta_rex_stake );
-      // dummy action added so that amount of REX tokens purchased shows up in action trace 
+      // dummy action added so that amount of REX tokens purchased shows up in action trace
       rex_results::buyresult_action buyrex_act( rex_account, std::vector<eosio::permission_level>{ } );
       buyrex_act.send( rex_received );
    }
@@ -525,11 +521,11 @@ namespace eosiosystem {
                                                                     pool->total_unlent.amount,
                                                                     itr->payment.amount );
          /// conditions for loan renewal
-         bool renew_loan = itr->payment <= itr->balance        /// loan has sufficient balance 
-                        && itr->payment.amount < rented_tokens /// loan has favorable return 
+         bool renew_loan = itr->payment <= itr->balance        /// loan has sufficient balance
+                        && itr->payment.amount < rented_tokens /// loan has favorable return
                         && rex_loans_available();              /// no pending sell orders
          if ( renew_loan ) {
-            /// update rex_pool in order to account for renewed loan 
+            /// update rex_pool in order to account for renewed loan
             add_loan_to_rex_pool( itr->payment, rented_tokens, false );
             /// update renewed loan fields
             delta_stake = update_renewed_loan( idx, itr, rented_tokens );
@@ -1010,7 +1006,7 @@ namespace eosiosystem {
     * @brief Reads amount of REX in savings bucket and removes the bucket from maturities
     *
     * Reads and (temporarily) removes REX savings bucket from REX maturities in order to
-    * allow uniform processing of remaining buckets as savings is a special case. This 
+    * allow uniform processing of remaining buckets as savings is a special case. This
     * function is used in conjunction with put_rex_savings.
     *
     * @param bitr - iterator pointing to rex_balance object
@@ -1064,7 +1060,7 @@ namespace eosiosystem {
          current_vote_stake.amount = ( uint128_t(bitr->rex_balance.amount) * _rexpool.begin()->total_lendable.amount )
                                      / _rexpool.begin()->total_rex.amount;
          _rexbalance.modify( bitr, same_payer, [&]( auto& rb ) {
-            rb.vote_stake.amount = current_vote_stake.amount; 
+            rb.vote_stake.amount = current_vote_stake.amount;
          });
          delta_stake = current_vote_stake.amount - init_vote_stake.amount;
       }

--- a/contracts/eosio.system/src/voting.cpp
+++ b/contracts/eosio.system/src/voting.cpp
@@ -1,7 +1,3 @@
-/**
- *  @file
- *  @copyright defined in eos/LICENSE.txt
- */
 #include <eosio.system/eosio.system.hpp>
 
 #include <eosiolib/eosio.hpp>

--- a/contracts/eosio.token/include/eosio.token/eosio.token.hpp
+++ b/contracts/eosio.token/include/eosio.token/eosio.token.hpp
@@ -1,7 +1,3 @@
-/**
- *  @file
- *  @copyright defined in eos/LICENSE.txt
- */
 #pragma once
 
 #include <eosiolib/asset.hpp>
@@ -20,10 +16,10 @@ namespace eosio {
    /**
     * @defgroup eosiotoken eosio.token
     * @ingroup eosiocontracts
-    * 
+    *
     * eosio.token contract
-    * 
-    * @details eosio.token contract defines the structures and actions that allow users to create, issue, and manage 
+    *
+    * @details eosio.token contract defines the structures and actions that allow users to create, issue, and manage
     * tokens on eosio based blockchains.
     * @{
     */
@@ -33,16 +29,16 @@ namespace eosio {
 
          /**
           * Create action.
-          * 
+          *
           * @details Allows `issuer` account to create a token in supply of `maximum_supply`.
           * @param issuer - the account that creates the token,
           * @param maximum_supply - the maximum supply set for the token created.
-          * 
+          *
           * @pre Token symbol has to be valid,
           * @pre Token symbol must not be already created,
           * @pre maximum_supply has to be smaller than the maximum supply allowed by the system: 1^62 - 1.
-          * @pre Maximum supply must be positive; 
-          * 
+          * @pre Maximum supply must be positive;
+          *
           * If validation is successful a new entry in statstable for token symbol scope gets created.
           */
          [[eosio::action]]
@@ -50,9 +46,9 @@ namespace eosio {
                       const asset&  maximum_supply);
          /**
           * Issue action.
-          * 
+          *
           * @details This action issues to `to` account a `quantity` of tokens.
-          * 
+          *
           * @param to - the account to issue tokens to, it must be the same as the issuer,
           * @param quntity - the amount of tokens to be issued,
           * @memo - the memo string that accompanies the token issue transaction.
@@ -62,10 +58,10 @@ namespace eosio {
 
          /**
           * Retire action.
-          * 
-          * @details The opposite for create action, if all validations succeed, 
+          *
+          * @details The opposite for create action, if all validations succeed,
           * it debits the statstable.supply amount.
-          * 
+          *
           * @param quantity - the quantity of tokens to retire,
           * @param memo - the memo string to accompany the transaction.
           */
@@ -74,10 +70,10 @@ namespace eosio {
 
          /**
           * Transfer action.
-          * 
+          *
           * @details Allows `from` account to transfer to `to` account the `quantity` tokens.
           * One account is debited and the other is credited with quantity tokens.
-          * 
+          *
           * @param from - the account to transfer from,
           * @param to - the account to be transferred to,
           * @param quantity - the quantity of tokens to be transferred,
@@ -90,15 +86,15 @@ namespace eosio {
                         const string&  memo );
          /**
           * Open action.
-          * 
-          * @details Allows `ram_payer` to create an account `owner` with zero balance for 
+          *
+          * @details Allows `ram_payer` to create an account `owner` with zero balance for
           * token `symbol` at the expense of `ram_payer`.
-          * 
+          *
           * @param owner - the account to be created,
           * @param symbol - the token to be payed with by `ram_payer`,
           * @param ram_payer - the account that supports the cost of this action.
-          * 
-          * More information can be read [here](https://github.com/EOSIO/eosio.contracts/issues/62) 
+          *
+          * More information can be read [here](https://github.com/EOSIO/eosio.contracts/issues/62)
           * and [here](https://github.com/EOSIO/eosio.contracts/issues/61).
           */
          [[eosio::action]]
@@ -106,13 +102,13 @@ namespace eosio {
 
          /**
           * Close action.
-          * 
-          * @details This action is the opposite for open, it closes the account `owner` 
+          *
+          * @details This action is the opposite for open, it closes the account `owner`
           * for token `symbol`.
-          * 
+          *
           * @param owner - the owner account to execute the close action for,
           * @param symbol - the symbol of the token to execute the close action for.
-          * 
+          *
           * @pre The pair of owner plus symbol has to exist otherwise no action is executed,
           * @pre If the pair of owner plus symbol exists, the balance has to be zero.
           */
@@ -121,9 +117,9 @@ namespace eosio {
 
          /**
           * Get supply method.
-          * 
-          * @details Gets the supply for token `sym_code`, created by `token_contract_account` account. 
-          * 
+          *
+          * @details Gets the supply for token `sym_code`, created by `token_contract_account` account.
+          *
           * @param token_contract_account - the account to get the supply for,
           * @param sym_code - the symbol to get the supply for.
           */
@@ -136,10 +132,10 @@ namespace eosio {
 
          /**
           * Get balance method.
-          * 
+          *
           * @details Get the balance for a token `sym_code` created by `token_contract_account` account,
           * for account `owner`.
-          * 
+          *
           * @param token_contract_account - the token creator account,
           * @param owner - the account for which the token balance is returned,
           * @param sym_code - the token for which the balance is returned.

--- a/contracts/eosio.token/src/eosio.token.cpp
+++ b/contracts/eosio.token/src/eosio.token.cpp
@@ -1,8 +1,3 @@
-/**
- *  @file
- *  @copyright defined in eos/LICENSE.txt
- */
-
 #include <eosio.token/eosio.token.hpp>
 
 namespace eosio {

--- a/tests/eosio.system_tester.hpp
+++ b/tests/eosio.system_tester.hpp
@@ -52,7 +52,7 @@ public:
    }
 
    void create_core_token( symbol core_symbol = symbol{CORE_SYM} ) {
-      FC_ASSERT( core_symbol.precision() != 4, "create_core_token assumes precision of core token is 4" );
+      FC_ASSERT( core_symbol.decimals() == 4, "create_core_token assumes core token has 4 digits of precision" );
       create_currency( N(eosio.token), config::system_account_name, asset(100000000000000, core_symbol) );
       issue( asset(10000000000000, core_symbol) );
       BOOST_REQUIRE_EQUAL( asset(10000000000000, core_symbol), get_balance( "eosio", core_symbol ) );

--- a/tests/eosio.system_tester.hpp
+++ b/tests/eosio.system_tester.hpp
@@ -1,7 +1,3 @@
-/**
- *  @file
- *  @copyright defined in eos/LICENSE.txt
- */
 #pragma once
 
 #include <eosio/testing/tester.hpp>


### PR DESCRIPTION
## Change Description

Fix wrong assertion in `create_core_token` (adapted from #189).

Cleanup extraneous and inconsistent license references.

## Deployment Changes
- [ ] Deployment Changes

## API Changes
- [ ] API Changes

## Documentation Additions
- [ ] Documentation Additions

