### PR TITLE
Default list of eosio subdirs as empty. Check the default directory o…

### DIFF
--- a/scripts/helper.sh
+++ b/scripts/helper.sh
@@ -26,7 +26,10 @@ function check-version-numbers() {
 # Handles choosing which EOSIO directory to select when the default location is used.
 function default-eosio-directories() {
   REGEX='^[0-9]+([.][0-9]+)?$'
-  ALL_EOSIO_SUBDIRS=($(ls ${HOME}/eosio | sort -V))
+  ALL_EOSIO_SUBDIRS=()
+  if [[ -d ${HOME}/eosio ]]; then
+    ALL_EOSIO_SUBDIRS=($(ls ${HOME}/eosio | sort -V))
+  fi
   for ITEM in "${ALL_EOSIO_SUBDIRS[@]}"; do
     if [[ "$ITEM" =~ $REGEX ]]; then
       DIR_MAJOR=$(echo $ITEM | cut -f1 -d '.')


### PR DESCRIPTION
…nly if it exists.

<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->

## Change Description
<!-- Describe your changes, their justification, AND their impact. Reference issues or pull requests where possible (use '#XX' or 'GH-XX' where XX is the issue or pull request number). -->
* Fixed issue in ```build.sh```  if the ```$HOME/eosio``` directory doesn’t exist.
** Defaults list of subdirectories to empty and performs checks only if ```$HOME/eosio``` exists.

## Deployment Changes
- [ ] Deployment Changes
<!-- checked [x] = Deployment changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces a change to the contracts that causes deployment to change, please describe the impact. -->


## API Changes
- [ ] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions
- [ ] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
