### PR TITLE
workaround check_transaction_authorization bug

### DIFF
--- a/contracts/eosio.msig/src/eosio.msig.cpp
+++ b/contracts/eosio.msig/src/eosio.msig.cpp
@@ -34,10 +34,13 @@ void multisig::propose( ignore<name> proposer,
    check( proptable.find( _proposal_name.value ) == proptable.end(), "proposal with the same name exists" );
 
    auto packed_requested = pack(_requested);
-   auto res = check_transaction_authorization( trx_pos, size,
-                                               (const char*)0, 0,
-                                               packed_requested.data(), packed_requested.size());
-   
+   // TODO: Remove internal_use_do_not_use namespace after minimum eosio.cdt dependency becomes 1.7.x
+   auto res =  internal_use_do_not_use::check_transaction_authorization( 
+                  trx_pos, size,
+                  (const char*)0, 0,
+                  packed_requested.data(), packed_requested.size()
+               );
+
    check( res > 0, "transaction authorization failed" );
 
    std::vector<char> pkd_trans;
@@ -176,10 +179,13 @@ void multisig::exec( name proposer, name proposal_name, name executer ) {
       old_apptable.erase(apps);
    }
    auto packed_provided_approvals = pack(approvals);
-   auto res = check_transaction_authorization( prop.packed_transaction.data(), prop.packed_transaction.size(),
-                                               (const char*)0, 0,
-                                               packed_provided_approvals.data(), packed_provided_approvals.size());
-   
+   // TODO: Remove internal_use_do_not_use namespace after minimum eosio.cdt dependency becomes 1.7.x
+   auto res =  internal_use_do_not_use::check_transaction_authorization(
+                  prop.packed_transaction.data(), prop.packed_transaction.size(),
+                  (const char*)0, 0,
+                  packed_provided_approvals.data(), packed_provided_approvals.size()
+               );
+
    check( res > 0, "transaction authorization failed" );
 
    send_deferred( (uint128_t(proposer.value) << 64) | proposal_name.value, executer,


### PR DESCRIPTION
## Change Description

This PR works around the `check_transaction_authorization` bug in eosio.cdt v1.6.1 by using the C API directly.

Note for eosio.contracts developers: even when this CDT bug is fixed in v1.6.2, we do not want to return back to the C++ wrapper function because the minimum CDT dependency of contracts would still be 1.6 (the dependency checker does not allow depending on patch releases). The CDT bug only shows up as a warning that most people would ignore. It isn't until the function is actually called during runtime (for example during an `eosio.msig::propose` action) that the bug is encountered (`unreachable executed` errors). 

When eosio.contracts minimum CDT dependency becomes 1.7, we can revert these changes and return back the the wrapped C++ version of `check_transaction_authorization`.

Note, that two of the unit tests still fail in this PR. This is due to changes introduced in #247, and the fixes are left for PR #253 to take care of.

## Deployment Changes
- [ ] Deployment Changes


## API Changes
- [ ] API Changes


## Documentation Additions
- [ ] Documentation Additions
