### PR TITLE
update contracts to work with new CDT headers - 1.7

### DIFF
--- a/contracts/eosio.bios/include/eosio.bios/eosio.bios.hpp
+++ b/contracts/eosio.bios/include/eosio.bios/eosio.bios.hpp
@@ -1,10 +1,14 @@
 #pragma once
-#include <eosiolib/action.hpp>
-#include <eosiolib/crypto.h>
-#include <eosiolib/eosio.hpp>
-#include <eosiolib/privileged.hpp>
-#include <eosiolib/producer_schedule.hpp>
-#include <eosiolib/fixed_bytes.hpp>
+
+#include <eosio/action.hpp>
+#include <eosio/crypto.hpp>
+#include <eosio/eosio.hpp>
+#include <eosio/fixed_bytes.hpp>
+#include <eosio/privileged.hpp>
+#include <eosio/producer_schedule.hpp>
+
+// This header is needed until `is_feature_activated` and `preactivate_feature` are added to `eosio.cdt`
+#include <eosio/../../capi/eosio/crypto.h>
 
 namespace eosio {
    namespace internal_use_do_not_use {
@@ -55,9 +59,9 @@ namespace eosio {
 
 namespace eosio {
 
+   using eosio::ignore;
    using eosio::permission_level;
    using eosio::public_key;
-   using eosio::ignore;
 
    /**
     * A weighted permission.
@@ -137,9 +141,9 @@ namespace eosio {
       uint32_t                                  timestamp;
       name                                      producer;
       uint16_t                                  confirmed = 0;
-      capi_checksum256                          previous;
-      capi_checksum256                          transaction_mroot;
-      capi_checksum256                          action_mroot;
+      checksum256                               previous;
+      checksum256                               transaction_mroot;
+      checksum256                               action_mroot;
       uint32_t                                  schedule_version = 0;
       std::optional<eosio::producer_schedule>   new_producers;
 
@@ -261,7 +265,7 @@ namespace eosio {
           * @param trx_id - the deferred transaction id to be cancelled.
           */
          [[eosio::action]]
-         void canceldelay( ignore<permission_level> canceling_auth, ignore<capi_checksum256> trx_id ) {}
+         void canceldelay( ignore<permission_level> canceling_auth, ignore<checksum256> trx_id ) {}
 
          /**
           * Set code action.
@@ -388,7 +392,7 @@ namespace eosio {
           */
          struct [[eosio::table]] abi_hash {
             name              owner;
-            capi_checksum256  hash;
+            checksum256       hash;
             uint64_t primary_key()const { return owner.value; }
 
             EOSLIB_SERIALIZE( abi_hash, (owner)(hash) )

--- a/contracts/eosio.bios/src/eosio.bios.cpp
+++ b/contracts/eosio.bios/src/eosio.bios.cpp
@@ -3,7 +3,7 @@
 namespace eosio {
 
 void bios::setabi( name account, const std::vector<char>& abi ) {
-   abi_hash_table table(_self, _self.value);
+   abi_hash_table table(get_self(), get_self().value);
    auto itr = table.find( account.value );
    if( itr == table.end() ) {
       table.emplace( account, [&]( auto& row ) {
@@ -22,22 +22,22 @@ void bios::onerror( ignore<uint128_t>, ignore<std::vector<char>> ) {
 }
 
 void bios::setpriv( name account, uint8_t is_priv ) {
-   require_auth( _self );
+   require_auth( get_self() );
    set_privileged( account, is_priv );
 }
 
 void bios::setalimits( name account, int64_t ram_bytes, int64_t net_weight, int64_t cpu_weight ) {
-   require_auth( _self );
+   require_auth( get_self() );
    set_resource_limits( account, ram_bytes, net_weight, cpu_weight );
 }
 
 void bios::setprods( std::vector<eosio::producer_key> schedule ) {
-   require_auth( _self );
+   require_auth( get_self() );
    set_proposed_producers( schedule );
 }
 
 void bios::setparams( const eosio::blockchain_parameters& params ) {
-   require_auth( _self );
+   require_auth( get_self() );
    set_blockchain_parameters( params );
 }
 

--- a/contracts/eosio.bios/src/eosio.bios.cpp
+++ b/contracts/eosio.bios/src/eosio.bios.cpp
@@ -8,11 +8,11 @@ void bios::setabi( name account, const std::vector<char>& abi ) {
    if( itr == table.end() ) {
       table.emplace( account, [&]( auto& row ) {
          row.owner = account;
-         sha256( const_cast<char*>(abi.data()), abi.size(), &row.hash );
+         row.hash  = sha256(const_cast<char*>(abi.data()), abi.size());
       });
    } else {
       table.modify( itr, same_payer, [&]( auto& row ) {
-         sha256( const_cast<char*>(abi.data()), abi.size(), &row.hash );
+         row.hash = sha256(const_cast<char*>(abi.data()), abi.size());
       });
    }
 }
@@ -23,23 +23,17 @@ void bios::onerror( ignore<uint128_t>, ignore<std::vector<char>> ) {
 
 void bios::setpriv( name account, uint8_t is_priv ) {
    require_auth( _self );
-   set_privileged( account.value, is_priv );
+   set_privileged( account, is_priv );
 }
 
 void bios::setalimits( name account, int64_t ram_bytes, int64_t net_weight, int64_t cpu_weight ) {
    require_auth( _self );
-   set_resource_limits( account.value, ram_bytes, net_weight, cpu_weight );
+   set_resource_limits( account, ram_bytes, net_weight, cpu_weight );
 }
 
 void bios::setprods( std::vector<eosio::producer_key> schedule ) {
-   (void)schedule; // schedule argument just forces the deserialization of the action data into vector<producer_key> (necessary check)
    require_auth( _self );
-
-   constexpr size_t max_stack_buffer_size = 512;
-   size_t size = action_data_size();
-   char* buffer = (char*)( max_stack_buffer_size < size ? malloc(size) : alloca(size) );
-   read_action_data( buffer, size );
-   set_proposed_producers(buffer, size);
+   set_proposed_producers( schedule );
 }
 
 void bios::setparams( const eosio::blockchain_parameters& params ) {

--- a/contracts/eosio.msig/include/eosio.msig/eosio.msig.hpp
+++ b/contracts/eosio.msig/include/eosio.msig/eosio.msig.hpp
@@ -1,7 +1,9 @@
 #pragma once
-#include <eosiolib/eosio.hpp>
-#include <eosiolib/ignore.hpp>
-#include <eosiolib/transaction.hpp>
+
+#include <eosio/binary_extension.hpp>
+#include <eosio/eosio.hpp>
+#include <eosio/ignore.hpp>
+#include <eosio/transaction.hpp>
 
 namespace eosio {
    /**
@@ -16,18 +18,18 @@ namespace eosio {
 
          /**
           * Create proposal
-          * 
+          *
           * @details Creates a proposal containing one transaction.
           * Allows an account `proposer` to make a proposal `proposal_name` which has `requested`
-          * permission levels expected to approve the proposal, and if approved by all expected 
+          * permission levels expected to approve the proposal, and if approved by all expected
           * permission levels then `trx` transaction can we executed by this proposal.
-          * The `proposer` account is authorized and the `trx` transaction is verified if it was 
-          * authorized by the provided keys and permissions, and if the proposal name doesn’t 
-          * already exist; if all validations pass the `proposal_name` and `trx` trasanction are 
-          * saved in the proposals table and the `requested` permission levels to the 
+          * The `proposer` account is authorized and the `trx` transaction is verified if it was
+          * authorized by the provided keys and permissions, and if the proposal name doesn’t
+          * already exist; if all validations pass the `proposal_name` and `trx` trasanction are
+          * saved in the proposals table and the `requested` permission levels to the
           * approvals table (for the `proposer` context).
           * Storage changes are billed to `proposer`.
-          * 
+          *
           * @param proposer - The account proposing a transaction
           * @param proposal_name - The name of the proposal (should be unique for proposer)
           * @param requested - Permission levels expected to approve the proposal
@@ -38,15 +40,15 @@ namespace eosio {
                ignore<std::vector<permission_level>> requested, ignore<transaction> trx);
          /**
           * Approve proposal
-          * 
+          *
           * @details Approves an existing proposal
           * Allows an account, the owner of `level` permission, to approve a proposal `proposal_name`
-          * proposed by `proposer`. If the proposal's requested approval list contains the `level` 
-          * permission then the `level` permission is moved from internal `requested_approvals` list to 
-          * internal `provided_approvals` list of the proposal, thus persisting the approval for 
+          * proposed by `proposer`. If the proposal's requested approval list contains the `level`
+          * permission then the `level` permission is moved from internal `requested_approvals` list to
+          * internal `provided_approvals` list of the proposal, thus persisting the approval for
           * the `proposal_name` proposal.
           * Storage changes are billed to `proposer`.
-          * 
+          *
           * @param proposer - The account proposing a transaction
           * @param proposal_name - The name of the proposal (should be unique for proposer)
           * @param level - Permission level approving the transaction
@@ -57,12 +59,12 @@ namespace eosio {
                        const eosio::binary_extension<eosio::checksum256>& proposal_hash );
          /**
           * Revoke proposal
-          * 
+          *
           * @details Revokes an existing proposal
-          * This action is the reverse of the `approve` action: if all validations pass 
-          * the `level` permission is erased from internal `provided_approvals` and added to the internal 
+          * This action is the reverse of the `approve` action: if all validations pass
+          * the `level` permission is erased from internal `provided_approvals` and added to the internal
           * `requested_approvals` list, and thus un-approve or revoke the proposal.
-          * 
+          *
           * @param proposer - The account proposing a transaction
           * @param proposal_name - The name of the proposal (should be an existing proposal)
           * @param level - Permission level revoking approval for proposal
@@ -71,34 +73,34 @@ namespace eosio {
          void unapprove( name proposer, name proposal_name, permission_level level );
          /**
           * Cancel proposal
-          * 
+          *
           * @details Cancels an existing proposal
-          * 
+          *
           * @param proposer - The account proposing a transaction
           * @param proposal_name - The name of the proposal (should be an existing proposal)
           * @param canceler - The account cancelling the proposal (only the proposer can cancel an unexpired transaction, and the canceler has to be different than the proposer)
-          * 
-          * Allows the `canceler` account to cancel the `proposal_name` proposal, created by a `proposer`, 
-          * only after time has expired on the proposed transaction. It removes corresponding entries from  
+          *
+          * Allows the `canceler` account to cancel the `proposal_name` proposal, created by a `proposer`,
+          * only after time has expired on the proposed transaction. It removes corresponding entries from
           * internal proptable and from approval (or old approvals) tables as well.
           */
          [[eosio::action]]
          void cancel( name proposer, name proposal_name, name canceler );
          /**
           * Execute proposal
-          * 
+          *
           * @details Allows an `executer` account to execute a proposal.
-          * 
-          * Preconditions: 
-          * - `executer` has authorization, 
-          * - `proposal_name` is found in the proposals table, 
-          * - all requested approvals are received, 
-          * - proposed transaction is not expired, 
-          * - and approval accounts are not found in invalidations table. 
-          * 
+          *
+          * Preconditions:
+          * - `executer` has authorization,
+          * - `proposal_name` is found in the proposals table,
+          * - all requested approvals are received,
+          * - proposed transaction is not expired,
+          * - and approval accounts are not found in invalidations table.
+          *
           * If all preconditions are met the transaction is executed as a deferred transaction,
           * and the proposal is erased from the proposals table.
-          * 
+          *
           * @param proposer - The account proposing a transaction
           * @param proposal_name - The name of the proposal (should be an existing proposal)
           * @param executer - The account executing the transaction
@@ -107,10 +109,10 @@ namespace eosio {
          void exec( name proposer, name proposal_name, name executer );
          /**
           * Invalidate proposal
-          * 
-          * @details Allows an `account` to invalidate itself, that is, its name is added to 
+          *
+          * @details Allows an `account` to invalidate itself, that is, its name is added to
           * the invalidations table and this table will be cross referenced when exec is performed.
-          * 
+          *
           * @param account - The account invalidating the transaction
           */
          [[eosio::action]]
@@ -122,6 +124,7 @@ namespace eosio {
          using cancel_action = eosio::action_wrapper<"cancel"_n, &multisig::cancel>;
          using exec_action = eosio::action_wrapper<"exec"_n, &multisig::exec>;
          using invalidate_action = eosio::action_wrapper<"invalidate"_n, &multisig::invalidate>;
+
       private:
          struct [[eosio::table]] proposal {
             name                            proposal_name;

--- a/contracts/eosio.msig/src/eosio.msig.cpp
+++ b/contracts/eosio.msig/src/eosio.msig.cpp
@@ -26,7 +26,7 @@ void multisig::propose( ignore<name> proposer,
    check( _trx_header.expiration >= eosio::time_point_sec(current_time_point()), "transaction expired" );
    //check( trx_header.actions.size() > 0, "transaction must have at least one action" );
 
-   proposals proptable( _self, _proposer.value );
+   proposals proptable( get_self(), _proposer.value );
    check( proptable.find( _proposal_name.value ) == proptable.end(), "proposal with the same name exists" );
 
    auto packed_requested = pack(_requested);
@@ -46,7 +46,7 @@ void multisig::propose( ignore<name> proposer,
       prop.packed_transaction  = pkd_trans;
    });
 
-   approvals apptable(  _self, _proposer.value );
+   approvals apptable( get_self(), _proposer.value );
    apptable.emplace( _proposer, [&]( auto& a ) {
       a.proposal_name       = _proposal_name;
       a.requested_approvals.reserve( _requested.size() );
@@ -62,12 +62,12 @@ void multisig::approve( name proposer, name proposal_name, permission_level leve
    require_auth( level );
 
    if( proposal_hash ) {
-      proposals proptable( _self, proposer.value );
+      proposals proptable( get_self(), proposer.value );
       auto& prop = proptable.get( proposal_name.value, "proposal not found" );
       assert_sha256( prop.packed_transaction.data(), prop.packed_transaction.size(), *proposal_hash );
    }
 
-   approvals apptable(  _self, proposer.value );
+   approvals apptable( get_self(), proposer.value );
    auto apps_it = apptable.find( proposal_name.value );
    if ( apps_it != apptable.end() ) {
       auto itr = std::find_if( apps_it->requested_approvals.begin(), apps_it->requested_approvals.end(), [&](const approval& a) { return a.level == level; } );
@@ -78,7 +78,7 @@ void multisig::approve( name proposer, name proposal_name, permission_level leve
             a.requested_approvals.erase( itr );
          });
    } else {
-      old_approvals old_apptable(  _self, proposer.value );
+      old_approvals old_apptable( get_self(), proposer.value );
       auto& apps = old_apptable.get( proposal_name.value, "proposal not found" );
 
       auto itr = std::find( apps.requested_approvals.begin(), apps.requested_approvals.end(), level );
@@ -94,7 +94,7 @@ void multisig::approve( name proposer, name proposal_name, permission_level leve
 void multisig::unapprove( name proposer, name proposal_name, permission_level level ) {
    require_auth( level );
 
-   approvals apptable(  _self, proposer.value );
+   approvals apptable( get_self(), proposer.value );
    auto apps_it = apptable.find( proposal_name.value );
    if ( apps_it != apptable.end() ) {
       auto itr = std::find_if( apps_it->provided_approvals.begin(), apps_it->provided_approvals.end(), [&](const approval& a) { return a.level == level; } );
@@ -104,7 +104,7 @@ void multisig::unapprove( name proposer, name proposal_name, permission_level le
             a.provided_approvals.erase( itr );
          });
    } else {
-      old_approvals old_apptable(  _self, proposer.value );
+      old_approvals old_apptable( get_self(), proposer.value );
       auto& apps = old_apptable.get( proposal_name.value, "proposal not found" );
       auto itr = std::find( apps.provided_approvals.begin(), apps.provided_approvals.end(), level );
       check( itr != apps.provided_approvals.end(), "no approval previously granted" );
@@ -118,7 +118,7 @@ void multisig::unapprove( name proposer, name proposal_name, permission_level le
 void multisig::cancel( name proposer, name proposal_name, name canceler ) {
    require_auth( canceler );
 
-   proposals proptable( _self, proposer.value );
+   proposals proptable( get_self(), proposer.value );
    auto& prop = proptable.get( proposal_name.value, "proposal not found" );
 
    if( canceler != proposer ) {
@@ -127,12 +127,12 @@ void multisig::cancel( name proposer, name proposal_name, name canceler ) {
    proptable.erase(prop);
 
    //remove from new table
-   approvals apptable(  _self, proposer.value );
+   approvals apptable( get_self(), proposer.value );
    auto apps_it = apptable.find( proposal_name.value );
    if ( apps_it != apptable.end() ) {
       apptable.erase(apps_it);
    } else {
-      old_approvals old_apptable(  _self, proposer.value );
+      old_approvals old_apptable( get_self(), proposer.value );
       auto apps_it = old_apptable.find( proposal_name.value );
       check( apps_it != old_apptable.end(), "proposal not found" );
       old_apptable.erase(apps_it);
@@ -142,17 +142,17 @@ void multisig::cancel( name proposer, name proposal_name, name canceler ) {
 void multisig::exec( name proposer, name proposal_name, name executer ) {
    require_auth( executer );
 
-   proposals proptable( _self, proposer.value );
+   proposals proptable( get_self(), proposer.value );
    auto& prop = proptable.get( proposal_name.value, "proposal not found" );
    transaction_header trx_header;
    datastream<const char*> ds( prop.packed_transaction.data(), prop.packed_transaction.size() );
    ds >> trx_header;
    check( trx_header.expiration >= eosio::time_point_sec(current_time_point()), "transaction expired" );
 
-   approvals apptable(  _self, proposer.value );
+   approvals apptable( get_self(), proposer.value );
    auto apps_it = apptable.find( proposal_name.value );
    std::vector<permission_level> approvals;
-   invalidations inv_table( _self, _self.value );
+   invalidations inv_table( get_self(), get_self().value );
    if ( apps_it != apptable.end() ) {
       approvals.reserve( apps_it->provided_approvals.size() );
       for ( auto& p : apps_it->provided_approvals ) {
@@ -163,7 +163,7 @@ void multisig::exec( name proposer, name proposal_name, name executer ) {
       }
       apptable.erase(apps_it);
    } else {
-      old_approvals old_apptable(  _self, proposer.value );
+      old_approvals old_apptable( get_self(), proposer.value );
       auto& apps = old_apptable.get( proposal_name.value, "proposal not found" );
       for ( auto& level : apps.provided_approvals ) {
          auto it = inv_table.find( level.actor.value );
@@ -190,7 +190,7 @@ void multisig::exec( name proposer, name proposal_name, name executer ) {
 
 void multisig::invalidate( name account ) {
    require_auth( account );
-   invalidations inv_table( _self, _self.value );
+   invalidations inv_table( get_self(), get_self().value );
    auto it = inv_table.find( account.value );
    if ( it == inv_table.end() ) {
       inv_table.emplace( account, [&](auto& i) {

--- a/contracts/eosio.msig/src/eosio.msig.cpp
+++ b/contracts/eosio.msig/src/eosio.msig.cpp
@@ -1,22 +1,10 @@
 #include <eosio.msig/eosio.msig.hpp>
-#include <eosiolib/action.hpp>
-#include <eosiolib/permission.hpp>
-#include <eosiolib/crypto.hpp>
+
+#include <eosio/action.hpp>
+#include <eosio/permission.hpp>
+#include <eosio/crypto.hpp>
 
 namespace eosio {
-
-/**
- * @ingroup eosiocontracts
- * 
- * Returns a high resolution time_point 
- * 
- * @details Returns a high resolution time_point which represents the number of microseconds 
- * from 1970 until the current time.
- */
-time_point current_time_point() {
-   const static time_point ct{ microseconds{ static_cast<int64_t>( current_time() ) } };
-   return ct;
-}
 
 void multisig::propose( ignore<name> proposer,
                         ignore<name> proposal_name,
@@ -42,10 +30,12 @@ void multisig::propose( ignore<name> proposer,
    check( proptable.find( _proposal_name.value ) == proptable.end(), "proposal with the same name exists" );
 
    auto packed_requested = pack(_requested);
-   auto res = ::check_transaction_authorization( trx_pos, size,
-                                                 (const char*)0, 0,
-                                                 packed_requested.data(), packed_requested.size()
-                                               );
+   // TODO: Remove internal_use_do_not_use namespace after minimum eosio.cdt dependency becomes 1.7.x
+   auto res =  internal_use_do_not_use::check_transaction_authorization(
+                  trx_pos, size,
+                  (const char*)0, 0,
+                  packed_requested.data(), packed_requested.size()
+               );
    check( res > 0, "transaction authorization failed" );
 
    std::vector<char> pkd_trans;
@@ -184,13 +174,15 @@ void multisig::exec( name proposer, name proposal_name, name executer ) {
       old_apptable.erase(apps);
    }
    auto packed_provided_approvals = pack(approvals);
-   auto res = ::check_transaction_authorization( prop.packed_transaction.data(), prop.packed_transaction.size(),
-                                                 (const char*)0, 0,
-                                                 packed_provided_approvals.data(), packed_provided_approvals.size()
-                                                 );
+   // TODO: Remove internal_use_do_not_use namespace after minimum eosio.cdt dependency becomes 1.7.x
+   auto res =  internal_use_do_not_use::check_transaction_authorization(
+                  prop.packed_transaction.data(), prop.packed_transaction.size(),
+                  (const char*)0, 0,
+                  packed_provided_approvals.data(), packed_provided_approvals.size()
+               );
    check( res > 0, "transaction authorization failed" );
 
-   send_deferred( (uint128_t(proposer.value) << 64) | proposal_name.value, executer.value,
+   send_deferred( (uint128_t(proposer.value) << 64) | proposal_name.value, executer,
                   prop.packed_transaction.data(), prop.packed_transaction.size() );
 
    proptable.erase(prop);

--- a/contracts/eosio.system/CMakeLists.txt
+++ b/contracts/eosio.system/CMakeLists.txt
@@ -1,4 +1,12 @@
-add_contract(eosio.system eosio.system ${CMAKE_CURRENT_SOURCE_DIR}/src/eosio.system.cpp)
+add_contract(eosio.system eosio.system
+   ${CMAKE_CURRENT_SOURCE_DIR}/src/eosio.system.cpp
+   ${CMAKE_CURRENT_SOURCE_DIR}/src/delegate_bandwidth.cpp
+   ${CMAKE_CURRENT_SOURCE_DIR}/src/exchange_state.cpp
+   ${CMAKE_CURRENT_SOURCE_DIR}/src/native.cpp
+   ${CMAKE_CURRENT_SOURCE_DIR}/src/producer_pay.cpp
+   ${CMAKE_CURRENT_SOURCE_DIR}/src/rex.cpp
+   ${CMAKE_CURRENT_SOURCE_DIR}/src/voting.cpp
+)
 
 target_include_directories(eosio.system
    PUBLIC

--- a/contracts/eosio.system/include/eosio.system/eosio.system.hpp
+++ b/contracts/eosio.system/include/eosio.system/eosio.system.hpp
@@ -1,16 +1,19 @@
 #pragma once
 
-#include <eosio.system/native.hpp>
-#include <eosiolib/asset.hpp>
-#include <eosiolib/time.hpp>
-#include <eosiolib/privileged.hpp>
-#include <eosiolib/singleton.hpp>
-#include <eosio.system/exchange_state.hpp>
+#include <eosio/asset.hpp>
+#include <eosio/privileged.hpp>
+#include <eosio/singleton.hpp>
+#include <eosio/system.hpp>
+#include <eosio/time.hpp>
 
-#include <string>
+#include <eosio.system/exchange_state.hpp>
+#include <eosio.system/native.hpp>
+
 #include <deque>
-#include <type_traits>
 #include <optional>
+#include <string>
+#include <type_traits>
+
 
 #ifdef CHANNEL_RAM_AND_NAMEBID_FEES_TO_REX
 #undef CHANNEL_RAM_AND_NAMEBID_FEES_TO_REX
@@ -22,18 +25,20 @@
 
 namespace eosiosystem {
 
-   using eosio::name;
    using eosio::asset;
+   using eosio::block_timestamp;
+   using eosio::check;
+   using eosio::const_mem_fun;
+   using eosio::datastream;
+   using eosio::indexed_by;
+   using eosio::microseconds;
+   using eosio::name;
    using eosio::symbol;
    using eosio::symbol_code;
-   using eosio::indexed_by;
-   using eosio::const_mem_fun;
-   using eosio::block_timestamp;
    using eosio::time_point;
    using eosio::time_point_sec;
    using eosio::microseconds;
-   using eosio::datastream;
-   using eosio::check;
+   using eosio::unsigned_int;
 
    template<typename E, typename F>
    static inline auto has_field( F flags, E field )
@@ -1219,9 +1224,6 @@ namespace eosiosystem {
 
          //defined in eosio.system.cpp
          static eosio_global_state get_default_parameters();
-         static time_point current_time_point();
-         static time_point_sec current_time_point_sec();
-         static block_timestamp current_block_time();
          symbol core_symbol()const;
          void update_ram_supply();
 

--- a/contracts/eosio.system/include/eosio.system/exchange_state.hpp
+++ b/contracts/eosio.system/include/eosio.system/exchange_state.hpp
@@ -1,8 +1,9 @@
 #pragma once
 
-#include <eosiolib/asset.hpp>
+#include <eosio/asset.hpp>
 
 namespace eosiosystem {
+   
    using eosio::asset;
    using eosio::symbol;
 
@@ -13,8 +14,8 @@ namespace eosiosystem {
 
    /**
     * Uses Bancor math to create a 50/50 relay between two asset types.
-    *  
-    * @details The state of the bancor exchange is entirely contained within this struct. 
+    *
+    * @details The state of the bancor exchange is entirely contained within this struct.
     * There are no external side effects associated with using this API.
     */
    struct [[eosio::table, eosio::contract("eosio.system")]] exchange_state {

--- a/contracts/eosio.system/include/eosio.system/exchange_state.hpp
+++ b/contracts/eosio.system/include/eosio.system/exchange_state.hpp
@@ -1,9 +1,10 @@
 #pragma once
 
 #include <eosio/asset.hpp>
+#include <eosio/multi_index.hpp>
 
 namespace eosiosystem {
-   
+
    using eosio::asset;
    using eosio::symbol;
 

--- a/contracts/eosio.system/include/eosio.system/native.hpp
+++ b/contracts/eosio.system/include/eosio.system/native.hpp
@@ -22,22 +22,9 @@ namespace eosio {
          void preactivate_feature( const ::capi_checksum256* feature_digest );
       }
    }
-}
 
-namespace eosio {
-   bool is_feature_activated( const eosio::checksum256& feature_digest ) {
-      auto feature_digest_data = feature_digest.extract_as_byte_array();
-      return internal_use_do_not_use::is_feature_activated(
-         reinterpret_cast<const ::capi_checksum256*>( feature_digest_data.data() )
-      );
-   }
-
-   void preactivate_feature( const eosio::checksum256& feature_digest ) {
-      auto feature_digest_data = feature_digest.extract_as_byte_array();
-      internal_use_do_not_use::preactivate_feature(
-         reinterpret_cast<const ::capi_checksum256*>( feature_digest_data.data() )
-      );
-   }
+   bool is_feature_activated( const eosio::checksum256& feature_digest );
+   void preactivate_feature( const eosio::checksum256& feature_digest );
 }
 
 namespace eosiosystem {
@@ -280,9 +267,7 @@ namespace eosiosystem {
           * @param sent_trx - the deferred transaction that failed.
           */
          [[eosio::action]]
-         void onerror( ignore<uint128_t> sender_id, ignore<std::vector<char>> sent_trx ) {
-            eosio::check( false, "the onerror action cannot be called directly" );
-         }
+         void onerror( ignore<uint128_t> sender_id, ignore<std::vector<char>> sent_trx );
 
          /**
           * Set abi action.

--- a/contracts/eosio.system/include/eosio.system/native.hpp
+++ b/contracts/eosio.system/include/eosio.system/native.hpp
@@ -1,13 +1,16 @@
 #pragma once
 
-#include <eosiolib/action.hpp>
-#include <eosiolib/public_key.hpp>
-#include <eosiolib/print.hpp>
-#include <eosiolib/privileged.h>
-#include <eosiolib/producer_schedule.hpp>
-#include <eosiolib/contract.hpp>
-#include <eosiolib/ignore.hpp>
-#include <eosiolib/fixed_bytes.hpp>
+#include <eosio/action.hpp>
+#include <eosio/contract.hpp>
+#include <eosio/crypto.hpp>
+#include <eosio/fixed_bytes.hpp>
+#include <eosio/ignore.hpp>
+#include <eosio/print.hpp>
+#include <eosio/privileged.hpp>
+#include <eosio/producer_schedule.hpp>
+
+// This header is needed until `is_feature_activiated` and `preactivate_feature` are added to `eosio.cdt`
+#include <eosio/../../capi/eosio/crypto.h>
 
 namespace eosio {
    namespace internal_use_do_not_use {
@@ -15,13 +18,13 @@ namespace eosio {
          __attribute__((eosio_wasm_import))
          bool is_feature_activated( const ::capi_checksum256* feature_digest );
 
-          __attribute__((eosio_wasm_import))
+         __attribute__((eosio_wasm_import))
          void preactivate_feature( const ::capi_checksum256* feature_digest );
       }
    }
 }
 
- namespace eosio {
+namespace eosio {
    bool is_feature_activated( const eosio::checksum256& feature_digest ) {
       auto feature_digest_data = feature_digest.extract_as_byte_array();
       return internal_use_do_not_use::is_feature_activated(
@@ -29,7 +32,7 @@ namespace eosio {
       );
    }
 
-    void preactivate_feature( const eosio::checksum256& feature_digest ) {
+   void preactivate_feature( const eosio::checksum256& feature_digest ) {
       auto feature_digest_data = feature_digest.extract_as_byte_array();
       internal_use_do_not_use::preactivate_feature(
          reinterpret_cast<const ::capi_checksum256*>( feature_digest_data.data() )
@@ -38,10 +41,12 @@ namespace eosio {
 }
 
 namespace eosiosystem {
+
+   using eosio::checksum256;
+   using eosio::ignore;
    using eosio::name;
    using eosio::permission_level;
    using eosio::public_key;
-   using eosio::ignore;
 
    /**
     * @addtogroup eosiosystem
@@ -123,9 +128,9 @@ namespace eosiosystem {
       uint32_t                                  timestamp;
       name                                      producer;
       uint16_t                                  confirmed = 0;
-      capi_checksum256                          previous;
-      capi_checksum256                          transaction_mroot;
-      capi_checksum256                          action_mroot;
+      checksum256                               previous;
+      checksum256                               transaction_mroot;
+      checksum256                               action_mroot;
       uint32_t                                  schedule_version = 0;
       std::optional<eosio::producer_schedule>   new_producers;
 
@@ -143,7 +148,7 @@ namespace eosiosystem {
     */
    struct [[eosio::table("abihash"), eosio::contract("eosio.system")]] abi_hash {
       name              owner;
-      capi_checksum256  hash;
+      checksum256       hash;
       uint64_t primary_key()const { return owner.value; }
 
       EOSLIB_SERIALIZE( abi_hash, (owner)(hash) )
@@ -262,7 +267,7 @@ namespace eosiosystem {
           * @param trx_id - the deferred transaction id to be cancelled.
           */
          [[eosio::action]]
-         void canceldelay( ignore<permission_level> canceling_auth, ignore<capi_checksum256> trx_id ) {}
+         void canceldelay( ignore<permission_level> canceling_auth, ignore<checksum256> trx_id ) {}
 
          /**
           * On error action.

--- a/contracts/eosio.system/include/eosio.system/rex.results.hpp
+++ b/contracts/eosio.system/include/eosio.system/rex.results.hpp
@@ -1,12 +1,12 @@
 #pragma once
 
-#include <eosiolib/eosio.hpp>
-#include <eosiolib/name.hpp>
-#include <eosiolib/asset.hpp>
+#include <eosio/asset.hpp>
+#include <eosio/eosio.hpp>
+#include <eosio/name.hpp>
 
-using eosio::name;
-using eosio::asset;
 using eosio::action_wrapper;
+using eosio::asset;
+using eosio::name;
 
 class [[eosio::contract("rex.results")]] rex_results : eosio::contract {
    public:

--- a/contracts/eosio.system/src/delegate_bandwidth.cpp
+++ b/contracts/eosio.system/src/delegate_bandwidth.cpp
@@ -1,24 +1,24 @@
+#include <eosio/datastream.hpp>
+#include <eosio/eosio.hpp>
+#include <eosio/multi_index.hpp>
+#include <eosio/privileged.hpp>
+#include <eosio/serialize.hpp>
+#include <eosio/transaction.hpp>
+
 #include <eosio.system/eosio.system.hpp>
-
-#include <eosiolib/eosio.hpp>
-#include <eosiolib/datastream.hpp>
-#include <eosiolib/serialize.hpp>
-#include <eosiolib/multi_index.hpp>
-#include <eosiolib/privileged.h>
-#include <eosiolib/transaction.hpp>
-
 #include <eosio.token/eosio.token.hpp>
-
 
 #include <cmath>
 #include <map>
 
 namespace eosiosystem {
+
    using eosio::asset;
-   using eosio::indexed_by;
    using eosio::const_mem_fun;
+   using eosio::indexed_by;
    using eosio::permission_level;
    using eosio::time_point_sec;
+
    using std::map;
    using std::pair;
 
@@ -157,8 +157,8 @@ namespace eosiosystem {
       auto voter_itr = _voters.find( res_itr->owner.value );
       if( voter_itr == _voters.end() || !has_field( voter_itr->flags1, voter_info::flags1_fields::ram_managed ) ) {
          int64_t ram_bytes, net, cpu;
-         get_resource_limits( res_itr->owner.value, &ram_bytes, &net, &cpu );
-         set_resource_limits( res_itr->owner.value, res_itr->ram_bytes + ram_gift_bytes, net, cpu );
+         get_resource_limits( res_itr->owner, ram_bytes, net, cpu );
+         set_resource_limits( res_itr->owner, res_itr->ram_bytes + ram_gift_bytes, net, cpu );
       }
    }
 
@@ -201,8 +201,8 @@ namespace eosiosystem {
       auto voter_itr = _voters.find( res_itr->owner.value );
       if( voter_itr == _voters.end() || !has_field( voter_itr->flags1, voter_info::flags1_fields::ram_managed ) ) {
          int64_t ram_bytes, net, cpu;
-         get_resource_limits( res_itr->owner.value, &ram_bytes, &net, &cpu );
-         set_resource_limits( res_itr->owner.value, res_itr->ram_bytes + ram_gift_bytes, net, cpu );
+         get_resource_limits( res_itr->owner, ram_bytes, net, cpu );
+         set_resource_limits( res_itr->owner, res_itr->ram_bytes + ram_gift_bytes, net, cpu );
       }
 
       {
@@ -221,7 +221,7 @@ namespace eosiosystem {
    void validate_b1_vesting( int64_t stake ) {
       const int64_t base_time = 1527811200; /// 2018-06-01
       const int64_t max_claimable = 100'000'000'0000ll;
-      const int64_t claimable = int64_t(max_claimable * double(now()-base_time) / (10*seconds_per_year) );
+      const int64_t claimable = int64_t(max_claimable * double(current_time_point().sec_since_epoch() - base_time) / (10*seconds_per_year) );
 
       check( max_claimable - claimable <= stake, "b1 can only claim their tokens over 10 years" );
    }
@@ -298,9 +298,9 @@ namespace eosiosystem {
 
             if( !(net_managed && cpu_managed) ) {
                int64_t ram_bytes, net, cpu;
-               get_resource_limits( receiver.value, &ram_bytes, &net, &cpu );
+               get_resource_limits( receiver, ram_bytes, net, cpu );
 
-               set_resource_limits( receiver.value,
+               set_resource_limits( receiver,
                                     ram_managed ? ram_bytes : std::max( tot_itr->ram_bytes + ram_gift_bytes, ram_bytes ),
                                     net_managed ? net : tot_itr->net_weight.amount,
                                     cpu_managed ? cpu : tot_itr->cpu_weight.amount );

--- a/contracts/eosio.system/src/delegate_bandwidth.cpp
+++ b/contracts/eosio.system/src/delegate_bandwidth.cpp
@@ -139,7 +139,7 @@ namespace eosiosystem {
       _gstate.total_ram_bytes_reserved += uint64_t(bytes_out);
       _gstate.total_ram_stake          += quant_after_fee.amount;
 
-      user_resources_table  userres( _self, receiver.value );
+      user_resources_table  userres( get_self(), receiver.value );
       auto res_itr = userres.find( receiver.value );
       if( res_itr ==  userres.end() ) {
          res_itr = userres.emplace( receiver, [&]( auto& res ) {
@@ -174,7 +174,7 @@ namespace eosiosystem {
 
       check( bytes > 0, "cannot sell negative byte" );
 
-      user_resources_table  userres( _self, account.value );
+      user_resources_table  userres( get_self(), account.value );
       auto res_itr = userres.find( account.value );
       check( res_itr != userres.end(), "no resource row" );
       check( res_itr->ram_bytes >= bytes, "insufficient quota" );
@@ -242,7 +242,7 @@ namespace eosiosystem {
 
       // update stake delegated from "from" to "receiver"
       {
-         del_bandwidth_table     del_tbl( _self, from.value );
+         del_bandwidth_table     del_tbl( get_self(), from.value );
          auto itr = del_tbl.find( receiver.value );
          if( itr == del_tbl.end() ) {
             itr = del_tbl.emplace( from, [&]( auto& dbo ){
@@ -267,7 +267,7 @@ namespace eosiosystem {
 
       // update totals of "receiver"
       {
-         user_resources_table   totals_tbl( _self, receiver.value );
+         user_resources_table   totals_tbl( get_self(), receiver.value );
          auto tot_itr = totals_tbl.find( receiver.value );
          if( tot_itr ==  totals_tbl.end() ) {
             tot_itr = totals_tbl.emplace( from, [&]( auto& tot ) {
@@ -314,7 +314,7 @@ namespace eosiosystem {
 
       // create refund or update from existing refund
       if ( stake_account != source_stake_from ) { //for eosio both transfer and refund make no sense
-         refunds_table refunds_tbl( _self, from.value );
+         refunds_table refunds_tbl( get_self(), from.value );
          auto req = refunds_tbl.find( from.value );
 
          //create/update/delete refund
@@ -383,7 +383,7 @@ namespace eosiosystem {
          if ( need_deferred_trx ) {
             eosio::transaction out;
             out.actions.emplace_back( permission_level{from, active_permission},
-                                      _self, "refund"_n,
+                                      get_self(), "refund"_n,
                                       from
             );
             out.delay_sec = refund_delay_sec;
@@ -459,7 +459,7 @@ namespace eosiosystem {
    void system_contract::refund( const name& owner ) {
       require_auth( owner );
 
-      refunds_table refunds_tbl( _self, owner.value );
+      refunds_table refunds_tbl( get_self(), owner.value );
       auto req = refunds_tbl.find( owner.value );
       check( req != refunds_tbl.end(), "refund request not found" );
       check( req->request_time + seconds(refund_delay_sec) <= current_time_point(),

--- a/contracts/eosio.system/src/eosio.system.cpp
+++ b/contracts/eosio.system/src/eosio.system.cpp
@@ -1,6 +1,7 @@
+#include <eosio/crypto.hpp>
+#include <eosio/dispatcher.hpp>
+
 #include <eosio.system/eosio.system.hpp>
-#include <eosiolib/dispatcher.hpp>
-#include <eosiolib/crypto.h>
 
 #include "producer_pay.cpp"
 #include "delegate_bandwidth.cpp"
@@ -34,21 +35,6 @@ namespace eosiosystem {
       eosio_global_state dp;
       get_blockchain_parameters(dp);
       return dp;
-   }
-
-   time_point system_contract::current_time_point() {
-      const static time_point ct{ microseconds{ static_cast<int64_t>( current_time() ) } };
-      return ct;
-   }
-
-   time_point_sec system_contract::current_time_point_sec() {
-      const static time_point_sec cts{ current_time_point() };
-      return cts;
-   }
-
-   block_timestamp system_contract::current_block_time() {
-      const static block_timestamp cbt{ current_time_point() };
-      return cbt;
    }
 
    symbol system_contract::core_symbol()const {
@@ -116,7 +102,7 @@ namespace eosiosystem {
 
    void system_contract::setpriv( const name& account, uint8_t ispriv ) {
       require_auth( _self );
-      set_privileged( account.value, ispriv );
+      set_privileged( account, ispriv );
    }
 
    void system_contract::setalimits( const name& account, int64_t ram, int64_t net, int64_t cpu ) {
@@ -134,14 +120,14 @@ namespace eosiosystem {
          check( !(ram_managed || net_managed || cpu_managed), "cannot use setalimits on an account with managed resources" );
       }
 
-      set_resource_limits( account.value, ram, net, cpu );
+      set_resource_limits( account, ram, net, cpu );
    }
 
    void system_contract::setacctram( const name& account, const std::optional<int64_t>& ram_bytes ) {
       require_auth( _self );
 
       int64_t current_ram, current_net, current_cpu;
-      get_resource_limits( account.value, &current_ram, &current_net, &current_cpu );
+      get_resource_limits( account, current_ram, current_net, current_cpu );
 
       int64_t ram = 0;
 
@@ -179,14 +165,14 @@ namespace eosiosystem {
          ram = *ram_bytes;
       }
 
-      set_resource_limits( account.value, ram, current_net, current_cpu );
+      set_resource_limits( account, ram, current_net, current_cpu );
    }
 
    void system_contract::setacctnet( const name& account, const std::optional<int64_t>& net_weight ) {
       require_auth( _self );
 
       int64_t current_ram, current_net, current_cpu;
-      get_resource_limits( account.value, &current_ram, &current_net, &current_cpu );
+      get_resource_limits( account, current_ram, current_net, current_cpu );
 
       int64_t net = 0;
 
@@ -223,14 +209,14 @@ namespace eosiosystem {
          net = *net_weight;
       }
 
-      set_resource_limits( account.value, current_ram, net, current_cpu );
+      set_resource_limits( account, current_ram, net, current_cpu );
    }
 
    void system_contract::setacctcpu( const name& account, const std::optional<int64_t>& cpu_weight ) {
       require_auth( _self );
 
       int64_t current_ram, current_net, current_cpu;
-      get_resource_limits( account.value, &current_ram, &current_net, &current_cpu );
+      get_resource_limits( account, current_ram, current_net, current_cpu );
 
       int64_t cpu = 0;
 
@@ -267,7 +253,7 @@ namespace eosiosystem {
          cpu = *cpu_weight;
       }
 
-      set_resource_limits( account.value, current_ram, current_net, cpu );
+      set_resource_limits( account, current_ram, current_net, cpu );
    }
 
    void system_contract::activate( const eosio::checksum256& feature_digest ) {
@@ -407,7 +393,7 @@ namespace eosiosystem {
         res.cpu_weight = asset( 0, system_contract::get_core_symbol() );
       });
 
-      set_resource_limits( newact.value, 0, 0, 0 );
+      set_resource_limits( newact, 0, 0, 0 );
    }
 
    void native::setabi( const name& acnt, const std::vector<char>& abi ) {
@@ -415,12 +401,12 @@ namespace eosiosystem {
       auto itr = table.find( acnt.value );
       if( itr == table.end() ) {
          table.emplace( acnt, [&]( auto& row ) {
-            row.owner= acnt;
-            sha256( const_cast<char*>(abi.data()), abi.size(), &row.hash );
+            row.owner = acnt;
+            row.hash = sha256(const_cast<char*>(abi.data()), abi.size());
          });
       } else {
          table.modify( itr, same_payer, [&]( auto& row ) {
-            sha256( const_cast<char*>(abi.data()), abi.size(), &row.hash );
+            row.hash = sha256(const_cast<char*>(abi.data()), abi.size());
          });
       }
    }

--- a/contracts/eosio.system/src/eosio.system.cpp
+++ b/contracts/eosio.system/src/eosio.system.cpp
@@ -13,17 +13,17 @@ namespace eosiosystem {
 
    system_contract::system_contract( name s, name code, datastream<const char*> ds )
    :native(s,code,ds),
-    _voters(_self, _self.value),
-    _producers(_self, _self.value),
-    _producers2(_self, _self.value),
-    _global(_self, _self.value),
-    _global2(_self, _self.value),
-    _global3(_self, _self.value),
-    _rammarket(_self, _self.value),
-    _rexpool(_self, _self.value),
-    _rexfunds(_self, _self.value),
-    _rexbalance(_self, _self.value),
-    _rexorders(_self, _self.value)
+    _voters(get_self(), get_self().value),
+    _producers(get_self(), get_self().value),
+    _producers2(get_self(), get_self().value),
+    _global(get_self(), get_self().value),
+    _global2(get_self(), get_self().value),
+    _global3(get_self(), get_self().value),
+    _rammarket(get_self(), get_self().value),
+    _rexpool(get_self(), get_self().value),
+    _rexfunds(get_self(), get_self().value),
+    _rexbalance(get_self(), get_self().value),
+    _rexorders(get_self(), get_self().value)
    {
       //print( "construct system\n" );
       _gstate  = _global.exists() ? _global.get() : get_default_parameters();
@@ -43,13 +43,13 @@ namespace eosiosystem {
    }
 
    system_contract::~system_contract() {
-      _global.set( _gstate, _self );
-      _global2.set( _gstate2, _self );
-      _global3.set( _gstate3, _self );
+      _global.set( _gstate, get_self() );
+      _global2.set( _gstate2, get_self() );
+      _global3.set( _gstate3, get_self() );
    }
 
    void system_contract::setram( uint64_t max_ram_size ) {
-      require_auth( _self );
+      require_auth( get_self() );
 
       check( _gstate.max_ram_size < max_ram_size, "ram may only be increased" ); /// decreasing ram might result market maker issues
       check( max_ram_size < 1024ll*1024*1024*1024*1024, "ram size is unrealistic" );
@@ -87,28 +87,28 @@ namespace eosiosystem {
    }
 
    void system_contract::setramrate( uint16_t bytes_per_block ) {
-      require_auth( _self );
+      require_auth( get_self() );
 
       update_ram_supply();
       _gstate2.new_ram_per_block = bytes_per_block;
    }
 
    void system_contract::setparams( const eosio::blockchain_parameters& params ) {
-      require_auth( _self );
+      require_auth( get_self() );
       (eosio::blockchain_parameters&)(_gstate) = params;
       check( 3 <= _gstate.max_authority_depth, "max_authority_depth should be at least 3" );
       set_blockchain_parameters( params );
    }
 
    void system_contract::setpriv( const name& account, uint8_t ispriv ) {
-      require_auth( _self );
+      require_auth( get_self() );
       set_privileged( account, ispriv );
    }
 
    void system_contract::setalimits( const name& account, int64_t ram, int64_t net, int64_t cpu ) {
-      require_auth( _self );
+      require_auth( get_self() );
 
-      user_resources_table userres( _self, account.value );
+      user_resources_table userres( get_self(), account.value );
       auto ritr = userres.find( account.value );
       check( ritr == userres.end(), "only supports unlimited accounts" );
 
@@ -124,7 +124,7 @@ namespace eosiosystem {
    }
 
    void system_contract::setacctram( const name& account, const std::optional<int64_t>& ram_bytes ) {
-      require_auth( _self );
+      require_auth( get_self() );
 
       int64_t current_ram, current_net, current_cpu;
       get_resource_limits( account, current_ram, current_net, current_cpu );
@@ -136,7 +136,7 @@ namespace eosiosystem {
          check( vitr != _voters.end() && has_field( vitr->flags1, voter_info::flags1_fields::ram_managed ),
                 "RAM of account is already unmanaged" );
 
-         user_resources_table userres( _self, account.value );
+         user_resources_table userres( get_self(), account.value );
          auto ritr = userres.find( account.value );
 
          ram = ram_gift_bytes;
@@ -169,7 +169,7 @@ namespace eosiosystem {
    }
 
    void system_contract::setacctnet( const name& account, const std::optional<int64_t>& net_weight ) {
-      require_auth( _self );
+      require_auth( get_self() );
 
       int64_t current_ram, current_net, current_cpu;
       get_resource_limits( account, current_ram, current_net, current_cpu );
@@ -181,7 +181,7 @@ namespace eosiosystem {
          check( vitr != _voters.end() && has_field( vitr->flags1, voter_info::flags1_fields::net_managed ),
                 "Network bandwidth of account is already unmanaged" );
 
-         user_resources_table userres( _self, account.value );
+         user_resources_table userres( get_self(), account.value );
          auto ritr = userres.find( account.value );
 
          if( ritr != userres.end() ) {
@@ -213,7 +213,7 @@ namespace eosiosystem {
    }
 
    void system_contract::setacctcpu( const name& account, const std::optional<int64_t>& cpu_weight ) {
-      require_auth( _self );
+      require_auth( get_self() );
 
       int64_t current_ram, current_net, current_cpu;
       get_resource_limits( account, current_ram, current_net, current_cpu );
@@ -225,7 +225,7 @@ namespace eosiosystem {
          check( vitr != _voters.end() && has_field( vitr->flags1, voter_info::flags1_fields::cpu_managed ),
                 "CPU bandwidth of account is already unmanaged" );
 
-         user_resources_table userres( _self, account.value );
+         user_resources_table userres( get_self(), account.value );
          auto ritr = userres.find( account.value );
 
          if( ritr != userres.end() ) {
@@ -262,7 +262,7 @@ namespace eosiosystem {
    }
 
    void system_contract::rmvproducer( const name& producer ) {
-      require_auth( _self );
+      require_auth( get_self() );
       auto prod = _producers.find( producer.value );
       check( prod != _producers.end(), "producer not found" );
       _producers.modify( prod, same_payer, [&](auto& p) {
@@ -271,7 +271,7 @@ namespace eosiosystem {
    }
 
    void system_contract::updtrevision( uint8_t revision ) {
-      require_auth( _self );
+      require_auth( get_self() );
       check( _gstate2.revision < 255, "can not increment revision" ); // prevent wrap around
       check( revision == _gstate2.revision + 1, "can only increment revision by one" );
       check( revision <= 1, // set upper bound to greatest revision supported in the code
@@ -291,7 +291,7 @@ namespace eosiosystem {
       check( bid.amount > 0, "insufficient bid" );
       token::transfer_action transfer_act{ token_account, { {bidder, active_permission} } };
       transfer_act.send( bidder, names_account, bid, std::string("bid name ")+ newname.to_string() );
-      name_bid_table bids(_self, _self.value);
+      name_bid_table bids(get_self(), get_self().value);
       print( name{bidder}, " bid ", bid, " on ", name{newname}, "\n" );
       auto current = bids.find( newname.value );
       if( current == bids.end() ) {
@@ -306,7 +306,7 @@ namespace eosiosystem {
          check( bid.amount - current->high_bid > (current->high_bid / 10), "must increase bid by 10%" );
          check( current->high_bidder != bidder, "account is already highest bidder" );
 
-         bid_refund_table refunds_table(_self, newname.value);
+         bid_refund_table refunds_table(get_self(), newname.value);
 
          auto it = refunds_table.find( current->high_bidder.value );
          if ( it != refunds_table.end() ) {
@@ -321,8 +321,8 @@ namespace eosiosystem {
          }
 
          transaction t;
-         t.actions.emplace_back( permission_level{_self, active_permission},
-                                 _self, "bidrefund"_n,
+         t.actions.emplace_back( permission_level{get_self(), active_permission},
+                                 get_self(), "bidrefund"_n,
                                  std::make_tuple( current->high_bidder, newname )
          );
          t.delay_sec = 0;
@@ -339,7 +339,7 @@ namespace eosiosystem {
    }
 
    void system_contract::bidrefund( const name& bidder, const name& newname ) {
-      bid_refund_table refunds_table(_self, newname.value);
+      bid_refund_table refunds_table(get_self(), newname.value);
       auto it = refunds_table.find( bidder.value );
       check( it != refunds_table.end(), "refund not found" );
 
@@ -362,7 +362,7 @@ namespace eosiosystem {
                             ignore<authority> owner,
                             ignore<authority> active ) {
 
-      if( creator != _self ) {
+      if( creator != get_self() ) {
          uint64_t tmp = newact.value >> 4;
          bool has_dot = false;
 
@@ -373,7 +373,7 @@ namespace eosiosystem {
          if( has_dot ) { // or is less than 12 characters
             auto suffix = newact.suffix();
             if( suffix == newact ) {
-               name_bid_table bids(_self, _self.value);
+               name_bid_table bids(get_self(), get_self().value);
                auto current = bids.find( newact.value );
                check( current != bids.end(), "no active bid for name" );
                check( current->high_bidder == creator, "only highest bidder can claim" );
@@ -385,7 +385,7 @@ namespace eosiosystem {
          }
       }
 
-      user_resources_table  userres( _self, newact.value);
+      user_resources_table  userres( get_self(), newact.value);
 
       userres.emplace( newact, [&]( auto& res ) {
         res.owner = newact;
@@ -397,7 +397,7 @@ namespace eosiosystem {
    }
 
    void native::setabi( const name& acnt, const std::vector<char>& abi ) {
-      eosio::multi_index< "abihash"_n, abi_hash >  table(_self, _self.value);
+      eosio::multi_index< "abihash"_n, abi_hash >  table(get_self(), get_self().value);
       auto itr = table.find( acnt.value );
       if( itr == table.end() ) {
          table.emplace( acnt, [&]( auto& row ) {
@@ -412,7 +412,7 @@ namespace eosiosystem {
    }
 
    void system_contract::init( unsigned_int version, const symbol& core ) {
-      require_auth( _self );
+      require_auth( get_self() );
       check( version.value == 0, "unsupported version for init action" );
 
       auto itr = _rammarket.find(ramcore_symbol.raw());
@@ -422,7 +422,7 @@ namespace eosiosystem {
       check( system_token_supply.symbol == core, "specified core symbol does not exist (precision mismatch)" );
 
       check( system_token_supply.amount > 0, "system token supply must be greater than 0" );
-      _rammarket.emplace( _self, [&]( auto& m ) {
+      _rammarket.emplace( get_self(), [&]( auto& m ) {
          m.supply.amount = 100000000000000ll;
          m.supply.symbol = ramcore_symbol;
          m.base.balance.amount = int64_t(_gstate.free_ram());
@@ -431,8 +431,8 @@ namespace eosiosystem {
          m.quote.balance.symbol = core;
       });
 
-      token::open_action open_act{ token_account, { {_self, active_permission} } };
-      open_act.send( rex_account, core, _self );
+      token::open_action open_act{ token_account, { {get_self(), active_permission} } };
+      open_act.send( rex_account, core, get_self() );
    }
 
 } /// eosio.system

--- a/contracts/eosio.system/src/eosio.system.cpp
+++ b/contracts/eosio.system/src/eosio.system.cpp
@@ -1,15 +1,13 @@
+#include <eosio.system/eosio.system.hpp>
+#include <eosio.token/eosio.token.hpp>
+
 #include <eosio/crypto.hpp>
 #include <eosio/dispatcher.hpp>
 
-#include <eosio.system/eosio.system.hpp>
-
-#include "producer_pay.cpp"
-#include "delegate_bandwidth.cpp"
-#include "voting.cpp"
-#include "exchange_state.cpp"
-#include "rex.cpp"
-
 namespace eosiosystem {
+
+   using eosio::current_time_point;
+   using eosio::token;
 
    system_contract::system_contract( name s, name code, datastream<const char*> ds )
    :native(s,code,ds),
@@ -69,7 +67,7 @@ namespace eosiosystem {
    }
 
    void system_contract::update_ram_supply() {
-      auto cbt = current_block_time();
+      auto cbt = eosio::current_block_time();
 
       if( cbt <= _gstate2.last_ram_increase ) return;
 
@@ -279,74 +277,7 @@ namespace eosiosystem {
       _gstate2.revision = revision;
    }
 
-   void system_contract::bidname( const name& bidder, const name& newname, const asset& bid ) {
-      require_auth( bidder );
-      check( newname.suffix() == newname, "you can only bid on top-level suffix" );
 
-      check( (bool)newname, "the empty name is not a valid account name to bid on" );
-      check( (newname.value & 0xFull) == 0, "13 character names are not valid account names to bid on" );
-      check( (newname.value & 0x1F0ull) == 0, "accounts with 12 character names and no dots can be created without bidding required" );
-      check( !is_account( newname ), "account already exists" );
-      check( bid.symbol == core_symbol(), "asset must be system token" );
-      check( bid.amount > 0, "insufficient bid" );
-      token::transfer_action transfer_act{ token_account, { {bidder, active_permission} } };
-      transfer_act.send( bidder, names_account, bid, std::string("bid name ")+ newname.to_string() );
-      name_bid_table bids(get_self(), get_self().value);
-      print( name{bidder}, " bid ", bid, " on ", name{newname}, "\n" );
-      auto current = bids.find( newname.value );
-      if( current == bids.end() ) {
-         bids.emplace( bidder, [&]( auto& b ) {
-            b.newname = newname;
-            b.high_bidder = bidder;
-            b.high_bid = bid.amount;
-            b.last_bid_time = current_time_point();
-         });
-      } else {
-         check( current->high_bid > 0, "this auction has already closed" );
-         check( bid.amount - current->high_bid > (current->high_bid / 10), "must increase bid by 10%" );
-         check( current->high_bidder != bidder, "account is already highest bidder" );
-
-         bid_refund_table refunds_table(get_self(), newname.value);
-
-         auto it = refunds_table.find( current->high_bidder.value );
-         if ( it != refunds_table.end() ) {
-            refunds_table.modify( it, same_payer, [&](auto& r) {
-                  r.amount += asset( current->high_bid, core_symbol() );
-               });
-         } else {
-            refunds_table.emplace( bidder, [&](auto& r) {
-                  r.bidder = current->high_bidder;
-                  r.amount = asset( current->high_bid, core_symbol() );
-               });
-         }
-
-         transaction t;
-         t.actions.emplace_back( permission_level{get_self(), active_permission},
-                                 get_self(), "bidrefund"_n,
-                                 std::make_tuple( current->high_bidder, newname )
-         );
-         t.delay_sec = 0;
-         uint128_t deferred_id = (uint128_t(newname.value) << 64) | current->high_bidder.value;
-         cancel_deferred( deferred_id );
-         t.send( deferred_id, bidder );
-
-         bids.modify( current, bidder, [&]( auto& b ) {
-            b.high_bidder = bidder;
-            b.high_bid = bid.amount;
-            b.last_bid_time = current_time_point();
-         });
-      }
-   }
-
-   void system_contract::bidrefund( const name& bidder, const name& newname ) {
-      bid_refund_table refunds_table(get_self(), newname.value);
-      auto it = refunds_table.find( bidder.value );
-      check( it != refunds_table.end(), "refund not found" );
-
-      token::transfer_action transfer_act{ token_account, { {names_account, active_permission}, {bidder, active_permission} } };
-      transfer_act.send( names_account, bidder, asset(it->amount), std::string("refund bid on name ")+(name{newname}).to_string() );
-      refunds_table.erase( it );
-   }
 
    /**
     *  Called after a new account is created. This code enforces resource-limits rules
@@ -385,7 +316,7 @@ namespace eosiosystem {
          }
       }
 
-      user_resources_table  userres( get_self(), newact.value);
+      user_resources_table  userres( get_self(), newact.value );
 
       userres.emplace( newact, [&]( auto& res ) {
         res.owner = newact;
@@ -402,11 +333,11 @@ namespace eosiosystem {
       if( itr == table.end() ) {
          table.emplace( acnt, [&]( auto& row ) {
             row.owner = acnt;
-            row.hash = sha256(const_cast<char*>(abi.data()), abi.size());
+            row.hash = eosio::sha256(const_cast<char*>(abi.data()), abi.size());
          });
       } else {
          table.modify( itr, same_payer, [&]( auto& row ) {
-            row.hash = sha256(const_cast<char*>(abi.data()), abi.size());
+            row.hash = eosio::sha256(const_cast<char*>(abi.data()), abi.size());
          });
       }
    }

--- a/contracts/eosio.system/src/exchange_state.cpp
+++ b/contracts/eosio.system/src/exchange_state.cpp
@@ -1,6 +1,12 @@
 #include <eosio.system/exchange_state.hpp>
 
+#include <eosio/check.hpp>
+
+#include <cmath>
+
 namespace eosiosystem {
+
+   using eosio::check;
 
    asset exchange_state::convert_to_exchange( connector& reserve, const asset& payment )
    {
@@ -24,7 +30,7 @@ namespace eosiosystem {
       const double Fi = double(1) / reserve.weight;
 
       double dR = R0 * ( std::pow(1. + dS / S0, Fi) - 1. ); // dR < 0 since dS < 0
-      if ( dR > 0 ) dR = 0; // rounding errors 
+      if ( dR > 0 ) dR = 0; // rounding errors
       reserve.balance.amount -= int64_t(-dR);
       supply                 -= tokens;
       return asset( int64_t(-dR), reserve.balance.symbol );

--- a/contracts/eosio.system/src/name_bidding.cpp
+++ b/contracts/eosio.system/src/name_bidding.cpp
@@ -1,0 +1,80 @@
+#include <eosio.system/eosio.system.hpp>
+#include <eosio.token/eosio.token.hpp>
+
+#include <eosio/transaction.hpp>
+
+namespace eosiosystem {
+
+   using eosio::current_time_point;
+   using eosio::token;
+
+   void system_contract::bidname( const name& bidder, const name& newname, const asset& bid ) {
+      require_auth( bidder );
+      check( newname.suffix() == newname, "you can only bid on top-level suffix" );
+
+      check( (bool)newname, "the empty name is not a valid account name to bid on" );
+      check( (newname.value & 0xFull) == 0, "13 character names are not valid account names to bid on" );
+      check( (newname.value & 0x1F0ull) == 0, "accounts with 12 character names and no dots can be created without bidding required" );
+      check( !is_account( newname ), "account already exists" );
+      check( bid.symbol == core_symbol(), "asset must be system token" );
+      check( bid.amount > 0, "insufficient bid" );
+      token::transfer_action transfer_act{ token_account, { {bidder, active_permission} } };
+      transfer_act.send( bidder, names_account, bid, std::string("bid name ")+ newname.to_string() );
+      name_bid_table bids(get_self(), get_self().value);
+      print( name{bidder}, " bid ", bid, " on ", name{newname}, "\n" );
+      auto current = bids.find( newname.value );
+      if( current == bids.end() ) {
+         bids.emplace( bidder, [&]( auto& b ) {
+            b.newname = newname;
+            b.high_bidder = bidder;
+            b.high_bid = bid.amount;
+            b.last_bid_time = current_time_point();
+         });
+      } else {
+         check( current->high_bid > 0, "this auction has already closed" );
+         check( bid.amount - current->high_bid > (current->high_bid / 10), "must increase bid by 10%" );
+         check( current->high_bidder != bidder, "account is already highest bidder" );
+
+         bid_refund_table refunds_table(get_self(), newname.value);
+
+         auto it = refunds_table.find( current->high_bidder.value );
+         if ( it != refunds_table.end() ) {
+            refunds_table.modify( it, same_payer, [&](auto& r) {
+                  r.amount += asset( current->high_bid, core_symbol() );
+               });
+         } else {
+            refunds_table.emplace( bidder, [&](auto& r) {
+                  r.bidder = current->high_bidder;
+                  r.amount = asset( current->high_bid, core_symbol() );
+               });
+         }
+
+         eosio::transaction t;
+         t.actions.emplace_back( permission_level{get_self(), active_permission},
+                                 get_self(), "bidrefund"_n,
+                                 std::make_tuple( current->high_bidder, newname )
+         );
+         t.delay_sec = 0;
+         uint128_t deferred_id = (uint128_t(newname.value) << 64) | current->high_bidder.value;
+         eosio::cancel_deferred( deferred_id );
+         t.send( deferred_id, bidder );
+
+         bids.modify( current, bidder, [&]( auto& b ) {
+            b.high_bidder = bidder;
+            b.high_bid = bid.amount;
+            b.last_bid_time = current_time_point();
+         });
+      }
+   }
+
+   void system_contract::bidrefund( const name& bidder, const name& newname ) {
+      bid_refund_table refunds_table(get_self(), newname.value);
+      auto it = refunds_table.find( bidder.value );
+      check( it != refunds_table.end(), "refund not found" );
+
+      token::transfer_action transfer_act{ token_account, { {names_account, active_permission}, {bidder, active_permission} } };
+      transfer_act.send( names_account, bidder, asset(it->amount), std::string("refund bid on name ")+(name{newname}).to_string() );
+      refunds_table.erase( it );
+   }
+
+}

--- a/contracts/eosio.system/src/native.cpp
+++ b/contracts/eosio.system/src/native.cpp
@@ -1,0 +1,27 @@
+#include <eosio.system/native.hpp>
+
+#include <eosio/check.hpp>
+
+namespace eosio {
+   bool is_feature_activated( const eosio::checksum256& feature_digest ) {
+      auto feature_digest_data = feature_digest.extract_as_byte_array();
+      return internal_use_do_not_use::is_feature_activated(
+         reinterpret_cast<const ::capi_checksum256*>( feature_digest_data.data() )
+      );
+   }
+
+   void preactivate_feature( const eosio::checksum256& feature_digest ) {
+      auto feature_digest_data = feature_digest.extract_as_byte_array();
+      internal_use_do_not_use::preactivate_feature(
+         reinterpret_cast<const ::capi_checksum256*>( feature_digest_data.data() )
+      );
+   }
+}
+
+namespace eosiosystem {
+
+   void native::onerror( ignore<uint128_t>, ignore<std::vector<char>> ) {
+      eosio::check( false, "the onerror action cannot be called directly" );
+   }
+
+}

--- a/contracts/eosio.system/src/producer_pay.cpp
+++ b/contracts/eosio.system/src/producer_pay.cpp
@@ -1,5 +1,4 @@
 #include <eosio.system/eosio.system.hpp>
-
 #include <eosio.token/eosio.token.hpp>
 
 namespace eosiosystem {

--- a/contracts/eosio.system/src/producer_pay.cpp
+++ b/contracts/eosio.system/src/producer_pay.cpp
@@ -3,17 +3,9 @@
 
 namespace eosiosystem {
 
-   const int64_t  min_pervote_daily_pay = 100'0000;
-   const int64_t  min_activated_stake   = 150'000'000'0000;
-   const double   continuous_rate       = 0.04879;          // 5% annual rate
-   const int64_t  inflation_pay_factor  = 5;                // 20% of the inflation
-   const int64_t  votepay_factor        = 4;                // 25% of the producer pay
-   const uint32_t blocks_per_year       = 52*7*24*2*3600;   // half seconds per year
-   const uint32_t seconds_per_year      = 52*7*24*3600;
-   const uint32_t blocks_per_day        = 2 * 24 * 3600;
-   const uint32_t blocks_per_hour       = 2 * 3600;
-   const int64_t  useconds_per_day      = 24 * 3600 * int64_t(1000000);
-   const int64_t  useconds_per_year     = seconds_per_year*1000000ll;
+   using eosio::current_time_point;
+   using eosio::microseconds;
+   using eosio::token;
 
    void system_contract::onblock( ignore<block_header> ) {
       using namespace eosio;
@@ -73,7 +65,6 @@ namespace eosiosystem {
       }
    }
 
-   using namespace eosio;
    void system_contract::claimrewards( const name& owner ) {
       require_auth( owner );
 
@@ -87,7 +78,7 @@ namespace eosiosystem {
 
       check( ct - prod.last_claim_time > microseconds(useconds_per_day), "already claimed rewards within past day" );
 
-      const asset token_supply   = eosio::token::get_supply(token_account, core_symbol().code() );
+      const asset token_supply   = token::get_supply(token_account, core_symbol().code() );
       const auto usecs_since_last_fill = (ct - _gstate.last_pervote_bucket_fill).count();
 
       if( usecs_since_last_fill > 0 && _gstate.last_pervote_bucket_fill > time_point() ) {

--- a/contracts/eosio.system/src/producer_pay.cpp
+++ b/contracts/eosio.system/src/producer_pay.cpp
@@ -18,7 +18,7 @@ namespace eosiosystem {
    void system_contract::onblock( ignore<block_header> ) {
       using namespace eosio;
 
-      require_auth(_self);
+      require_auth(get_self());
 
       block_timestamp timestamp;
       name producer;
@@ -54,7 +54,7 @@ namespace eosiosystem {
          update_elected_producers( timestamp );
 
          if( (timestamp.slot - _gstate.last_name_close.slot) > blocks_per_day ) {
-            name_bid_table bids(_self, _self.value);
+            name_bid_table bids(get_self(), get_self().value);
             auto idx = bids.get_index<"highbid"_n>();
             auto highest = idx.lower_bound( std::numeric_limits<uint64_t>::max()/2 );
             if( highest != idx.end() &&
@@ -98,14 +98,14 @@ namespace eosiosystem {
          auto to_per_block_pay = to_producers / votepay_factor;
          auto to_per_vote_pay  = to_producers - to_per_block_pay;
          {
-            token::issue_action issue_act{ token_account, { {_self, active_permission} } };
-            issue_act.send( _self, asset(new_tokens, core_symbol()), "issue tokens for producer pay and savings" );
+            token::issue_action issue_act{ token_account, { {get_self(), active_permission} } };
+            issue_act.send( get_self(), asset(new_tokens, core_symbol()), "issue tokens for producer pay and savings" );
          }
          {
-            token::transfer_action transfer_act{ token_account, { {_self, active_permission} } };
-            transfer_act.send( _self, saving_account, asset(to_savings, core_symbol()), "unallocated inflation" );
-            transfer_act.send( _self, bpay_account, asset(to_per_block_pay, core_symbol()), "fund per-block bucket" );
-            transfer_act.send( _self, vpay_account, asset(to_per_vote_pay, core_symbol()), "fund per-vote bucket" );
+            token::transfer_action transfer_act{ token_account, { {get_self(), active_permission} } };
+            transfer_act.send( get_self(), saving_account, asset(to_savings, core_symbol()), "unallocated inflation" );
+            transfer_act.send( get_self(), bpay_account, asset(to_per_block_pay, core_symbol()), "fund per-block bucket" );
+            transfer_act.send( get_self(), vpay_account, asset(to_per_vote_pay, core_symbol()), "fund per-vote bucket" );
          }
 
          _gstate.pervote_bucket          += to_per_vote_pay;

--- a/contracts/eosio.system/src/rex.cpp
+++ b/contracts/eosio.system/src/rex.cpp
@@ -392,9 +392,9 @@ namespace eosiosystem {
 
          if( !(net_managed && cpu_managed) ) {
             int64_t ram_bytes = 0, net = 0, cpu = 0;
-            get_resource_limits( receiver.value, &ram_bytes, &net, &cpu );
+            get_resource_limits( receiver, ram_bytes, net, cpu );
 
-            set_resource_limits( receiver.value,
+            set_resource_limits( receiver,
                                  ram_bytes,
                                  net_managed ? net : tot_itr->net_weight.amount,
                                  cpu_managed ? cpu : tot_itr->cpu_weight.amount );
@@ -851,7 +851,7 @@ namespace eosiosystem {
    time_point_sec system_contract::get_rex_maturity()
    {
       const uint32_t num_of_maturity_buckets = 5;
-      static const uint32_t now = current_time_point_sec().utc_seconds;
+      static const uint32_t now = current_time_point().sec_since_epoch();
       static const uint32_t r   = now % seconds_per_day;
       static const time_point_sec rms{ now - r + num_of_maturity_buckets * seconds_per_day };
       return rms;
@@ -864,7 +864,7 @@ namespace eosiosystem {
     */
    void system_contract::process_rex_maturities( const rex_balance_table::const_iterator& bitr )
    {
-      const time_point_sec now = current_time_point_sec();
+      const time_point_sec now = current_time_point();
       _rexbalance.modify( bitr, same_payer, [&]( auto& rb ) {
          while ( !rb.rex_maturities.empty() && rb.rex_maturities.front().first <= now ) {
             rb.matured_rex += rb.rex_maturities.front().second;

--- a/contracts/eosio.system/src/rex.cpp
+++ b/contracts/eosio.system/src/rex.cpp
@@ -1,7 +1,11 @@
 #include <eosio.system/eosio.system.hpp>
+#include <eosio.token/eosio.token.hpp>
 #include <eosio.system/rex.results.hpp>
 
 namespace eosiosystem {
+
+   using eosio::current_time_point;
+   using eosio::token;
 
    void system_contract::deposit( const name& owner, const asset& amount )
    {

--- a/contracts/eosio.system/src/rex.cpp
+++ b/contracts/eosio.system/src/rex.cpp
@@ -59,7 +59,7 @@ namespace eosiosystem {
       check_voting_requirement( owner );
 
       {
-         del_bandwidth_table dbw_table( _self, owner.value );
+         del_bandwidth_table dbw_table( get_self(), owner.value );
          auto del_itr = dbw_table.require_find( receiver.value, "delegated bandwidth record does not exist" );
          check( from_net.amount <= del_itr->net_weight.amount, "amount exceeds tokens staked for net");
          check( from_cpu.amount <= del_itr->cpu_weight.amount, "amount exceeds tokens staked for cpu");
@@ -152,7 +152,7 @@ namespace eosiosystem {
    {
       require_auth( from );
 
-      rex_cpu_loan_table cpu_loans( _self, _self.value );
+      rex_cpu_loan_table cpu_loans( get_self(), get_self().value );
       int64_t rented_tokens = rent_rex( cpu_loans, from, receiver, loan_payment, loan_fund );
       update_resource_limits( from, receiver, 0, rented_tokens );
    }
@@ -161,7 +161,7 @@ namespace eosiosystem {
    {
       require_auth( from );
 
-      rex_net_loan_table net_loans( _self, _self.value );
+      rex_net_loan_table net_loans( get_self(), get_self().value );
       int64_t rented_tokens = rent_rex( net_loans, from, receiver, loan_payment, loan_fund );
       update_resource_limits( from, receiver, rented_tokens, 0 );
    }
@@ -170,7 +170,7 @@ namespace eosiosystem {
    {
       require_auth( from );
 
-      rex_cpu_loan_table cpu_loans( _self, _self.value );
+      rex_cpu_loan_table cpu_loans( get_self(), get_self().value );
       fund_rex_loan( cpu_loans, from, loan_num, payment  );
    }
 
@@ -178,7 +178,7 @@ namespace eosiosystem {
    {
       require_auth( from );
 
-      rex_net_loan_table net_loans( _self, _self.value );
+      rex_net_loan_table net_loans( get_self(), get_self().value );
       fund_rex_loan( net_loans, from, loan_num, payment );
    }
 
@@ -186,7 +186,7 @@ namespace eosiosystem {
    {
       require_auth( from );
 
-      rex_cpu_loan_table cpu_loans( _self, _self.value );
+      rex_cpu_loan_table cpu_loans( get_self(), get_self().value );
       defund_rex_loan( cpu_loans, from, loan_num, amount );
    }
 
@@ -194,7 +194,7 @@ namespace eosiosystem {
    {
       require_auth( from );
 
-      rex_net_loan_table net_loans( _self, _self.value );
+      rex_net_loan_table net_loans( get_self(), get_self().value );
       defund_rex_loan( net_loans, from, loan_num, amount );
    }
 
@@ -322,11 +322,11 @@ namespace eosiosystem {
 
       /// check for any outstanding loans or rex fund
       {
-         rex_cpu_loan_table cpu_loans( _self, _self.value );
+         rex_cpu_loan_table cpu_loans( get_self(), get_self().value );
          auto cpu_idx = cpu_loans.get_index<"byowner"_n>();
          bool no_outstanding_cpu_loans = ( cpu_idx.find( owner.value ) == cpu_idx.end() );
 
-         rex_net_loan_table net_loans( _self, _self.value );
+         rex_net_loan_table net_loans( get_self(), get_self().value );
          auto net_idx = net_loans.get_index<"byowner"_n>();
          bool no_outstanding_net_loans = ( net_idx.find( owner.value ) == net_idx.end() );
 
@@ -362,7 +362,7 @@ namespace eosiosystem {
          return;
       }
 
-      user_resources_table totals_tbl( _self, receiver.value );
+      user_resources_table totals_tbl( get_self(), receiver.value );
       auto tot_itr = totals_tbl.find( receiver.value );
       if ( tot_itr == totals_tbl.end() ) {
          check( 0 <= delta_net && 0 <= delta_cpu, "logic error, should not occur");
@@ -551,7 +551,7 @@ namespace eosiosystem {
 
       /// process cpu loans
       {
-         rex_cpu_loan_table cpu_loans( _self, _self.value );
+         rex_cpu_loan_table cpu_loans( get_self(), get_self().value );
          auto cpu_idx = cpu_loans.get_index<"byexpr"_n>();
          for ( uint16_t i = 0; i < max; ++i ) {
             auto itr = cpu_idx.begin();
@@ -568,7 +568,7 @@ namespace eosiosystem {
 
       /// process net loans
       {
-         rex_net_loan_table net_loans( _self, _self.value );
+         rex_net_loan_table net_loans( get_self(), get_self().value );
          auto net_idx = net_loans.get_index<"byexpr"_n>();
          for ( uint16_t i = 0; i < max; ++i ) {
             auto itr = net_idx.begin();
@@ -920,7 +920,7 @@ namespace eosiosystem {
       auto itr = _rexpool.begin();
       if ( !rex_system_initialized() ) {
          /// initialize REX pool
-         _rexpool.emplace( _self, [&]( auto& rp ) {
+         _rexpool.emplace( get_self(), [&]( auto& rp ) {
             rex_received.amount = payment.amount * rex_ratio;
             rp.total_lendable   = payment;
             rp.total_lent       = asset( 0, core_symbol() );

--- a/contracts/eosio.system/src/voting.cpp
+++ b/contracts/eosio.system/src/voting.cpp
@@ -5,7 +5,6 @@
 #include <eosio/privileged.hpp>
 #include <eosio/serialize.hpp>
 #include <eosio/singleton.hpp>
-#include <eosio/transaction.hpp>
 
 #include <eosio.system/eosio.system.hpp>
 #include <eosio.token/eosio.token.hpp>
@@ -16,9 +15,10 @@
 namespace eosiosystem {
 
    using eosio::const_mem_fun;
+   using eosio::current_time_point;
    using eosio::indexed_by;
+   using eosio::microseconds;
    using eosio::singleton;
-   using eosio::transaction;
 
    void system_contract::regproducer( const name& producer, const eosio::public_key& producer_key, const std::string& url, uint16_t location ) {
       check( url.size() < 512, "url too long" );
@@ -204,7 +204,7 @@ namespace eosiosystem {
          new_vote_weight += voter->proxied_vote_weight;
       }
 
-      std::map<name, pair<double, bool /*new*/> > producer_deltas;
+      std::map<name, std::pair<double, bool /*new*/> > producer_deltas;
       if ( voter->last_vote_weight > 0 ) {
          if( voter->proxy ) {
             auto old_proxy = _voters.find( voter->proxy.value );

--- a/contracts/eosio.system/src/voting.cpp
+++ b/contracts/eosio.system/src/voting.cpp
@@ -1,21 +1,22 @@
-#include <eosio.system/eosio.system.hpp>
+#include <eosio/crypto.hpp>
+#include <eosio/datastream.hpp>
+#include <eosio/eosio.hpp>
+#include <eosio/multi_index.hpp>
+#include <eosio/privileged.hpp>
+#include <eosio/serialize.hpp>
+#include <eosio/singleton.hpp>
+#include <eosio/transaction.hpp>
 
-#include <eosiolib/eosio.hpp>
-#include <eosiolib/crypto.h>
-#include <eosiolib/datastream.hpp>
-#include <eosiolib/serialize.hpp>
-#include <eosiolib/multi_index.hpp>
-#include <eosiolib/privileged.hpp>
-#include <eosiolib/singleton.hpp>
-#include <eosiolib/transaction.hpp>
+#include <eosio.system/eosio.system.hpp>
 #include <eosio.token/eosio.token.hpp>
 
 #include <algorithm>
 #include <cmath>
 
 namespace eosiosystem {
-   using eosio::indexed_by;
+
    using eosio::const_mem_fun;
+   using eosio::indexed_by;
    using eosio::singleton;
    using eosio::transaction;
 
@@ -98,16 +99,14 @@ namespace eosiosystem {
       for( const auto& item : top_producers )
          producers.push_back(item.first);
 
-      auto packed_schedule = pack(producers);
-
-      if( set_proposed_producers( packed_schedule.data(),  packed_schedule.size() ) >= 0 ) {
+      if( set_proposed_producers( producers ) >= 0 ) {
          _gstate.last_producer_schedule_size = static_cast<decltype(_gstate.last_producer_schedule_size)>( top_producers.size() );
       }
    }
 
    double stake2vote( int64_t staked ) {
       /// TODO subtract 2080 brings the large numbers closer to this decade
-      double weight = int64_t( (now() - (block_timestamp::block_timestamp_epoch / 1000)) / (seconds_per_day * 7) )  / double( 52 );
+      double weight = int64_t( (current_time_point().sec_since_epoch() - (block_timestamp::block_timestamp_epoch / 1000)) / (seconds_per_day * 7) )  / double( 52 );
       return double(staked) * std::pow( 2, weight );
    }
 
@@ -205,7 +204,7 @@ namespace eosiosystem {
          new_vote_weight += voter->proxied_vote_weight;
       }
 
-      boost::container::flat_map<name, pair<double, bool /*new*/> > producer_deltas;
+      std::map<name, pair<double, bool /*new*/> > producer_deltas;
       if ( voter->last_vote_weight > 0 ) {
          if( voter->proxy ) {
             auto old_proxy = _voters.find( voter->proxy.value );

--- a/contracts/eosio.token/include/eosio.token/eosio.token.hpp
+++ b/contracts/eosio.token/include/eosio.token/eosio.token.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
-#include <eosiolib/asset.hpp>
-#include <eosiolib/eosio.hpp>
+#include <eosio/asset.hpp>
+#include <eosio/eosio.hpp>
 
 #include <string>
 

--- a/contracts/eosio.token/src/eosio.token.cpp
+++ b/contracts/eosio.token/src/eosio.token.cpp
@@ -5,18 +5,18 @@ namespace eosio {
 void token::create( const name&   issuer,
                     const asset&  maximum_supply )
 {
-    require_auth( _self );
+    require_auth( get_self() );
 
     auto sym = maximum_supply.symbol;
     check( sym.is_valid(), "invalid symbol name" );
     check( maximum_supply.is_valid(), "invalid supply");
     check( maximum_supply.amount > 0, "max-supply must be positive");
 
-    stats statstable( _self, sym.code().raw() );
+    stats statstable( get_self(), sym.code().raw() );
     auto existing = statstable.find( sym.code().raw() );
     check( existing == statstable.end(), "token with symbol already exists" );
 
-    statstable.emplace( _self, [&]( auto& s ) {
+    statstable.emplace( get_self(), [&]( auto& s ) {
        s.supply.symbol = maximum_supply.symbol;
        s.max_supply    = maximum_supply;
        s.issuer        = issuer;
@@ -30,7 +30,7 @@ void token::issue( const name& to, const asset& quantity, const string& memo )
     check( sym.is_valid(), "invalid symbol name" );
     check( memo.size() <= 256, "memo has more than 256 bytes" );
 
-    stats statstable( _self, sym.code().raw() );
+    stats statstable( get_self(), sym.code().raw() );
     auto existing = statstable.find( sym.code().raw() );
     check( existing != statstable.end(), "token with symbol does not exist, create token before issue" );
     const auto& st = *existing;
@@ -56,7 +56,7 @@ void token::retire( const asset& quantity, const string& memo )
     check( sym.is_valid(), "invalid symbol name" );
     check( memo.size() <= 256, "memo has more than 256 bytes" );
 
-    stats statstable( _self, sym.code().raw() );
+    stats statstable( get_self(), sym.code().raw() );
     auto existing = statstable.find( sym.code().raw() );
     check( existing != statstable.end(), "token with symbol does not exist" );
     const auto& st = *existing;
@@ -83,7 +83,7 @@ void token::transfer( const name&    from,
     require_auth( from );
     check( is_account( to ), "to account does not exist");
     auto sym = quantity.symbol.code();
-    stats statstable( _self, sym.raw() );
+    stats statstable( get_self(), sym.raw() );
     const auto& st = statstable.get( sym.raw() );
 
     require_recipient( from );
@@ -101,7 +101,7 @@ void token::transfer( const name&    from,
 }
 
 void token::sub_balance( const name& owner, const asset& value ) {
-   accounts from_acnts( _self, owner.value );
+   accounts from_acnts( get_self(), owner.value );
 
    const auto& from = from_acnts.get( value.symbol.code().raw(), "no balance object found" );
    check( from.balance.amount >= value.amount, "overdrawn balance" );
@@ -113,7 +113,7 @@ void token::sub_balance( const name& owner, const asset& value ) {
 
 void token::add_balance( const name& owner, const asset& value, const name& ram_payer )
 {
-   accounts to_acnts( _self, owner.value );
+   accounts to_acnts( get_self(), owner.value );
    auto to = to_acnts.find( value.symbol.code().raw() );
    if( to == to_acnts.end() ) {
       to_acnts.emplace( ram_payer, [&]( auto& a ){
@@ -132,11 +132,11 @@ void token::open( const name& owner, const symbol& symbol, const name& ram_payer
 
    auto sym_code_raw = symbol.code().raw();
 
-   stats statstable( _self, sym_code_raw );
+   stats statstable( get_self(), sym_code_raw );
    const auto& st = statstable.get( sym_code_raw, "symbol does not exist" );
    check( st.supply.symbol == symbol, "symbol precision mismatch" );
 
-   accounts acnts( _self, owner.value );
+   accounts acnts( get_self(), owner.value );
    auto it = acnts.find( sym_code_raw );
    if( it == acnts.end() ) {
       acnts.emplace( ram_payer, [&]( auto& a ){
@@ -148,7 +148,7 @@ void token::open( const name& owner, const symbol& symbol, const name& ram_payer
 void token::close( const name& owner, const symbol& symbol )
 {
    require_auth( owner );
-   accounts acnts( _self, owner.value );
+   accounts acnts( get_self(), owner.value );
    auto it = acnts.find( symbol.code().raw() );
    check( it != acnts.end(), "Balance row already deleted or never existed. Action won't have any effect." );
    check( it->balance.amount == 0, "Cannot close because the balance is not zero." );

--- a/contracts/eosio.wrap/include/eosio.wrap/eosio.wrap.hpp
+++ b/contracts/eosio.wrap/include/eosio.wrap/eosio.wrap.hpp
@@ -1,8 +1,8 @@
 #pragma once
 
-#include <eosiolib/eosio.hpp>
-#include <eosiolib/ignore.hpp>
-#include <eosiolib/transaction.hpp>
+#include <eosio/eosio.hpp>
+#include <eosio/ignore.hpp>
+#include <eosio/transaction.hpp>
 
 namespace eosio {
    /**
@@ -10,10 +10,10 @@ namespace eosio {
     * @ingroup eosiocontracts
     * eosio.wrap contract simplifies Block Producer superuser actions by making them more readable and easier to audit.
 
-    * @details It does not grant block producers any additional powers that do not already exist within the 
-    * system. Currently, 15/21 block producers can already change an account's keys or modify an 
-    * account's contract at the request of ECAF or an account's owner. However, the current method 
-    * is opaque and leaves undesirable side effects on specific system accounts. 
+    * @details It does not grant block producers any additional powers that do not already exist within the
+    * system. Currently, 15/21 block producers can already change an account's keys or modify an
+    * account's contract at the request of ECAF or an account's owner. However, the current method
+    * is opaque and leaves undesirable side effects on specific system accounts.
     * eosio.wrap allows for a cleaner method of implementing these important governance actions.
     * @{
     */
@@ -23,14 +23,14 @@ namespace eosio {
 
          /**
           * Execute action.
-          * 
+          *
           * @details Execute a transaction while bypassing regular authorization checks.
-          * 
+          *
           * @param executer - account executing the transaction,
           * @param trx - the transaction to be executed.
-          * 
+          *
           * @pre Requires authorization of eosio.wrap which needs to be a privileged account.
-          * 
+          *
           * @post Deferred transaction RAM usage is billed to 'executer'
           */
          [[eosio::action]]

--- a/contracts/eosio.wrap/src/eosio.wrap.cpp
+++ b/contracts/eosio.wrap/src/eosio.wrap.cpp
@@ -10,7 +10,8 @@ void wrap::exec( ignore<name>, ignore<transaction> ) {
 
    require_auth( executer );
 
-   send_deferred( (uint128_t(executer.value) << 64) | current_time(), executer.value, _ds.pos(), _ds.remaining() );
+   send_deferred( (uint128_t(executer.value) << 64) | (uint64_t)current_time_point().time_since_epoch().count(),
+                  executer, _ds.pos(), _ds.remaining() );
 }
 
 } /// namespace eosio

--- a/contracts/eosio.wrap/src/eosio.wrap.cpp
+++ b/contracts/eosio.wrap/src/eosio.wrap.cpp
@@ -3,7 +3,7 @@
 namespace eosio {
 
 void wrap::exec( ignore<name>, ignore<transaction> ) {
-   require_auth( _self );
+   require_auth( get_self() );
 
    name executer;
    _ds >> executer;


### PR DESCRIPTION
## Change Description

Update all contracts to use the new EOSIO.CDT v1.6.x headers rather than the deprecated ones. This part of the PR is effectively a port of #242 for the 1.7.x branch. 

In addition, the upgrade to the new headers requires also bringing in workaround for the check_transaction_authorization bug (see #257 for the version of this workaround that was merged into the develop branch).

Also, all usage of raw `_self` is replaced by the `get_self()` accessor function.

Finally, the system contract files are rearranged to enable building the system contract by separately compiling individual .cpp files and linking the .o files together into the final .wasm file. (There is one exception where the `name_bidding.cpp` file is directly included into the `delegate_bandwidth.cpp` file rather than compiling it separately. This is to work around a problems with the header files in CDT that case duplicate symbol errors when linking. See EOSIO/eosio.cdt#539.) 

## Deployment Changes
- [ ] Deployment Changes

## API Changes
- [ ] API Changes

## Documentation Additions
- [ ] Documentation Additions
