### PR TITLE
Change setinflation parameters

### DIFF
--- a/contracts/eosio.system/include/eosio.system/eosio.system.hpp
+++ b/contracts/eosio.system/include/eosio.system/eosio.system.hpp
@@ -70,8 +70,9 @@ namespace eosiosystem {
 
    static constexpr int64_t  inflation_precision           = 100;     // 2 decimals
    static constexpr int64_t  default_annual_rate           = 500;     // 5% annual rate
-   static constexpr int64_t  default_inflation_pay_factor  = 5;       // 20% of the inflation
-   static constexpr int64_t  default_votepay_factor        = 4;       // 25% of the producer pay
+   static constexpr int64_t  pay_factor_precision          = 10000;
+   static constexpr int64_t  default_inflation_pay_factor  = 50000;   // producers pay share = 10000 / 50000 = 20% of the inflation
+   static constexpr int64_t  default_votepay_factor        = 40000;   // per-block pay share = 10000 / 40000 = 25% of the producer pay
 
    /**
     *
@@ -1273,13 +1274,13 @@ namespace eosiosystem {
           *
           * @param inflation_pay_factor - Inverse of the fraction of the inflation used to reward block producers.
           *     The remaining inflation will be sent to the `eosio.saving` account.
-          *     (eg. For 20% of inflation going to block producer rewards  => inflation_pay_factor=5
-          *          For 100% of inflation going to block producer rewards  => inflation_pay_factor=1).
+          *     (eg. For 20% of inflation going to block producer rewards   => inflation_pay_factor = 50000
+          *          For 100% of inflation going to block producer rewards  => inflation_pay_factor = 10000).
           *
           * @param votepay_factor - Inverse of the fraction of the block producer rewards to be distributed proportional to blocks produced.
           *     The remaining rewards will be distributed proportional to votes received.
-          *     (eg. For 25% of block producer rewards going towards block pay => votepay_factor=4
-          *          For 50% of block producer rewards going towards block pay => votepay_factor=2).
+          *     (eg. For 25% of block producer rewards going towards block pay => votepay_factor = 40000
+          *          For 75% of block producer rewards going towards block pay => votepay_factor = 13333).
           */
          [[eosio::action]]
          void setinflation( int64_t annual_rate, int64_t inflation_pay_factor, int64_t votepay_factor );
@@ -1328,6 +1329,7 @@ namespace eosiosystem {
          using setpriv_action = eosio::action_wrapper<"setpriv"_n, &system_contract::setpriv>;
          using setalimits_action = eosio::action_wrapper<"setalimits"_n, &system_contract::setalimits>;
          using setparams_action = eosio::action_wrapper<"setparams"_n, &system_contract::setparams>;
+         using setinflation_action = eosio::action_wrapper<"setinflation"_n, &system_contract::setinflation>;
 
       private:
          // Implementation details:

--- a/contracts/eosio.system/ricardian/eosio.system.contracts.md.in
+++ b/contracts/eosio.system/ricardian/eosio.system.contracts.md.in
@@ -558,8 +558,8 @@ icon: @ICON_BASE_URL@/@ADMIN_ICON_URI@
 {{$action.account}} sets the inflation parameters as follows:
 
 * Annual inflation rate (in units of a hundredth of a percent): {{annual_rate}}
-* Fraction of inflation used to reward block producers: 1/{{inflation_pay_factor}}
-* Fraction of block producer rewards to be distributed proportional to blocks produced: 1/{{votepay_factor}}
+* Fraction of inflation used to reward block producers: 10000/{{inflation_pay_factor}}
+* Fraction of block producer rewards to be distributed proportional to blocks produced: 10000/{{votepay_factor}}
 
 <h1 class="contract">undelegatebw</h1>
 

--- a/contracts/eosio.system/src/eosio.system.cpp
+++ b/contracts/eosio.system/src/eosio.system.cpp
@@ -290,18 +290,19 @@ namespace eosiosystem {
       check( _gstate2.revision < 255, "can not increment revision" ); // prevent wrap around
       check( revision == _gstate2.revision + 1, "can only increment revision by one" );
       check( revision <= 1, // set upper bound to greatest revision supported in the code
-                    "specified revision is not yet supported by the code" );
+             "specified revision is not yet supported by the code" );
       _gstate2.revision = revision;
    }
-
-
 
    void system_contract::setinflation( int64_t annual_rate, int64_t inflation_pay_factor, int64_t votepay_factor ) {
       require_auth(get_self());
       check(annual_rate >= 0, "annual_rate can't be negative");
-      check(inflation_pay_factor > 0, "inflation_pay_factor must be positive");
-      check(votepay_factor > 0, "votepay_factor must be positive");
-
+      if ( inflation_pay_factor < pay_factor_precision ) {
+         check( false, "inflation_pay_factor must not be less than " + std::to_string(pay_factor_precision) );
+      }
+      if ( votepay_factor < pay_factor_precision ) {
+         check( false, "votepay_factor must not be less than " + std::to_string(pay_factor_precision) );
+      }
       _gstate4.continuous_rate      = get_continuous_rate(annual_rate);
       _gstate4.inflation_pay_factor = inflation_pay_factor;
       _gstate4.votepay_factor       = votepay_factor;

--- a/contracts/eosio.system/src/producer_pay.cpp
+++ b/contracts/eosio.system/src/producer_pay.cpp
@@ -82,12 +82,12 @@ namespace eosiosystem {
       const auto usecs_since_last_fill = (ct - _gstate.last_pervote_bucket_fill).count();
 
       if( usecs_since_last_fill > 0 && _gstate.last_pervote_bucket_fill > time_point() ) {
-         auto new_tokens = static_cast<int64_t>( (_gstate4.continuous_rate * double(token_supply.amount) * double(usecs_since_last_fill)) / double(useconds_per_year) );
+         int64_t new_tokens = (_gstate4.continuous_rate * double(token_supply.amount) * double(usecs_since_last_fill)) / double(useconds_per_year);
 
-         auto to_producers     = new_tokens / _gstate4.inflation_pay_factor;
-         auto to_savings       = new_tokens - to_producers;
-         auto to_per_block_pay = to_producers / _gstate4.votepay_factor;
-         auto to_per_vote_pay  = to_producers - to_per_block_pay;
+         int64_t to_producers     = (new_tokens * uint128_t(pay_factor_precision)) / _gstate4.inflation_pay_factor;
+         int64_t to_savings       = new_tokens - to_producers;
+         int64_t to_per_block_pay = (to_producers * uint128_t(pay_factor_precision)) / _gstate4.votepay_factor;
+         int64_t to_per_vote_pay  = to_producers - to_per_block_pay;
 
          if( new_tokens > 0 ) {
             {

--- a/tests/eosio.system_tests.cpp
+++ b/tests/eosio.system_tests.cpp
@@ -1433,6 +1433,17 @@ BOOST_FIXTURE_TEST_CASE(producer_pay, eosio_system_tester, * boost::unit_test::t
 BOOST_FIXTURE_TEST_CASE(change_inflation, eosio_system_tester) try {
 
    {
+      BOOST_REQUIRE_EQUAL( success(),
+                           setinflation(0, 10000, 10000) );
+      BOOST_REQUIRE_EQUAL( wasm_assert_msg("annual_rate can't be negative"),
+                           setinflation(-1, 10000, 10000) );
+      BOOST_REQUIRE_EQUAL( wasm_assert_msg("inflation_pay_factor must not be less than 10000"),
+                           setinflation(1, 9999, 10000) );
+      BOOST_REQUIRE_EQUAL( wasm_assert_msg("votepay_factor must not be less than 10000"),
+                           setinflation(1, 10000, 9999) );
+   }
+
+   {
       const asset large_asset = core_sym::from_string("80.0000");
       create_account_with_resources( N(defproducera), config::system_account_name, core_sym::from_string("1.0000"), false, large_asset, large_asset );
       create_account_with_resources( N(defproducerb), config::system_account_name, core_sym::from_string("1.0000"), false, large_asset, large_asset );
@@ -1513,6 +1524,7 @@ BOOST_FIXTURE_TEST_CASE(change_inflation, eosio_system_tester) try {
    }
 
 } FC_LOG_AND_RETHROW()
+
 
 BOOST_FIXTURE_TEST_CASE(multiple_producer_pay, eosio_system_tester, * boost::unit_test::tolerance(1e-10)) try {
 

--- a/tests/eosio.system_tests.cpp
+++ b/tests/eosio.system_tests.cpp
@@ -1382,12 +1382,12 @@ BOOST_FIXTURE_TEST_CASE(producer_pay, eosio_system_tester, * boost::unit_test::t
       BOOST_REQUIRE_EQUAL(claim_time, microseconds_since_epoch_of_iso_string( prod["last_claim_time"] ));
       auto usecs_between_fills = claim_time - initial_claim_time;
 
-      BOOST_REQUIRE_EQUAL(int64_t( ( double(initial_supply.get_amount()) * double(usecs_between_fills) * continuous_rate / usecs_per_year ) ),
-                          supply.get_amount() - initial_supply.get_amount());
+      BOOST_REQUIRE_EQUAL( int64_t( initial_supply.get_amount() * double(usecs_between_fills) * continuous_rate / usecs_per_year ),
+                           supply.get_amount() - initial_supply.get_amount() );
       BOOST_REQUIRE_EQUAL( (supply.get_amount() - initial_supply.get_amount()) - (supply.get_amount() - initial_supply.get_amount()) / 5,
-                          savings - initial_savings);
+                           savings - initial_savings );
 
-      int64_t to_producer        = int64_t( (double(initial_supply.get_amount()) * double(usecs_between_fills) * continuous_rate) / usecs_per_year ) / 5;
+      int64_t to_producer        = int64_t( initial_supply.get_amount() * double(usecs_between_fills) * continuous_rate / usecs_per_year ) / 5;
       int64_t to_perblock_bucket = to_producer / 4;
       int64_t to_pervote_bucket  = to_producer - to_perblock_bucket;
 
@@ -1487,7 +1487,7 @@ BOOST_FIXTURE_TEST_CASE(change_inflation, eosio_system_tester) try {
             BOOST_REQUIRE_EQUAL( theoretical_new_tokens, 0 );
          }
 
-         double savings_inflation = inflation*double(inflation_pay_factor-1)/double(inflation_pay_factor);
+         double savings_inflation = inflation - inflation * 10000 / inflation_pay_factor;
 
          double computed_savings_tokens = double(final_savings-initial_savings);
          double theoretical_savings_tokens = double(initial_supply.get_amount())*savings_inflation;
@@ -1502,14 +1502,14 @@ BOOST_FIXTURE_TEST_CASE(change_inflation, eosio_system_tester) try {
          }
       };
 
-      //1% inflation for 1 year => 50% saving / 50% bp reward
-      run_for_1year(100, 2, 5);
+      // 1% inflation for 1 year. 50% savings / 50% bp reward. 10000 / 50000 = 0.2 => 20% blockpay, 80% votepay
+      run_for_1year(100, 20000, 50000);
 
-      //3% inflation for 1 year => 66.6% savings / 33.33 bp reward
-      run_for_1year(300, 3, 5);
+      // 3% inflation for 1 year. 66.6% savings / 33.33% bp reward. 10000/13333 = 0.75 => 75% blockpay, 25% votepay 
+      run_for_1year(300, 30000, 13333); 
 
-      //0% inflation for 1 year
-      run_for_1year(0, 3, 5);
+      // 0% inflation for 1 year
+      run_for_1year(0, 30000, 50000);
    }
 
 } FC_LOG_AND_RETHROW()


### PR DESCRIPTION
<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->

## Change Description
<!-- Describe your changes, their justification, AND their impact. Reference issues or pull requests where possible (use '#XX' or 'GH-XX' where XX is the issue or pull request number). -->
Changed `setinflation` parameters `inflation_pay_factor` and `votepay_factor` as follows:

The fraction of inflation that goes to bp rewards is `10000 / inflation_pay_factor`. For example, if `20%` of inflation going to block producer rewards, `inflation_pay_factor = 50000`.

Per-block pay fraction of bp rewards is `10000 / votepay_factor`. For example:
For `25%` of bp rewards going towards block pay, `votepay_factor = 40000`.
For `75%` of bp rewards going towards block pay, `votepay_factor = 13333`.

## Deployment Changes
- [ ] Deployment Changes
<!-- checked [x] = Deployment changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces a change to the contracts that causes deployment to change, please describe the impact. -->


## API Changes
- [ ] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions
- [x] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
