### PR TITLE
Implemented support for custom eosio and eosio.cdt installation paths.

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,5 +1,60 @@
-#! /bin/bash
-set -e # exit on failure of any "simple" command (excludes &&, ||, or | chains)
+#!/usr/bin/env bash
+set -eo pipefail
+
+function usage() {
+   printf "Usage: $0 OPTION...
+  -e DIR      Directory where EOSIO is installed. (Default: $HOME/eosio/X.Y)
+  -c DIR      Directory where EOSIO.CDT is installed. (Default: /usr/local/eosio.cdt)
+  -y          Noninteractive mode (Uses defaults for each prompt.)
+  -h          Print this help menu.
+   \\n" "$0" 1>&2
+   exit 1
+}
+
+if [ $# -ne 0 ]; then
+  while getopts "e:c:yh" opt; do
+    case "${opt}" in
+      e )
+        EOSIO_DIR_PROMPT=$OPTARG
+      ;;
+      c )
+        CDT_DIR_PROMPT=$OPTARG
+      ;;
+      y )
+        NONINTERACTIVE=true
+        PROCEED=true
+      ;;
+      h )
+        usage
+      ;;
+      ? )
+        echo "Invalid Option!" 1>&2
+        usage
+      ;;
+      : )
+        echo "Invalid Option: -${OPTARG} requires an argument." 1>&2
+        usage
+      ;;
+      * )
+        usage
+      ;;
+    esac
+  done
+fi
+
+# Source helper functions and variables.
+. ./scripts/.environment
+. ./scripts/helper.sh
+
+# Prompt user for location of eosio.
+eosio-directory-prompt
+
+# Prompt user for location of eosio.cdt.
+cdt-directory-prompt
+
+# Ensure eosio version is appropriate.
+nodeos-version-check
+
 printf "\t=========== Building eosio.contracts ===========\n\n"
 RED='\033[0;31m'
 NC='\033[0m'

--- a/docker/buildContracts.sh
+++ b/docker/buildContracts.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 set -e # exit on failure of any "simple" command (excludes &&, ||, or | chains)
 cd /eosio.contracts
-./build.sh
+./build.sh -c /usr/opt/eosio.cdt -e /opt/eosio -y
 cd build
 tar -pczf /artifacts/contracts.tar.gz *

--- a/scripts/.environment
+++ b/scripts/.environment
@@ -1,0 +1,12 @@
+export SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+export REPO_ROOT="${SCRIPT_DIR}/.."
+export TEST_DIR="${REPO_ROOT}/tests"
+
+export EOSIO_MIN_VERSION_MAJOR=$(cat $TEST_DIR/CMakeLists.txt | grep -E "^[[:blank:]]*set[[:blank:]]*\([[:blank:]]*EOSIO_VERSION_MIN" | tail -1 | sed 's/.*EOSIO_VERSION_MIN //g' | sed 's/ //g' | sed 's/"//g' | cut -d\) -f1 | cut -f1 -d '.')
+export EOSIO_MIN_VERSION_MINOR=$(cat $TEST_DIR/CMakeLists.txt | grep -E "^[[:blank:]]*set[[:blank:]]*\([[:blank:]]*EOSIO_VERSION_MIN" | tail -1 | sed 's/.*EOSIO_VERSION_MIN //g' | sed 's/ //g' | sed 's/"//g' | cut -d\) -f1 | cut -f2 -d '.')
+export EOSIO_SOFT_MAX_MAJOR=$(cat $TEST_DIR/CMakeLists.txt | grep -E "^[[:blank:]]*set[[:blank:]]*\([[:blank:]]*EOSIO_VERSION_SOFT_MAX" | tail -1 | sed 's/.*EOSIO_VERSION_SOFT_MAX //g' | sed 's/ //g' | sed 's/"//g' | cut -d\) -f1 | cut -f1 -d '.')
+export EOSIO_SOFT_MAX_MINOR=$(cat $TEST_DIR/CMakeLists.txt | grep -E "^[[:blank:]]*set[[:blank:]]*\([[:blank:]]*EOSIO_VERSION_SOFT_MAX" | tail -1 | sed 's/.*EOSIO_VERSION_SOFT_MAX //g' | sed 's/ //g' | sed 's/"//g' | cut -d\) -f1 | cut -f2 -d '.')
+export EOSIO_MAX_VERSION=$(cat $TEST_DIR/CMakeLists.txt | grep -E "^[[:blank:]]*set[[:blank:]]*\([[:blank:]]*EOSIO_VERSION_HARD_MAX" | tail -1 | sed 's/.*EOSIO_VERSION_HARD_MAX //g' | sed 's/ //g' | sed 's/"//g' | cut -d\) -f1)
+export EOSIO_MAX_VERSION="${EOSIO_MAX_VERSION:-$(echo $EOSIO_SOFT_MAX_MAJOR.999)}"
+export EOSIO_MAX_VERSION_MAJOR=$(echo $EOSIO_MAX_VERSION | cut -f1 -d '.')
+export EOSIO_MAX_VERSION_MINOR=$(echo $EOSIO_MAX_VERSION | cut -f2 -d '.')

--- a/scripts/helper.sh
+++ b/scripts/helper.sh
@@ -1,0 +1,135 @@
+# Ensures passed in version values are supported.
+function check-version-numbers() {
+  CHECK_VERSION_MAJOR=$1
+  CHECK_VERSION_MINOR=$2
+
+  if [[ $CHECK_VERSION_MAJOR -lt $EOSIO_MIN_VERSION_MAJOR ]]; then
+    exit 1
+  fi
+  if [[ $CHECK_VERSION_MAJOR -gt $EOSIO_MAX_VERSION_MAJOR ]]; then
+    exit 1
+  fi
+  if [[ $CHECK_VERSION_MAJOR -eq $EOSIO_MIN_VERSION_MAJOR ]]; then 
+    if [[ $CHECK_VERSION_MINOR -lt $EOSIO_MIN_VERSION_MINOR ]]; then
+      exit 1
+    fi
+  fi
+  if [[ $CHECK_VERSION_MAJOR -eq $EOSIO_MAX_VERSION_MAJOR ]]; then 
+    if [[ $CHECK_VERSION_MINOR -gt $EOSIO_MAX_VERSION_MINOR ]]; then
+      exit 1
+    fi
+  fi
+  exit 0
+}
+
+
+# Handles choosing which EOSIO directory to select when the default location is used.
+function default-eosio-directories() {
+  REGEX='^[0-9]+([.][0-9]+)?$'
+  ALL_EOSIO_SUBDIRS=($(ls ${HOME}/eosio | sort -V))
+  for ITEM in "${ALL_EOSIO_SUBDIRS[@]}"; do
+    if [[ "$ITEM" =~ $REGEX ]]; then
+      DIR_MAJOR=$(echo $ITEM | cut -f1 -d '.')
+      DIR_MINOR=$(echo $ITEM | cut -f2 -d '.')
+      if $(check-version-numbers $DIR_MAJOR $DIR_MINOR); then
+        PROMPT_EOSIO_DIRS+=($ITEM)
+      fi
+    fi
+  done
+  for ITEM in "${PROMPT_EOSIO_DIRS[@]}"; do
+    if [[ "$ITEM" =~ $REGEX ]]; then
+      EOSIO_VERSION=$ITEM
+    fi
+  done
+}
+
+
+# Prompts or sets default behavior for choosing EOSIO directory.
+function eosio-directory-prompt() {
+  if [[ -z $EOSIO_DIR_PROMPT ]]; then
+    default-eosio-directories;
+    echo 'No EOSIO location was specified.'
+    while true; do
+      if [[ $NONINTERACTIVE != true ]]; then
+        if [[ -z $EOSIO_VERSION ]]; then
+          echo "No default EOSIO installations detected..."
+          PROCEED=n
+        else
+          printf "Is EOSIO installed in the default location: $HOME/eosio/$EOSIO_VERSION (y/n)" && read -p " " PROCEED
+        fi
+      fi
+      echo ""
+      case $PROCEED in
+        "" )
+          echo "Is EOSIO installed in the default location?";;
+        0 | true | [Yy]* )
+          break;;
+        1 | false | [Nn]* )
+          if [[ $PROMPT_EOSIO_DIRS ]]; then
+            echo "Found these compatible EOSIO versions in the default location."
+            printf "$HOME/eosio/%s\n" "${PROMPT_EOSIO_DIRS[@]}"
+          fi
+          printf "Enter the installation location of EOSIO:" && read -e -p " " EOSIO_DIR_PROMPT;
+          break;;
+        * )
+          echo "Please type 'y' for yes or 'n' for no.";;
+      esac
+    done
+  fi
+  export EOSIO_INSTALL_DIR="${EOSIO_DIR_PROMPT:-${HOME}/eosio/${EOSIO_VERSION}}"
+}
+
+
+# Prompts or default behavior for choosing EOSIO.CDT directory.
+function cdt-directory-prompt() {
+  if [[ -z $CDT_DIR_PROMPT ]]; then
+    echo 'No EOSIO.CDT location was specified.'
+    while true; do
+      if [[ $NONINTERACTIVE != true ]]; then
+        printf "Is EOSIO.CDT installed in the default location? /usr/local/eosio.cdt (y/n)" && read -p " " PROCEED
+      fi
+      echo ""
+      case $PROCEED in
+        "" )
+          echo "Is EOSIO.CDT installed in the default location?";;
+        0 | true | [Yy]* )
+          break;;
+        1 | false | [Nn]* )
+          printf "Enter the installation location of EOSIO.CDT:" && read -e -p " " CDT_DIR_PROMPT;
+          break;;
+        * )
+          echo "Please type 'y' for yes or 'n' for no.";;
+      esac
+    done
+  fi
+  export CDT_INSTALL_DIR="${CDT_DIR_PROMPT:-/usr/local/eosio.cdt}"
+}
+
+
+# Ensures EOSIO is installed and compatible via version listed in tests/CMakeLists.txt.
+function nodeos-version-check() {
+  INSTALLED_VERSION=$(echo $($EOSIO_INSTALL_DIR/bin/nodeos --version))
+  INSTALLED_VERSION_MAJOR=$(echo $INSTALLED_VERSION | cut -f1 -d '.' | sed 's/v//g')
+  INSTALLED_VERSION_MINOR=$(echo $INSTALLED_VERSION | cut -f2 -d '.' | sed 's/v//g')
+
+  if [[ -z $INSTALLED_VERSION_MAJOR || -z $INSTALLED_VERSION_MINOR ]]; then
+    echo "Could not determine EOSIO version. Exiting..."
+    exit 1;
+  fi
+
+  if $(check-version-numbers $INSTALLED_VERSION_MAJOR $INSTALLED_VERSION_MINOR); then
+    if [[ $INSTALLED_VERSION_MAJOR -gt $EOSIO_SOFT_MAX_MAJOR ]]; then
+      echo "Detected EOSIO version is greater than recommended soft max: $EOSIO_SOFT_MAX_MAJOR.$EOSIO_SOFT_MAX_MINOR. Proceed with caution."
+    fi
+    if [[ $INSTALLED_VERSION_MAJOR -eq $EOSIO_SOFT_MAX_MAJOR && $INSTALLED_VERSION_MINOR -gt $EOSIO_SOFT_MAX_MINOR ]]; then
+      echo "Detected EOSIO version is greater than recommended soft max: $EOSIO_SOFT_MAX_MAJOR.$EOSIO_SOFT_MAX_MINOR. Proceed with caution."
+    fi
+    echo "Using EOSIO installation at: $EOSIO_INSTALL_DIR"
+    echo "Using EOSIO.CDT installation at: $CDT_INSTALL_DIR"
+  else
+    echo "Supported versions are: $EOSIO_MIN_VERSION_MAJOR.$EOSIO_MIN_VERSION_MINOR - $EOSIO_MAX_VERSION_MAJOR.$EOSIO_MAX_VERSION_MINOR"
+    echo "Invalid EOSIO installation. Exiting..."
+    exit 1;
+  fi
+  export CMAKE_FRAMEWORK_PATH="${EOSIO_INSTALL_DIR}:${CDT_INSTALL_DIR}:${CMAKE_PREFIX_PATH}"
+}


### PR DESCRIPTION
<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->

## Change Description
Adjustments have been made to the eosio.contract build script, build.sh, to support prompt user input for eosio and eosio.cdt installation directories. Flags are now supported and may be passed to the build script to support a non-interactive mode (accepting all default locations and actions) or to supply custom locations at runtime, without input.

Additionally, docker/buildContracts.sh has been updated to use the new flags, supplying non-interactive mode and the expected location of eosio and eosio.cdt.

**NOTE**: This is an implementation of #259 for the release/1.7.x branch.