### PR TITLE
Add error messages for `get_balance` & `get_supply`

### DIFF
--- a/contracts/eosio.token/include/eosio.token/eosio.token.hpp
+++ b/contracts/eosio.token/include/eosio.token/eosio.token.hpp
@@ -126,7 +126,7 @@ namespace eosio {
          static asset get_supply( const name& token_contract_account, const symbol_code& sym_code )
          {
             stats statstable( token_contract_account, sym_code.raw() );
-            const auto& st = statstable.get( sym_code.raw(), "no supply object found" );
+            const auto& st = statstable.get( sym_code.raw(), "Wrong symbol type" );
             return st.supply;
          }
 
@@ -143,7 +143,7 @@ namespace eosio {
          static asset get_balance( const name& token_contract_account, const name& owner, const symbol_code& sym_code )
          {
             accounts accountstable( token_contract_account, owner.value );
-            const auto& ac = accountstable.get( sym_code.raw(), "no balance object found" );
+            const auto& ac = accountstable.get( sym_code.raw(), "Wrong symbol type" );
             return ac.balance;
          }
 

--- a/contracts/eosio.token/include/eosio.token/eosio.token.hpp
+++ b/contracts/eosio.token/include/eosio.token/eosio.token.hpp
@@ -126,7 +126,7 @@ namespace eosio {
          static asset get_supply( const name& token_contract_account, const symbol_code& sym_code )
          {
             stats statstable( token_contract_account, sym_code.raw() );
-            const auto& st = statstable.get( sym_code.raw() );
+            const auto& st = statstable.get( sym_code.raw(), "no supply object found" );
             return st.supply;
          }
 
@@ -143,7 +143,7 @@ namespace eosio {
          static asset get_balance( const name& token_contract_account, const name& owner, const symbol_code& sym_code )
          {
             accounts accountstable( token_contract_account, owner.value );
-            const auto& ac = accountstable.get( sym_code.raw() );
+            const auto& ac = accountstable.get( sym_code.raw(), "no balance object found" );
             return ac.balance;
          }
 

--- a/contracts/eosio.token/include/eosio.token/eosio.token.hpp
+++ b/contracts/eosio.token/include/eosio.token/eosio.token.hpp
@@ -126,7 +126,7 @@ namespace eosio {
          static asset get_supply( const name& token_contract_account, const symbol_code& sym_code )
          {
             stats statstable( token_contract_account, sym_code.raw() );
-            const auto& st = statstable.get( sym_code.raw(), "Wrong symbol type" );
+            const auto& st = statstable.get( sym_code.raw(), "invalid supply symbol code" );
             return st.supply;
          }
 
@@ -143,7 +143,7 @@ namespace eosio {
          static asset get_balance( const name& token_contract_account, const name& owner, const symbol_code& sym_code )
          {
             accounts accountstable( token_contract_account, owner.value );
-            const auto& ac = accountstable.get( sym_code.raw(), "Wrong symbol type" );
+            const auto& ac = accountstable.get( sym_code.raw(), "no balance with specified symbol" );
             return ac.balance;
          }
 


### PR DESCRIPTION
Add additional error messages when using `get_balance` & `get_supply` static methods from `eosio.token`

Error message would change from:

```
Error 3050003: eosio_assert_message assertion failure
Error Details:
assertion failure with message: unable to find key
pending console output: 
```

to =>

```
Error 3050003: eosio_assert_message assertion failure
Error Details:
assertion failure with message: no supply object found
pending console output: 
```