### PR TITLE
Prevent overflow within claimrewards in cases of extreme inflation - 1.8.x

### DIFF
--- a/contracts/eosio.system/src/producer_pay.cpp
+++ b/contracts/eosio.system/src/producer_pay.cpp
@@ -83,6 +83,7 @@ namespace eosiosystem {
 
       if( usecs_since_last_fill > 0 && _gstate.last_pervote_bucket_fill > time_point() ) {
          int64_t new_tokens = (_gstate4.continuous_rate * double(token_supply.amount) * double(usecs_since_last_fill)) / double(useconds_per_year);
+         check( new_tokens >= 0, "overflow in calculating new tokens to be issued; inflation rate is too high" );
 
          int64_t to_producers     = (new_tokens * uint128_t(pay_factor_precision)) / _gstate4.inflation_pay_factor;
          int64_t to_savings       = new_tokens - to_producers;

--- a/contracts/eosio.system/src/producer_pay.cpp
+++ b/contracts/eosio.system/src/producer_pay.cpp
@@ -82,8 +82,10 @@ namespace eosiosystem {
       const auto usecs_since_last_fill = (ct - _gstate.last_pervote_bucket_fill).count();
 
       if( usecs_since_last_fill > 0 && _gstate.last_pervote_bucket_fill > time_point() ) {
-         int64_t new_tokens = (_gstate4.continuous_rate * double(token_supply.amount) * double(usecs_since_last_fill)) / double(useconds_per_year);
-         check( new_tokens >= 0, "overflow in calculating new tokens to be issued; inflation rate is too high" );
+         double additional_inflation = (_gstate4.continuous_rate * double(token_supply.amount) * double(usecs_since_last_fill)) / double(useconds_per_year);
+         check( additional_inflation <= double(std::numeric_limits<int64_t>::max() - ((1ll << 10) - 1)),
+                "overflow in calculating new tokens to be issued; inflation rate is too high" );
+         int64_t new_tokens = static_cast<int64_t>(additional_inflation);
 
          int64_t to_producers     = (new_tokens * uint128_t(pay_factor_precision)) / _gstate4.inflation_pay_factor;
          int64_t to_savings       = new_tokens - to_producers;

--- a/contracts/eosio.system/src/producer_pay.cpp
+++ b/contracts/eosio.system/src/producer_pay.cpp
@@ -85,7 +85,7 @@ namespace eosiosystem {
          double additional_inflation = (_gstate4.continuous_rate * double(token_supply.amount) * double(usecs_since_last_fill)) / double(useconds_per_year);
          check( additional_inflation <= double(std::numeric_limits<int64_t>::max() - ((1ll << 10) - 1)),
                 "overflow in calculating new tokens to be issued; inflation rate is too high" );
-         int64_t new_tokens = static_cast<int64_t>(additional_inflation);
+         int64_t new_tokens = (additional_inflation < 0.0) ? 0 : static_cast<int64_t>(additional_inflation);
 
          int64_t to_producers     = (new_tokens * uint128_t(pay_factor_precision)) / _gstate4.inflation_pay_factor;
          int64_t to_savings       = new_tokens - to_producers;


### PR DESCRIPTION
## Change Description

Ports #328 to `release/1.8.x`.

## Deployment Changes
- [ ] Deployment Changes

## API Changes
- [ ] API Changes

## Documentation Additions
- [ ] Documentation Additions

