### PR TITLE
Build and Test on Images from the eosio-dot-contracts-base-images-beta Pipeline

### DIFF
--- a/.cicd/pipeline.yml
+++ b/.cicd/pipeline.yml
@@ -28,7 +28,7 @@ steps:
       - docker#v3.2.0:
           always-pull: true
           debug: $DEBUG
-          image: "eosio/ci-contracts-builder:d1be23a980c874b30a7d696daab7c8d2e31c2175"
+          image: "eosio/ci-contracts-builder:17ee214-889efb1"
           mount-buildkite-agent: true
           mount-checkout: true
           propagate-environment: true

--- a/.cicd/pipeline.yml
+++ b/.cicd/pipeline.yml
@@ -1,6 +1,14 @@
 steps:
   - wait
 
+  - trigger: "eosio_contracts_base_images_beta"
+    label: ":docker: Ensure Base Images"
+    build:
+      commit: "${BUILDKITE_COMMIT}"
+      branch: "${BUILDKITE_BRANCH}"
+
+  - wait
+
   - label: ":webhook: Trigger Travis CI Build"
     command: |
       ./.cicd/trigger-travis.sh

--- a/.cicd/pipeline.yml
+++ b/.cicd/pipeline.yml
@@ -20,7 +20,7 @@ steps:
       - docker#v3.2.0:
           always-pull: true
           debug: $DEBUG
-          image: "eosio/ci-contracts-builder:latest"
+          image: "eosio/ci-contracts-builder:d1be23a980c874b30a7d696daab7c8d2e31c2175"
           mount-buildkite-agent: true
           mount-checkout: true
           propagate-environment: true

--- a/.cicd/pipeline.yml
+++ b/.cicd/pipeline.yml
@@ -1,7 +1,7 @@
 steps:
   - wait
 
-  - trigger: "eosio_contracts_base_images_beta"
+  - trigger: "eosio-dot-contracts-base-images-beta"
     label: ":docker: Ensure Base Images"
     build:
       commit: "${BUILDKITE_COMMIT}"

--- a/.cicd/travis-build.sh
+++ b/.cicd/travis-build.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 set -e
 CPU_CORES=$(getconf _NPROCESSORS_ONLN)
+# build
 cd /eosio.contracts
 [[ -d "build" ]] && rm -rf build
 mkdir build

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,9 @@ compiler: clang
 services:
   - docker
 before_install:
-  - "docker pull eosio/ci-contracts-builder:d1be23a980c874b30a7d696daab7c8d2e31c2175"
+  - "docker pull eosio/ci-contracts-builder:17ee214-889efb1"
 script:
-  - "docker run --rm -v $(pwd):/eosio.contracts eosio/ci-contracts-builder:d1be23a980c874b30a7d696daab7c8d2e31c2175 bash -c /eosio.contracts/.cicd/travis-build.sh"
+  - "docker run --rm -v $(pwd):/eosio.contracts eosio/ci-contracts-builder:17ee214-889efb1 bash -c /eosio.contracts/.cicd/travis-build.sh"
 notifications:
   webhooks:
     secure: CEIaN/RNCYALwL+QgBhVlyq5DvomyMcmB+gUfdDabxJk55misbIAXkj7l3+1dvq4EeB8Vw3vSKAimfjpj0hGCopOPxPsE5SPYWx3czI7cBPvuu3S4NSmx6WEe+pjI3IexUVQXRLazhvvwB6D/vZnFlr3ECYj59K0fGoYOKW14oG2RLVP7Clx3qoo1O8y7F+Ia6fEp/Q4pvwgFKnUL4hJrCUefJwSKDH8Nxf4FF5U41RLE8Xhdqxo1zbZBpT30gaPERzBnTCO3ko5NIEI/WPruQgcRr/PVDTG1xYZ2XqImDb/fHZKqkOJSoOTH+2U2KBxfXCwLPzkz6CkpJ7v14VL4qoV/F5DA9/fTSB4+B6IWusFF8NhstMmeCw0vkfaO/8WW8VEYHXnlTPFAQZJEiEyIYDcyVnUXur0yFEkvr4ZdGDmUEv/AdClVJ7Ig7T4MF2K66Yqtj930VQhI5PSWMKIWFG+2eboBrmXet+Z+2GRhwCGm5knB4/bcDcg9E80cwUWVol6AxVO07n70Qx57qX9Tvz/Ay9ugtEY+xSDQQ+HkFw62MiPDsNhSFoUD+TNY+SnEe1qnciKhb2/1bNTkKMPjifjJmDWkfC07qrXsDBcj4cIgfj6vh8lBj7U6kg7vCjXeJeljgu0wcTDd+EprDHpfRwkoXi9UsnSw2HXAveZMP4=

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,9 @@ compiler: clang
 services:
   - docker
 before_install:
-  - "docker pull eosio/ci-contracts-builder:latest"
+  - "docker pull eosio/ci-contracts-builder:d1be23a980c874b30a7d696daab7c8d2e31c2175"
 script:
-  - "docker run --rm -v $(pwd):/eosio.contracts eosio/ci-contracts-builder:latest bash -c /eosio.contracts/.cicd/travis-build.sh"
+  - "docker run --rm -v $(pwd):/eosio.contracts eosio/ci-contracts-builder:d1be23a980c874b30a7d696daab7c8d2e31c2175 bash -c /eosio.contracts/.cicd/travis-build.sh"
 notifications:
   webhooks:
     secure: CEIaN/RNCYALwL+QgBhVlyq5DvomyMcmB+gUfdDabxJk55misbIAXkj7l3+1dvq4EeB8Vw3vSKAimfjpj0hGCopOPxPsE5SPYWx3czI7cBPvuu3S4NSmx6WEe+pjI3IexUVQXRLazhvvwB6D/vZnFlr3ECYj59K0fGoYOKW14oG2RLVP7Clx3qoo1O8y7F+Ia6fEp/Q4pvwgFKnUL4hJrCUefJwSKDH8Nxf4FF5U41RLE8Xhdqxo1zbZBpT30gaPERzBnTCO3ko5NIEI/WPruQgcRr/PVDTG1xYZ2XqImDb/fHZKqkOJSoOTH+2U2KBxfXCwLPzkz6CkpJ7v14VL4qoV/F5DA9/fTSB4+B6IWusFF8NhstMmeCw0vkfaO/8WW8VEYHXnlTPFAQZJEiEyIYDcyVnUXur0yFEkvr4ZdGDmUEv/AdClVJ7Ig7T4MF2K66Yqtj930VQhI5PSWMKIWFG+2eboBrmXet+Z+2GRhwCGm5knB4/bcDcg9E80cwUWVol6AxVO07n70Qx57qX9Tvz/Ay9ugtEY+xSDQQ+HkFw62MiPDsNhSFoUD+TNY+SnEe1qnciKhb2/1bNTkKMPjifjJmDWkfC07qrXsDBcj4cIgfj6vh8lBj7U6kg7vCjXeJeljgu0wcTDd+EprDHpfRwkoXi9UsnSw2HXAveZMP4=

--- a/pipeline.jsonc
+++ b/pipeline.jsonc
@@ -4,7 +4,7 @@
         "pipeline-branch": "master",
         "dependencies": // dependencies to pull for a build of contracts, by branch, tag, or commit hash
         {
-            "eosio": "release/1.8.x",
+            "eosio": "d0c1fe13cd411b0fa6f942cd4a50de7a5ba49351",
             "eosio.cdt": "release/1.6.x"
         }
     }

--- a/pipeline.jsonc
+++ b/pipeline.jsonc
@@ -4,7 +4,7 @@
         "pipeline-branch": "master",
         "dependencies": // dependencies to pull for a build of contracts, by branch, tag, or commit hash
         {
-            "eosio": "d0c1fe13cd411b0fa6f942cd4a50de7a5ba49351",
+            "eosio": "17ee21428e21cbc7b244e1b1a39549373b5c2325",
             "eosio.cdt": "release/1.6.x"
         }
     }


### PR DESCRIPTION
## Change Description
This pull request changes the [beta pipelines](https://github.com/EOSIO/eosio.contracts/pull/306) on [Buildkite](https://buildkite.com/EOSIO/eosio-dot-contracts-beta) and [Travis](https://travis-ci.com/EOSIO/eosio.contracts/builds) to pull the base images created on the [eosio-dot-contracts-base-images-beta pipeline](https://buildkite.com/EOSIO/eosio-dot-contracts-base-images-beta) building from the [EOSIO beta pipeline](https://buildkite.com/EOSIO/eosio-beta), instead of previous images build in the (now extinct) [contracts-docker](https://buildkite.com/EOSIO/contracts-docker) pipeline building from GCR.

The `pipeline.jsonc` file had to be updated from `release/1.8.x` to that commit because we can't do base image builds from the release branches until we merge our code into them.

### Tested
- eosio-dot-contracts-base-images-beta [build 22](https://buildkite.com/EOSIO/eosio-dot-contracts-base-images-beta/builds/22)
- eosio-dot-contracts-beta [build 275](https://buildkite.com/EOSIO/eosio-dot-contracts-beta/builds/275)

## Deployment Changes
- [ ] Deployment Changes
None.

## API Changes
- [ ] API Changes
None.

## Documentation Additions
- [ ] Documentation Additions
None.