### PR TITLE
Update minimum CDT dependency to 1.7.x

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.5)
 project(eosio_contracts)
 
 set(VERSION_MAJOR 1)
-set(VERSION_MINOR 8)
+set(VERSION_MINOR 9)
 set(VERSION_PATCH 0)
 set(VERSION_SUFFIX rc1)
 
@@ -19,8 +19,8 @@ find_package(eosio.cdt)
 
 message(STATUS "Building eosio.contracts v${VERSION_FULL}")
 
-set(EOSIO_CDT_VERSION_MIN "1.6")
-set(EOSIO_CDT_VERSION_SOFT_MAX "1.6")
+set(EOSIO_CDT_VERSION_MIN "1.7")
+set(EOSIO_CDT_VERSION_SOFT_MAX "1.7")
 #set(EOSIO_CDT_VERSION_HARD_MAX "")
 
 ### Check the version of eosio.cdt

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ The following unprivileged contract(s) are also part of the system.
    * [eosio.token](./contracts/eosio.token)
 
 Dependencies:
-* [eosio.cdt v1.6.x](https://github.com/EOSIO/eosio.cdt/releases/tag/v1.6.2)
+* [eosio.cdt v1.7.x](https://github.com/EOSIO/eosio.cdt/releases/tag/v1.7.0-rc1)
 * [eosio v1.8.x](https://github.com/EOSIO/eos/releases/tag/v1.8.1) (optional dependency only needed to build unit tests)
 
 To build contracts alone:

--- a/contracts/eosio.bios/include/eosio.bios/eosio.bios.hpp
+++ b/contracts/eosio.bios/include/eosio.bios/eosio.bios.hpp
@@ -7,37 +7,6 @@
 #include <eosio/privileged.hpp>
 #include <eosio/producer_schedule.hpp>
 
-// This header is needed until `is_feature_activiated` and `preactivate_feature` are added to `eosio.cdt`
-#include <eosio/../../capi/eosio/crypto.h>
-
-namespace eosio {
-   namespace internal_use_do_not_use {
-      extern "C" {
-         __attribute__((eosio_wasm_import))
-         bool is_feature_activated( const ::capi_checksum256* feature_digest );
-
-         __attribute__((eosio_wasm_import))
-         void preactivate_feature( const ::capi_checksum256* feature_digest );
-      }
-   }
-}
-
-namespace eosio {
-   bool is_feature_activated( const eosio::checksum256& feature_digest ) {
-      auto feature_digest_data = feature_digest.extract_as_byte_array();
-      return internal_use_do_not_use::is_feature_activated(
-         reinterpret_cast<const ::capi_checksum256*>( feature_digest_data.data() )
-      );
-   }
-
-   void preactivate_feature( const eosio::checksum256& feature_digest ) {
-      auto feature_digest_data = feature_digest.extract_as_byte_array();
-      internal_use_do_not_use::preactivate_feature(
-         reinterpret_cast<const ::capi_checksum256*>( feature_digest_data.data() )
-      );
-   }
-}
-
 /**
  * EOSIO Contracts
  *
@@ -57,9 +26,13 @@ namespace eosio {
  * - eosio.token
  */
 
-namespace eosio {
+namespace eosiobios {
 
+   using eosio::action_wrapper;
+   using eosio::check;
+   using eosio::checksum256;
    using eosio::ignore;
+   using eosio::name;
    using eosio::permission_level;
    using eosio::public_key;
 
@@ -161,7 +134,7 @@ namespace eosio {
     *
     * @{
     */
-   class [[eosio::contract("eosio.bios")]] bios : public contract {
+   class [[eosio::contract("eosio.bios")]] bios : public eosio::contract {
       public:
          using contract::contract;
          /**
@@ -420,4 +393,4 @@ namespace eosio {
          using reqactivated_action = action_wrapper<"reqactivated"_n, &bios::reqactivated>;
    };
    /** @}*/ // end of @defgroup eosiobios eosio.bios
-} /// namespace eosio
+} /// namespace eosiobios

--- a/contracts/eosio.bios/src/eosio.bios.cpp
+++ b/contracts/eosio.bios/src/eosio.bios.cpp
@@ -1,6 +1,6 @@
 #include <eosio.bios/eosio.bios.hpp>
 
-namespace eosio {
+namespace eosiobios {
 
 void bios::setabi( name account, const std::vector<char>& abi ) {
    abi_hash_table table(get_self(), get_self().value);
@@ -8,11 +8,11 @@ void bios::setabi( name account, const std::vector<char>& abi ) {
    if( itr == table.end() ) {
       table.emplace( account, [&]( auto& row ) {
          row.owner = account;
-         row.hash  = sha256(const_cast<char*>(abi.data()), abi.size());
+         row.hash  = eosio::sha256(const_cast<char*>(abi.data()), abi.size());
       });
    } else {
-      table.modify( itr, same_payer, [&]( auto& row ) {
-         row.hash = sha256(const_cast<char*>(abi.data()), abi.size());
+      table.modify( itr, eosio::same_payer, [&]( auto& row ) {
+         row.hash = eosio::sha256(const_cast<char*>(abi.data()), abi.size());
       });
    }
 }

--- a/contracts/eosio.msig/src/eosio.msig.cpp
+++ b/contracts/eosio.msig/src/eosio.msig.cpp
@@ -30,8 +30,7 @@ void multisig::propose( ignore<name> proposer,
    check( proptable.find( _proposal_name.value ) == proptable.end(), "proposal with the same name exists" );
 
    auto packed_requested = pack(_requested);
-   // TODO: Remove internal_use_do_not_use namespace after minimum eosio.cdt dependency becomes 1.7.x
-   auto res =  internal_use_do_not_use::check_transaction_authorization(
+   auto res =  check_transaction_authorization(
                   trx_pos, size,
                   (const char*)0, 0,
                   packed_requested.data(), packed_requested.size()
@@ -175,8 +174,7 @@ void multisig::exec( name proposer, name proposal_name, name executer ) {
       old_apptable.erase(apps);
    }
    auto packed_provided_approvals = pack(approvals);
-   // TODO: Remove internal_use_do_not_use namespace after minimum eosio.cdt dependency becomes 1.7.x
-   auto res =  internal_use_do_not_use::check_transaction_authorization(
+   auto res =  check_transaction_authorization(
                   prop.packed_transaction.data(), prop.packed_transaction.size(),
                   (const char*)0, 0,
                   packed_provided_approvals.data(), packed_provided_approvals.size()

--- a/contracts/eosio.system/include/eosio.system/native.hpp
+++ b/contracts/eosio.system/include/eosio.system/native.hpp
@@ -9,24 +9,6 @@
 #include <eosio/privileged.hpp>
 #include <eosio/producer_schedule.hpp>
 
-// This header is needed until `is_feature_activiated` and `preactivate_feature` are added to `eosio.cdt`
-#include <eosio/../../capi/eosio/crypto.h>
-
-namespace eosio {
-   namespace internal_use_do_not_use {
-      extern "C" {
-         __attribute__((eosio_wasm_import))
-         bool is_feature_activated( const ::capi_checksum256* feature_digest );
-
-         __attribute__((eosio_wasm_import))
-         void preactivate_feature( const ::capi_checksum256* feature_digest );
-      }
-   }
-
-   bool is_feature_activated( const eosio::checksum256& feature_digest );
-   void preactivate_feature( const eosio::checksum256& feature_digest );
-}
-
 namespace eosiosystem {
 
    using eosio::checksum256;

--- a/contracts/eosio.system/src/native.cpp
+++ b/contracts/eosio.system/src/native.cpp
@@ -2,22 +2,6 @@
 
 #include <eosio/check.hpp>
 
-namespace eosio {
-   bool is_feature_activated( const eosio::checksum256& feature_digest ) {
-      auto feature_digest_data = feature_digest.extract_as_byte_array();
-      return internal_use_do_not_use::is_feature_activated(
-         reinterpret_cast<const ::capi_checksum256*>( feature_digest_data.data() )
-      );
-   }
-
-   void preactivate_feature( const eosio::checksum256& feature_digest ) {
-      auto feature_digest_data = feature_digest.extract_as_byte_array();
-      internal_use_do_not_use::preactivate_feature(
-         reinterpret_cast<const ::capi_checksum256*>( feature_digest_data.data() )
-      );
-   }
-}
-
 namespace eosiosystem {
 
    void native::onerror( ignore<uint128_t>, ignore<std::vector<char>> ) {

--- a/pipeline.jsonc
+++ b/pipeline.jsonc
@@ -5,7 +5,7 @@
         "dependencies": // dependencies to pull for a build of contracts, by branch, tag, or commit hash
         {
             "eosio": "release/1.8.x",
-            "eosio.cdt": "release/1.6.x"
+            "eosio.cdt": "0e9b9b0ca5244d0caae4ea1c23ebcd3e7c7398fc" // eventually update to release/1.7.x
         }
     }
 }


### PR DESCRIPTION
## Change Description

Updated the minimum CDT dependency to 1.7.x. This means that the eosio.bios and eosio.system contracts can remove their definitions for the preactive_feature and is_feature_activated intrinsics and simply use the ones provided in CDT. It also means that the proper C++ version of `check_transaction_authorization` can be used in eosio.msig rather than the one in the `internal_use_do_not_use` namespace.


## Deployment Changes
- [ ] Deployment Changes


## API Changes
- [ ] API Changes


## Documentation Additions
- [ ] Documentation Additions

