### PR TITLE
Add missing header_extensions field to block_header

### DIFF
--- a/contracts/eosio.system/include/eosio.system/native.hpp
+++ b/contracts/eosio.system/include/eosio.system/native.hpp
@@ -120,10 +120,11 @@ namespace eosiosystem {
       checksum256                               action_mroot;
       uint32_t                                  schedule_version = 0;
       std::optional<eosio::producer_schedule>   new_producers;
+      std::vector<std::pair<uint16_t,std::vector<char>>> header_extensions;
 
       // explicit serialization macro is not necessary, used here only to improve compilation time
       EOSLIB_SERIALIZE(block_header, (timestamp)(producer)(confirmed)(previous)(transaction_mroot)(action_mroot)
-                                     (schedule_version)(new_producers))
+                                     (schedule_version)(new_producers)(header_extensions))
    };
 
    /**


### PR DESCRIPTION
## Change Description

Add missing field, header_extensions, to block_header struct in system contract

## Deployment Changes
- [ ] Deployment Changes

## API Changes
- [ ] API Changes

## Documentation Additions
- [ ] Documentation Additions