### PR TITLE
fix assertion in create_core_token; clean up inconsistent license references; fix README links - v1.6.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,15 +6,16 @@ The design of the EOSIO blockchain calls for a number of smart contracts that ar
 
 This repository contains examples of these privileged contracts that are useful when deploying, managing, and/or using an EOSIO blockchain.  They are provided for reference purposes:
 
-   * [eosio.system](https://github.com/eosio/eosio.contracts/tree/master/eosio.system)
-   * [eosio.msig](https://github.com/eosio/eosio.contracts/tree/master/eosio.msig)
-   * [eosio.wrap](https://github.com/eosio/eosio.contracts/tree/master/eosio.wrap)
+   * [eosio.bios](./contracts/eosio.bios)
+   * [eosio.system](./contracts/eosio.system)
+   * [eosio.msig](./contracts/eosio.msig)
+   * [eosio.wrap](./contracts/eosio.wrap)
 
 The following unprivileged contract(s) are also part of the system.
-   * [eosio.token](https://github.com/eosio/eosio.contracts/tree/master/eosio.token)
+   * [eosio.token](./contracts/eosio.token)
 
 Dependencies:
-* [eosio v1.7.x](https://github.com/EOSIO/eos/releases/tag/v1.7.0)
+* [eosio v1.7.x](https://github.com/EOSIO/eos/releases/tag/v1.7.4)
 * [eosio.cdt v1.5.x](https://github.com/EOSIO/eosio.cdt/releases/tag/v1.5.0)
 
 To build the contracts and the unit tests:

--- a/contracts/eosio.system/include/eosio.system/eosio.system.hpp
+++ b/contracts/eosio.system/include/eosio.system/eosio.system.hpp
@@ -1,7 +1,3 @@
-/**
- *  @file
- *  @copyright defined in eos/LICENSE.txt
- */
 #pragma once
 
 #include <eosio.system/native.hpp>
@@ -481,10 +477,10 @@ namespace eosiosystem {
           */
          [[eosio::action]]
          void mvtosavings( const name& owner, const asset& rex );
-         
+
          /**
           * Moves a specified amount of REX out of savings bucket. The moved amount
-          * will have the regular REX maturity period of 4 days.  
+          * will have the regular REX maturity period of 4 days.
           */
          [[eosio::action]]
          void mvfrsavings( const name& owner, const asset& rex );

--- a/contracts/eosio.system/include/eosio.system/native.hpp
+++ b/contracts/eosio.system/include/eosio.system/native.hpp
@@ -1,7 +1,3 @@
-/**
- *  @file
- *  @copyright defined in eos/LICENSE.txt
- */
 #pragma once
 
 #include <eosiolib/action.hpp>

--- a/contracts/eosio.system/src/delegate_bandwidth.cpp
+++ b/contracts/eosio.system/src/delegate_bandwidth.cpp
@@ -1,7 +1,3 @@
-/**
- *  @file
- *  @copyright defined in eos/LICENSE.txt
- */
 #include <eosio.system/eosio.system.hpp>
 
 #include <eosiolib/eosio.hpp>
@@ -134,7 +130,7 @@ namespace eosiosystem {
          );
          channel_to_rex( ramfee_account, fee );
       }
-      
+
       int64_t bytes_out;
 
       const auto& market = _rammarket.get(ramcore_symbol.raw(), "ram market does not exist");

--- a/contracts/eosio.system/src/rex.cpp
+++ b/contracts/eosio.system/src/rex.cpp
@@ -1,7 +1,3 @@
-/**
- *  @copyright defined in eos/LICENSE.txt
- */
-
 #include <eosio.system/eosio.system.hpp>
 #include <eosio.system/rex.results.hpp>
 
@@ -66,7 +62,7 @@ namespace eosiosystem {
       const asset delta_rex_stake = add_to_rex_balance( from, amount, rex_received );
       runrex(2);
       update_rex_account( from, asset( 0, core_symbol() ), delta_rex_stake );
-      // dummy action added so that amount of REX tokens purchased shows up in action trace 
+      // dummy action added so that amount of REX tokens purchased shows up in action trace
       rex_results::buyresult_action buyrex_act( rex_account, std::vector<eosio::permission_level>{ } );
       buyrex_act.send( rex_received );
    }
@@ -373,7 +369,7 @@ namespace eosiosystem {
    }
 
    /**
-    * @brief Moves a specified amount of REX to savings bucket 
+    * @brief Moves a specified amount of REX to savings bucket
     *
     * @param owner - account name of REX owner
     * @param rex - amount of REX to be moved
@@ -679,11 +675,11 @@ namespace eosiosystem {
                                                     pool->total_unlent.amount,
                                                     itr->payment.amount );
          /// conditions for loan renewal
-         bool renew_loan = itr->payment <= itr->balance        /// loan has sufficient balance 
-                        && itr->payment.amount < rented_tokens /// loan has favorable return 
+         bool renew_loan = itr->payment <= itr->balance        /// loan has sufficient balance
+                        && itr->payment.amount < rented_tokens /// loan has favorable return
                         && rex_loans_available();              /// no pending sell orders
          if ( renew_loan ) {
-            /// update rex_pool in order to account for renewed loan 
+            /// update rex_pool in order to account for renewed loan
             add_loan_to_rex_pool( itr->payment, rented_tokens, false );
             /// update renewed loan fields
             delta_stake = update_renewed_loan( idx, itr, rented_tokens );
@@ -1162,7 +1158,7 @@ namespace eosiosystem {
     * @brief Reads amount of REX in savings bucket and removes the bucket from maturities
     *
     * Reads and (temporarily) removes REX savings bucket from REX maturities in order to
-    * allow uniform processing of remaining buckets as savings is a special case. This 
+    * allow uniform processing of remaining buckets as savings is a special case. This
     * function is used in conjunction with put_rex_savings.
     *
     * @param bitr - iterator pointing to rex_balance object
@@ -1216,7 +1212,7 @@ namespace eosiosystem {
          current_vote_stake.amount = ( uint128_t(bitr->rex_balance.amount) * _rexpool.begin()->total_lendable.amount )
                                      / _rexpool.begin()->total_rex.amount;
          _rexbalance.modify( bitr, same_payer, [&]( auto& rb ) {
-            rb.vote_stake.amount = current_vote_stake.amount; 
+            rb.vote_stake.amount = current_vote_stake.amount;
          });
          delta_stake = current_vote_stake.amount - init_vote_stake.amount;
       }

--- a/contracts/eosio.system/src/voting.cpp
+++ b/contracts/eosio.system/src/voting.cpp
@@ -1,7 +1,3 @@
-/**
- *  @file
- *  @copyright defined in eos/LICENSE.txt
- */
 #include <eosio.system/eosio.system.hpp>
 
 #include <eosiolib/eosio.hpp>

--- a/contracts/eosio.token/include/eosio.token/eosio.token.hpp
+++ b/contracts/eosio.token/include/eosio.token/eosio.token.hpp
@@ -1,7 +1,3 @@
-/**
- *  @file
- *  @copyright defined in eos/LICENSE.txt
- */
 #pragma once
 
 #include <eosiolib/asset.hpp>

--- a/contracts/eosio.token/src/eosio.token.cpp
+++ b/contracts/eosio.token/src/eosio.token.cpp
@@ -1,8 +1,3 @@
-/**
- *  @file
- *  @copyright defined in eos/LICENSE.txt
- */
-
 #include <eosio.token/eosio.token.hpp>
 
 namespace eosio {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required( VERSION 3.5 )
 
 set(EOSIO_VERSION_MIN "1.6")
 set(EOSIO_VERSION_SOFT_MAX "1.7")
-#set(EOSIO_VERSION_HARD_MAX "")
+set(EOSIO_VERSION_HARD_MAX "1.7")
 
 find_package(eosio)
 

--- a/tests/eosio.system_tester.hpp
+++ b/tests/eosio.system_tester.hpp
@@ -52,7 +52,7 @@ public:
    }
 
    void create_core_token( symbol core_symbol = symbol{CORE_SYM} ) {
-      FC_ASSERT( core_symbol.precision() != 4, "create_core_token assumes precision of core token is 4" );
+      FC_ASSERT( core_symbol.decimals() == 4, "create_core_token assumes core token has 4 digits of precision" );
       create_currency( N(eosio.token), config::system_account_name, asset(100000000000000, core_symbol) );
       issue(config::system_account_name, asset(10000000000000, core_symbol) );
       BOOST_REQUIRE_EQUAL( asset(10000000000000, core_symbol), get_balance( "eosio", core_symbol ) );
@@ -413,7 +413,7 @@ public:
                return proceeds;
             }
          }
-      } 
+      }
       return proceeds;
    }
 
@@ -595,7 +595,7 @@ public:
       vector<char> data = get_row_by_account( config::system_account_name, from, N(delband), receiver );
       return data.empty() ? fc::variant() : abi_ser.binary_to_variant("delegated_bandwidth", data, abi_serializer_max_time);
    }
-      
+
    asset get_rex_balance( const account_name& act ) const {
       vector<char> data = get_row_by_account( config::system_account_name, config::system_account_name, N(rexbal), act );
       return data.empty() ? asset(0, symbol(SY(4, REX))) : abi_ser.binary_to_variant("rex_balance", data, abi_serializer_max_time)["rex_balance"].as<asset>();

--- a/tests/eosio.system_tester.hpp
+++ b/tests/eosio.system_tester.hpp
@@ -1,7 +1,3 @@
-/**
- *  @file
- *  @copyright defined in eos/LICENSE.txt
- */
 #pragma once
 
 #include <eosio/testing/tester.hpp>


### PR DESCRIPTION
## Change Description

Fix wrong assertion in `create_core_token` (adapted from #189).

Cleanup extraneous and inconsistent license references.

Fix links in README.

Set hard max of 1.7 for EOSIO dependency.


## Deployment Changes
- [ ] Deployment Changes

## API Changes
- [ ] API Changes

## Documentation Additions
- [ ] Documentation Additions

