### PR TITLE
remove unnecessary EOSIO_DISPATCH macros; add action wrappers for activate and reqactivated actions - develop

### DIFF
--- a/contracts/eosio.bios/include/eosio.bios/eosio.bios.hpp
+++ b/contracts/eosio.bios/include/eosio.bios/eosio.bios.hpp
@@ -294,6 +294,19 @@ namespace eosio {
          /** @}*/
 
          /**
+          * Set abi for contract.
+          *
+          * @details Set the abi for contract identified by `account` name. Creates an entry in the abi_hash_table
+          * index, with `account` name as key, if it is not already present and sets its value with the abi hash.
+          * Otherwise it is updating the current abi hash value for the existing `account` key.
+          *
+          * @param account - the name of the account to set the abi for
+          * @param abi     - the abi hash represented as a vector of characters
+          */
+         [[eosio::action]]
+         void setabi( name account, const std::vector<char>& abi );
+
+         /**
           * Set privilege status for an account.
           *
           * @details Allows to set privilege status for an account (turn it on/off).
@@ -301,10 +314,7 @@ namespace eosio {
           * @param is_priv - 0 for false, > 0 for true.
           */
          [[eosio::action]]
-         void setpriv( name account, uint8_t is_priv ) {
-            require_auth( _self );
-            set_privileged( account, is_priv );
-         }
+         void setpriv( name account, uint8_t is_priv );
 
          /**
           * Set the resource limits of an account
@@ -317,10 +327,7 @@ namespace eosio {
           * @param cpu_weight - fractionally proportionate cpu limit of available resources based on (weight / total_weight_of_all_accounts)
           */
          [[eosio::action]]
-         void setalimits( name account, int64_t ram_bytes, int64_t net_weight, int64_t cpu_weight ) {
-            require_auth( _self );
-            set_resource_limits( account, ram_bytes, net_weight, cpu_weight );
-         }
+         void setalimits( name account, int64_t ram_bytes, int64_t net_weight, int64_t cpu_weight );
 
          /**
           * Set a new list of active producers, that is, a new producers' schedule.
@@ -333,10 +340,7 @@ namespace eosio {
           * @param schedule - New list of active producers to set
           */
          [[eosio::action]]
-         void setprods( std::vector<eosio::producer_key> schedule ) {
-            require_auth( _self );
-            set_proposed_producers( schedule );
-         }
+         void setprods( std::vector<eosio::producer_key> schedule );
 
          /**
           * Set the blockchain parameters
@@ -346,10 +350,7 @@ namespace eosio {
           * @param params - New blockchain parameters to set
           */
          [[eosio::action]]
-         void setparams( const eosio::blockchain_parameters& params ) {
-            require_auth( _self );
-            set_blockchain_parameters( params );
-         }
+         void setparams( const eosio::blockchain_parameters& params );
 
          /**
           * Check if an account has authorization to access current action.
@@ -360,9 +361,7 @@ namespace eosio {
           * @param from - the account name to authorize
           */
          [[eosio::action]]
-         void reqauth( name from ) {
-            require_auth( from );
-         }
+         void reqauth( name from );
 
          /**
           * Activates a protocol feature.
@@ -372,10 +371,7 @@ namespace eosio {
           * @param feature_digest - hash of the protocol feature to activate.
           */
          [[eosio::action]]
-         void activate( const eosio::checksum256& feature_digest ) {
-            require_auth( get_self() );
-            preactivate_feature( feature_digest );
-         }
+         void activate( const eosio::checksum256& feature_digest );
 
          /**
           * Asserts that a protocol feature has been activated.
@@ -385,35 +381,7 @@ namespace eosio {
           * @param feature_digest - hash of the protocol feature to check for activation.
           */
          [[eosio::action]]
-         void reqactivated( const eosio::checksum256& feature_digest ) {
-            check( is_feature_activated( feature_digest ), "protocol feature is not activated" );
-         }
-
-         /**
-          * Set abi for contract.
-          *
-          * @details Set the abi for contract identified by `account` name. Creates an entry in the abi_hash_table
-          * index, with `account` name as key, if it is not already present and sets its value with the abi hash.
-          * Otherwise it is updating the current abi hash value for the existing `account` key.
-          *
-          * @param account - the name of the account to set the abi for
-          * @param abi     - the abi hash represented as a vector of characters
-          */
-         [[eosio::action]]
-         void setabi( name account, const std::vector<char>& abi ) {
-            abi_hash_table table(_self, _self.value);
-            auto itr = table.find( account.value );
-            if( itr == table.end() ) {
-               table.emplace( account, [&]( auto& row ) {
-                  row.owner = account;
-                  row.hash  = sha256(const_cast<char*>(abi.data()), abi.size());
-               });
-            } else {
-               table.modify( itr, same_payer, [&]( auto& row ) {
-                  row.hash = sha256(const_cast<char*>(abi.data()), abi.size());
-               });
-            }
-         }
+         void reqactivated( const eosio::checksum256& feature_digest );
 
          /**
           * Abi hash structure
@@ -440,12 +408,14 @@ namespace eosio {
          using unlinkauth_action = action_wrapper<"unlinkauth"_n, &bios::unlinkauth>;
          using canceldelay_action = action_wrapper<"canceldelay"_n, &bios::canceldelay>;
          using setcode_action = action_wrapper<"setcode"_n, &bios::setcode>;
+         using setabi_action = action_wrapper<"setabi"_n, &bios::setabi>;
          using setpriv_action = action_wrapper<"setpriv"_n, &bios::setpriv>;
          using setalimits_action = action_wrapper<"setalimits"_n, &bios::setalimits>;
          using setprods_action = action_wrapper<"setprods"_n, &bios::setprods>;
          using setparams_action = action_wrapper<"setparams"_n, &bios::setparams>;
          using reqauth_action = action_wrapper<"reqauth"_n, &bios::reqauth>;
-         using setabi_action = action_wrapper<"setabi"_n, &bios::setabi>;
+         using activate_action = action_wrapper<"activate"_n, &bios::activate>;
+         using reqactivated_action = action_wrapper<"reqactivated"_n, &bios::reqactivated>;
    };
    /** @}*/ // end of @defgroup eosiobios eosio.bios
 } /// namespace eosio

--- a/contracts/eosio.bios/include/eosio.bios/eosio.bios.hpp
+++ b/contracts/eosio.bios/include/eosio.bios/eosio.bios.hpp
@@ -268,17 +268,6 @@ namespace eosio {
          void canceldelay( ignore<permission_level> canceling_auth, ignore<checksum256> trx_id ) {}
 
          /**
-          * On error action.
-          *
-          * @details Called every time an error occurs while a transaction was processed.
-          *
-          * @param sender_id - the id of the sender,
-          * @param sent_trx - the transaction that failed.
-          */
-         [[eosio::action]]
-         void onerror( ignore<uint128_t> sender_id, ignore<std::vector<char>> sent_trx ) {}
-
-         /**
           * Set code action.
           *
           * @details Sets the contract code for an account.
@@ -305,6 +294,19 @@ namespace eosio {
           */
          [[eosio::action]]
          void setabi( name account, const std::vector<char>& abi );
+
+         /**
+          * On error action.
+          *
+          * @details Notification of this action is delivered to the sender of a deferred transaction
+          * when an objective error occurs while executing the deferred transaction.
+          * This action is not meant to be called directly.
+          *
+          * @param sender_id - the id for the deferred transaction chosen by the sender,
+          * @param sent_trx - the deferred transaction that failed.
+          */
+         [[eosio::action]]
+         void onerror( ignore<uint128_t> sender_id, ignore<std::vector<char>> sent_trx );
 
          /**
           * Set privilege status for an account.

--- a/contracts/eosio.bios/src/eosio.bios.cpp
+++ b/contracts/eosio.bios/src/eosio.bios.cpp
@@ -1,3 +1,53 @@
 #include <eosio.bios/eosio.bios.hpp>
 
-EOSIO_DISPATCH( eosio::bios, (setpriv)(setalimits)(setprods)(setparams)(reqauth)(setabi)(activate)(reqactivated) )
+namespace eosio {
+
+void bios::setabi( name account, const std::vector<char>& abi ) {
+   abi_hash_table table(_self, _self.value);
+   auto itr = table.find( account.value );
+   if( itr == table.end() ) {
+      table.emplace( account, [&]( auto& row ) {
+         row.owner = account;
+         row.hash  = sha256(const_cast<char*>(abi.data()), abi.size());
+      });
+   } else {
+      table.modify( itr, same_payer, [&]( auto& row ) {
+         row.hash = sha256(const_cast<char*>(abi.data()), abi.size());
+      });
+   }
+}
+
+void bios::setpriv( name account, uint8_t is_priv ) {
+   require_auth( _self );
+   set_privileged( account, is_priv );
+}
+
+void bios::setalimits( name account, int64_t ram_bytes, int64_t net_weight, int64_t cpu_weight ) {
+   require_auth( _self );
+   set_resource_limits( account, ram_bytes, net_weight, cpu_weight );
+}
+
+void bios::setprods( std::vector<eosio::producer_key> schedule ) {
+   require_auth( _self );
+   set_proposed_producers( schedule );
+}
+
+void bios::setparams( const eosio::blockchain_parameters& params ) {
+   require_auth( _self );
+   set_blockchain_parameters( params );
+}
+
+void bios::reqauth( name from ) {
+   require_auth( from );
+}
+
+void bios::activate( const eosio::checksum256& feature_digest ) {
+   require_auth( get_self() );
+   preactivate_feature( feature_digest );
+}
+
+void bios::reqactivated( const eosio::checksum256& feature_digest ) {
+   check( is_feature_activated( feature_digest ), "protocol feature is not activated" );
+}
+
+}

--- a/contracts/eosio.bios/src/eosio.bios.cpp
+++ b/contracts/eosio.bios/src/eosio.bios.cpp
@@ -17,6 +17,10 @@ void bios::setabi( name account, const std::vector<char>& abi ) {
    }
 }
 
+void bios::onerror( ignore<uint128_t>, ignore<std::vector<char>> ) {
+   check( false, "the onerror action cannot be called directly" );
+}
+
 void bios::setpriv( name account, uint8_t is_priv ) {
    require_auth( _self );
    set_privileged( account, is_priv );

--- a/contracts/eosio.msig/src/eosio.msig.cpp
+++ b/contracts/eosio.msig/src/eosio.msig.cpp
@@ -207,5 +207,3 @@ void multisig::invalidate( name account ) {
 }
 
 } /// namespace eosio
-
-EOSIO_DISPATCH( eosio::multisig, (propose)(approve)(unapprove)(cancel)(exec)(invalidate) )

--- a/contracts/eosio.system/include/eosio.system/eosio.system.hpp
+++ b/contracts/eosio.system/include/eosio.system/eosio.system.hpp
@@ -1224,6 +1224,7 @@ namespace eosiosystem {
          using setacctram_action = eosio::action_wrapper<"setacctram"_n, &system_contract::setacctram>;
          using setacctnet_action = eosio::action_wrapper<"setacctnet"_n, &system_contract::setacctnet>;
          using setacctcpu_action = eosio::action_wrapper<"setacctcpu"_n, &system_contract::setacctcpu>;
+         using activate_action = eosio::action_wrapper<"activate"_n, &system_contract::activate>;
          using delegatebw_action = eosio::action_wrapper<"delegatebw"_n, &system_contract::delegatebw>;
          using deposit_action = eosio::action_wrapper<"deposit"_n, &system_contract::deposit>;
          using withdraw_action = eosio::action_wrapper<"withdraw"_n, &system_contract::withdraw>;
@@ -1240,21 +1241,7 @@ namespace eosiosystem {
          using updaterex_action = eosio::action_wrapper<"updaterex"_n, &system_contract::updaterex>;
          using rexexec_action = eosio::action_wrapper<"rexexec"_n, &system_contract::rexexec>;
          using setrex_action = eosio::action_wrapper<"setrex"_n, &system_contract::setrex>;
-         /**
-          * Move to savings action.
-          *
-          * @details Moves a specified amount of REX to savings bucket.
-          * @param owner - account name of REX owner
-          * @param rex - amount of REX to be moved
-          */
          using mvtosavings_action = eosio::action_wrapper<"mvtosavings"_n, &system_contract::mvtosavings>;
-         /**
-          * Move from savings action.
-          *
-          * @details Moves a specified amount of REX from savings bucket
-          * @param owner - account name of REX owner
-          * @param rex - amount of REX to be moved
-          */
          using mvfrsavings_action = eosio::action_wrapper<"mvfrsavings"_n, &system_contract::mvfrsavings>;
          using consolidate_action = eosio::action_wrapper<"consolidate"_n, &system_contract::consolidate>;
          using closerex_action = eosio::action_wrapper<"closerex"_n, &system_contract::closerex>;
@@ -1270,7 +1257,6 @@ namespace eosiosystem {
          using voteproducer_action = eosio::action_wrapper<"voteproducer"_n, &system_contract::voteproducer>;
          using regproxy_action = eosio::action_wrapper<"regproxy"_n, &system_contract::regproxy>;
          using claimrewards_action = eosio::action_wrapper<"claimrewards"_n, &system_contract::claimrewards>;
-
          using rmvproducer_action = eosio::action_wrapper<"rmvproducer"_n, &system_contract::rmvproducer>;
          using updtrevision_action = eosio::action_wrapper<"updtrevision"_n, &system_contract::updtrevision>;
          using bidname_action = eosio::action_wrapper<"bidname"_n, &system_contract::bidname>;

--- a/contracts/eosio.system/include/eosio.system/native.hpp
+++ b/contracts/eosio.system/include/eosio.system/native.hpp
@@ -272,13 +272,17 @@ namespace eosiosystem {
          /**
           * On error action.
           *
-          * @details Called every time an error occurs while a transaction was processed.
+          * @details Notification of this action is delivered to the sender of a deferred transaction
+          * when an objective error occurs while executing the deferred transaction.
+          * This action is not meant to be called directly.
           *
-          * @param sender_id - the id of the sender,
-          * @param sent_trx - the transaction that failed.
+          * @param sender_id - the id for the deferred transaction chosen by the sender,
+          * @param sent_trx - the deferred transaction that failed.
           */
          [[eosio::action]]
-         void onerror( ignore<uint128_t> sender_id, ignore<std::vector<char>> sent_trx ) {}
+         void onerror( ignore<uint128_t> sender_id, ignore<std::vector<char>> sent_trx ) {
+            eosio::check( false, "the onerror action cannot be called directly" );
+         }
 
          /**
           * Set abi action.

--- a/contracts/eosio.system/src/eosio.system.cpp
+++ b/contracts/eosio.system/src/eosio.system.cpp
@@ -468,21 +468,3 @@ namespace eosiosystem {
    }
 
 } /// eosio.system
-
-
-EOSIO_DISPATCH( eosiosystem::system_contract,
-     // native.hpp (newaccount definition is actually in eosio.system.cpp)
-     (newaccount)(updateauth)(deleteauth)(linkauth)(unlinkauth)(canceldelay)(onerror)(setabi)
-     // eosio.system.cpp
-     (init)(setram)(setramrate)(setparams)(setpriv)(setalimits)(setacctram)(setacctnet)(setacctcpu)(activate)
-     (rmvproducer)(updtrevision)(bidname)(bidrefund)(setinflation)
-     // rex.cpp
-     (deposit)(withdraw)(buyrex)(unstaketorex)(sellrex)(cnclrexorder)(rentcpu)(rentnet)(fundcpuloan)(fundnetloan)
-     (defcpuloan)(defnetloan)(updaterex)(consolidate)(mvtosavings)(mvfrsavings)(setrex)(rexexec)(closerex)
-     // delegate_bandwidth.cpp
-     (buyrambytes)(buyram)(sellram)(delegatebw)(undelegatebw)(refund)
-     // voting.cpp
-     (regproducer)(unregprod)(voteproducer)(regproxy)
-     // producer_pay.cpp
-     (onblock)(claimrewards)
-)

--- a/contracts/eosio.token/src/eosio.token.cpp
+++ b/contracts/eosio.token/src/eosio.token.cpp
@@ -156,5 +156,3 @@ void token::close( const name& owner, const symbol& symbol )
 }
 
 } /// namespace eosio
-
-EOSIO_DISPATCH( eosio::token, (create)(issue)(transfer)(open)(close)(retire) )

--- a/contracts/eosio.wrap/src/eosio.wrap.cpp
+++ b/contracts/eosio.wrap/src/eosio.wrap.cpp
@@ -14,5 +14,3 @@ void wrap::exec( ignore<name>, ignore<transaction> ) {
 }
 
 } /// namespace eosio
-
-EOSIO_DISPATCH( eosio::wrap, (exec) )


### PR DESCRIPTION
## Change Description

Add action wrappers for the `activate` and `reqactivated` actions.

Remove unnecessary EOSIO_DISPATCH macros so that the automatic code generation introduced in eosio.cdt v1.6.x can be used instead.

Due to the use of the code generator, `eosio::onerror` notifications will now automatically be rejected by these contracts. That means if any deferred transactions sent by the eosio.system, eosio.msig, or eosio.wrap contracts fail, they would now retire with a status of `hard_fail` rather than `soft_fail` and the CPU and NET usage of that transaction would be billed to the authorizers of the deferred transaction rather than the sending contract.

Furthermore, this PR also disallows directly calling the onerror action in both the eosio.system and eosio.bios contracts. Before this change, it would just accept the action even though the action does nothing and was never meant to be called directly.

## Deployment Changes
- [ ] Deployment Changes

## API Changes
- [ ] API Changes

## Documentation Additions
- [ ] Documentation Additions

