### PR TITLE
Allow producers to register  WTMsig block signing authorities in system contract

### DIFF
--- a/.cicd/test.sh
+++ b/.cicd/test.sh
@@ -11,6 +11,6 @@ fi
 ARGS=${ARGS:-"--rm -v $(pwd):$MOUNTED_DIR"}
 CDT_COMMANDS="apt-get install -y wget && wget -q $CDT_URL -O eosio.cdt.deb && dpkg -i eosio.cdt.deb && export PATH=/usr/opt/eosio.cdt/$CDT_VERSION/bin:\\\$PATH"
 PRE_COMMANDS="$CDT_COMMANDS && cd $MOUNTED_DIR/build/tests"
-TEST_COMMANDS="ctest -j $JOBS"
+TEST_COMMANDS="ctest -j $JOBS --output-on-failure"
 COMMANDS="$PRE_COMMANDS && $TEST_COMMANDS"
 eval docker run $ARGS $(buildkite-intrinsics) $DOCKER_IMAGE bash -c \"$COMMANDS\"

--- a/contracts/eosio.bios/include/eosio.bios/eosio.bios.hpp
+++ b/contracts/eosio.bios/include/eosio.bios/eosio.bios.hpp
@@ -315,7 +315,7 @@ namespace eosiobios {
           * @param schedule - New list of active producers to set
           */
          [[eosio::action]]
-         void setprods( std::vector<eosio::producer_key> schedule );
+         void setprods( const std::vector<eosio::producer_authority>& schedule );
 
          /**
           * Set the blockchain parameters

--- a/contracts/eosio.bios/ricardian/eosio.bios.contracts.md.in
+++ b/contracts/eosio.bios/ricardian/eosio.bios.contracts.md.in
@@ -154,7 +154,13 @@ icon: @ICON_BASE_URL@/@ADMIN_ICON_URI@
 
 {{$action.account}} proposes a block producer schedule of:
 {{#each schedule}}
-  1. {{this.producer_name}} with a block signing key of {{this.block_signing_key}}
+  1. {{this.producer_name}}
+{{/each}}
+
+The block signing authorities of each of the producers in the above schedule are listed below:
+{{#each schedule}}
+### {{this.producer_name}}
+{{to_json this.authority}}
 {{/each}}
 
 <h1 class="contract">unlinkauth</h1>

--- a/contracts/eosio.bios/src/eosio.bios.cpp
+++ b/contracts/eosio.bios/src/eosio.bios.cpp
@@ -31,7 +31,7 @@ void bios::setalimits( name account, int64_t ram_bytes, int64_t net_weight, int6
    set_resource_limits( account, ram_bytes, net_weight, cpu_weight );
 }
 
-void bios::setprods( std::vector<eosio::producer_key> schedule ) {
+void bios::setprods( const std::vector<eosio::producer_authority>& schedule ) {
    require_auth( get_self() );
    set_proposed_producers( schedule );
 }

--- a/contracts/eosio.system/include/eosio.system/eosio.system.hpp
+++ b/contracts/eosio.system/include/eosio.system/eosio.system.hpp
@@ -229,7 +229,7 @@ namespace eosiosystem {
 
       // explicit serialization macro is not necessary, used here only to improve compilation time
       EOSLIB_SERIALIZE( producer_info, (owner)(total_votes)(producer_key)(is_active)(url)
-                        (unpaid_blocks)(last_claim_time)(location) )
+                        (unpaid_blocks)(last_claim_time)(location)(producer_authority) )
    };
 
    /**

--- a/contracts/eosio.system/ricardian/eosio.system.clauses.md
+++ b/contracts/eosio.system/ricardian/eosio.system.clauses.md
@@ -6,13 +6,13 @@ User agreement for the chain can go here.
 
 I, {{producer}}, hereby nominate myself for consideration as an elected block producer.
 
-If {{producer}} is selected to produce blocks by the system contract, I will sign blocks with {{producer_key}} and I hereby attest that I will keep this key secret and secure.
+If {{producer}} is selected to produce blocks by the system contract, I will sign blocks with my registered block signing keys and I hereby attest that I will keep these keys secret and secure.
 
-If {{producer}} is unable to perform obligations under this contract I will resign my position by resubmitting this contract with the null producer key.
+If {{producer}} is unable to perform obligations under this contract I will resign my position using the unregprod action.
 
 I acknowledge that a block is 'objectively valid' if it conforms to the deterministic blockchain rules in force at the time of its creation, and is 'objectively invalid' if it fails to conform to those rules.
 
-{{producer}} hereby agrees to only use {{producer_key}} to sign messages under the following scenarios:
+{{producer}} hereby agrees to only use my registered block signing keys to sign messages under the following scenarios:
 
 * proposing an objectively valid block at the time appointed by the block scheduling algorithm;
 * pre-confirming a block produced by another producer in the schedule when I find said block objectively valid;
@@ -20,8 +20,8 @@ I acknowledge that a block is 'objectively valid' if it conforms to the determin
 
 I hereby accept liability for any and all provable damages that result from my:
 
-* signing two different block proposals with the same timestamp with {{producer_key}};
-* signing two different block proposals with the same block number with {{producer_key}};
+* signing two different block proposals with the same timestamp;
+* signing two different block proposals with the same block number;
 * signing any block proposal which builds off of an objectively invalid block;
 * signing a pre-confirmation for an objectively invalid block;
 * or, signing a confirmation for a block for which I do not possess pre-confirmation messages from more than two-thirds of the active block producers.

--- a/contracts/eosio.system/ricardian/eosio.system.contracts.md.in
+++ b/contracts/eosio.system/ricardian/eosio.system.contracts.md.in
@@ -309,6 +309,30 @@ icon: @ICON_BASE_URL@/@VOTING_ICON_URI@
 
 Register {{producer}} account as a block producer candidate.
 
+URL: {{url}}
+Location code: {{location}}
+Block signing key: {{producer_key}}
+
+## Block Producer Agreement
+{{$clauses.BlockProducerAgreement}}
+
+<h1 class="contract">regproducer2</h1>
+
+---
+spec_version: "0.2.0"
+title: Register as a Block Producer Candidate
+summary: 'Register {{nowrap producer}} account as a block producer candidate'
+icon: @ICON_BASE_URL@/@VOTING_ICON_URI@
+---
+
+Register {{producer}} account as a block producer candidate.
+
+URL: {{url}}
+Location code: {{location}}
+Block signing authority:
+{{to_json producer_authority}}
+
+## Block Producer Agreement
 {{$clauses.BlockProducerAgreement}}
 
 <h1 class="contract">regproxy</h1>

--- a/contracts/eosio.system/src/voting.cpp
+++ b/contracts/eosio.system/src/voting.cpp
@@ -2,6 +2,7 @@
 #include <eosio/datastream.hpp>
 #include <eosio/eosio.hpp>
 #include <eosio/multi_index.hpp>
+#include <eosio/permission.hpp>
 #include <eosio/privileged.hpp>
 #include <eosio/serialize.hpp>
 #include <eosio/singleton.hpp>
@@ -9,6 +10,9 @@
 #include <eosio.system/eosio.system.hpp>
 #include <eosio.token/eosio.token.hpp>
 
+#include <type_traits>
+#include <limits>
+#include <set>
 #include <algorithm>
 #include <cmath>
 
@@ -20,20 +24,40 @@ namespace eosiosystem {
    using eosio::microseconds;
    using eosio::singleton;
 
-   void system_contract::regproducer( const name& producer, const eosio::public_key& producer_key, const std::string& url, uint16_t location ) {
-      check( url.size() < 512, "url too long" );
-      check( producer_key != eosio::public_key(), "public key should not be the default value" );
-      require_auth( producer );
+   eosio::block_signing_authority convert_to_block_signing_authority( const eosio::public_key& producer_key ) {
+      return eosio::block_signing_authority_v0{ .threshold = 1, .keys = {{producer_key, 1}} };
+   }
 
+   template<class... Ts> struct overloaded : Ts... { using Ts::operator()...; };
+   template<class... Ts> overloaded(Ts...) -> overloaded<Ts...>;
+
+   bool is_null_key( const eosio::public_key& pub_key ) {
+      return std::visit( overloaded{
+         []( const eosio::ecc_public_key& k ) { return (k == eosio::ecc_public_key{}); },
+         []( const eosio::webauthn_public_key& k ) { return (k.key == eosio::ecc_public_key{}); }
+      }, pub_key );
+   }
+
+   void system_contract::register_producer( const name& producer, const eosio::block_signing_authority& producer_authority, const std::string& url, uint16_t location ) {
       auto prod = _producers.find( producer.value );
       const auto ct = current_time_point();
 
+      eosio::public_key producer_key{};
+
+      std::visit( [&](auto&& auth ) {
+         if( auth.keys.size() == 1 ) {
+            // if the producer_authority consists of a single key, use that key in the legacy producer_key field
+            producer_key = auth.keys[0].key;
+         }
+      }, producer_authority );
+
       if ( prod != _producers.end() ) {
          _producers.modify( prod, producer, [&]( producer_info& info ){
-            info.producer_key = producer_key;
-            info.is_active    = true;
-            info.url          = url;
-            info.location     = location;
+            info.producer_key       = producer_key;
+            info.is_active          = true;
+            info.url                = url;
+            info.location           = location;
+            info.producer_authority.emplace( producer_authority );
             if ( info.last_claim_time == time_point() )
                info.last_claim_time = ct;
          });
@@ -49,13 +73,14 @@ namespace eosiosystem {
          }
       } else {
          _producers.emplace( producer, [&]( producer_info& info ){
-            info.owner           = producer;
-            info.total_votes     = 0;
-            info.producer_key    = producer_key;
-            info.is_active       = true;
-            info.url             = url;
-            info.location        = location;
-            info.last_claim_time = ct;
+            info.owner              = producer;
+            info.total_votes        = 0;
+            info.producer_key       = producer_key;
+            info.is_active          = true;
+            info.url                = url;
+            info.location           = location;
+            info.last_claim_time    = ct;
+            info.producer_authority.emplace( producer_authority );
          });
          _producers2.emplace( producer, [&]( producer_info2& info ){
             info.owner                     = producer;
@@ -63,6 +88,47 @@ namespace eosiosystem {
          });
       }
 
+   }
+
+   void system_contract::regproducer( const name& producer, const eosio::public_key& producer_key, const std::string& url, uint16_t location ) {
+      require_auth( producer );
+      check( url.size() < 512, "url too long" );
+
+      check( producer_key.index() < 2, "currently only K1 and R1 producer keys are supported" );
+      check( !is_null_key( producer_key ), "public key should not be the default value" );
+      check_permission_authorization( null_account, active_permission, {} ); // aborts transaction if native side cannot unpack producer_key
+
+      register_producer( producer, convert_to_block_signing_authority( producer_key ), url, location );
+   }
+
+   void system_contract::regproducer2( const name& producer, const eosio::block_signing_authority& producer_authority, const std::string& url, uint16_t location ) {
+      require_auth( producer );
+      check( url.size() < 512, "url too long" );
+
+      std::visit( [&](auto&& auth ) {
+         uint32_t sum_weights = 0;
+         std::set<eosio::public_key> unique_keys;
+
+         for (const auto& kw: auth.keys ) {
+            check( kw.key.index() < 2, "currently only K1 and R1 producer keys are supported" );
+            check( !is_null_key( kw.key ), "producer authority includes an invalid key" );
+
+            if( std::numeric_limits<uint32_t>::max() - sum_weights <= kw.weight ) {
+               sum_weights = std::numeric_limits<uint32_t>::max();
+            } else {
+               sum_weights += kw.weight;
+            }
+
+            unique_keys.insert(kw.key);
+         }
+
+         check( auth.keys.size() == unique_keys.size(), "producer authority includes a duplicated key" );
+         check( auth.threshold > 0, "producer authority has a threshold of 0" );
+         check( sum_weights >= auth.threshold, "producer authority is unsatisfiable" );
+      }, producer_authority );
+
+
+      register_producer( producer, producer_authority, url, location );
    }
 
    void system_contract::unregprod( const name& producer ) {
@@ -79,25 +145,35 @@ namespace eosiosystem {
 
       auto idx = _producers.get_index<"prototalvote"_n>();
 
-      std::vector< std::pair<eosio::producer_key,uint16_t> > top_producers;
+      using value_type = std::pair<eosio::producer_authority, uint16_t>;
+      std::vector< value_type > top_producers;
       top_producers.reserve(21);
 
-      for ( auto it = idx.cbegin(); it != idx.cend() && top_producers.size() < 21 && 0 < it->total_votes && it->active(); ++it ) {
-         top_producers.emplace_back( std::pair<eosio::producer_key,uint16_t>({{it->owner, it->producer_key}, it->location}) );
+      for( auto it = idx.cbegin(); it != idx.cend() && top_producers.size() < 21 && 0 < it->total_votes && it->active(); ++it ) {
+         top_producers.emplace_back(
+            eosio::producer_authority{
+               .producer_name = it->owner,
+               .authority     = it->producer_authority.has_value() ? *it->producer_authority
+                                                                   : convert_to_block_signing_authority( it->producer_key )
+            },
+            it->location
+         );
       }
 
-      if ( top_producers.size() == 0 || top_producers.size() < _gstate.last_producer_schedule_size ) {
+      if( top_producers.size() == 0 || top_producers.size() < _gstate.last_producer_schedule_size ) {
          return;
       }
 
-      /// sort by producer name
-      std::sort( top_producers.begin(), top_producers.end() );
+      std::sort( top_producers.begin(), top_producers.end(), []( const value_type& lhs, const value_type& rhs ) {
+         return lhs.first.producer_name < rhs.first.producer_name; // sort by producer name
+         // return lhs.second < rhs.second; // sort by location
+      } );
 
-      std::vector<eosio::producer_key> producers;
+      std::vector<eosio::producer_authority> producers;
 
       producers.reserve(top_producers.size());
-      for( const auto& item : top_producers )
-         producers.push_back(item.first);
+      for( auto& item : top_producers )
+         producers.push_back( std::move(item.first) );
 
       if( set_proposed_producers( producers ) >= 0 ) {
          _gstate.last_producer_schedule_size = static_cast<decltype(_gstate.last_producer_schedule_size)>( top_producers.size() );

--- a/contracts/eosio.system/src/voting.cpp
+++ b/contracts/eosio.system/src/voting.cpp
@@ -96,7 +96,7 @@ namespace eosiosystem {
 
       check( producer_key.index() < 2, "currently only K1 and R1 producer keys are supported" );
       check( !is_null_key( producer_key ), "public key should not be the default value" );
-      check_permission_authorization( null_account, active_permission, {} ); // aborts transaction if native side cannot unpack producer_key
+      check_permission_authorization( null_account, active_permission, {producer_key} ); // aborts transaction if native side cannot unpack producer_key
 
       register_producer( producer, convert_to_block_signing_authority( producer_key ), url, location );
    }
@@ -105,9 +105,9 @@ namespace eosiosystem {
       require_auth( producer );
       check( url.size() < 512, "url too long" );
 
+      std::set<eosio::public_key> unique_keys;
       std::visit( [&](auto&& auth ) {
          uint32_t sum_weights = 0;
-         std::set<eosio::public_key> unique_keys;
 
          for (const auto& kw: auth.keys ) {
             check( kw.key.index() < 2, "currently only K1 and R1 producer keys are supported" );
@@ -127,6 +127,7 @@ namespace eosiosystem {
          check( sum_weights >= auth.threshold, "producer authority is unsatisfiable" );
       }, producer_authority );
 
+      check_permission_authorization( null_account, active_permission, unique_keys ); // aborts transaction if native side cannot unpack all of the keys
 
       register_producer( producer, producer_authority, url, location );
    }

--- a/contracts/eosio.system/src/voting.cpp
+++ b/contracts/eosio.system/src/voting.cpp
@@ -96,7 +96,6 @@ namespace eosiosystem {
 
       check( producer_key.index() < 2, "currently only K1 and R1 producer keys are supported" );
       check( !is_null_key( producer_key ), "public key should not be the default value" );
-      check_permission_authorization( null_account, active_permission, {producer_key} ); // aborts transaction if native side cannot unpack producer_key
 
       register_producer( producer, convert_to_block_signing_authority( producer_key ), url, location );
    }
@@ -126,8 +125,6 @@ namespace eosiosystem {
          check( auth.threshold > 0, "producer authority has a threshold of 0" );
          check( sum_weights >= auth.threshold, "producer authority is unsatisfiable" );
       }, producer_authority );
-
-      check_permission_authorization( null_account, active_permission, unique_keys ); // aborts transaction if native side cannot unpack all of the keys
 
       register_producer( producer, producer_authority, url, location );
    }

--- a/pipeline.jsonc
+++ b/pipeline.jsonc
@@ -4,8 +4,8 @@
         "pipeline-branch": "master",
         "dependencies": // dependencies to pull for a build of contracts, by branch, tag, or commit hash
         {
-            "eosio": "89166b5a314fa2bcda664329efcc13f505bd8eac", // eventually update to release/2.0.x
-            "eosio.cdt": "72cbc2b6cb045d744d241d53a78467d5b65b9191" // eventually update to release/1.7.x
+            "eosio": "329071ae8ae7c8e467f42079ebdb09e675d7e702", // eventually update to release/2.0.x
+            "eosio.cdt": "aad0c4729b848c9cbe409aa1fdd917797a4d91e7" // eventually update to release/1.7.x
         }
     }
 }

--- a/pipeline.jsonc
+++ b/pipeline.jsonc
@@ -5,7 +5,7 @@
         "dependencies": // dependencies to pull for a build of contracts, by branch, tag, or commit hash
         {
             "eosio": "d5c7ee2e52e448abc0f0e854b31b177d427f6bce", // eventually update to release/2.0.x
-            "eosio.cdt": "0e9b9b0ca5244d0caae4ea1c23ebcd3e7c7398fc" // eventually update to release/1.7.x
+            "eosio.cdt": "72cbc2b6cb045d744d241d53a78467d5b65b9191" // eventually update to release/1.7.x
         }
     }
 }

--- a/tests/eosio.system_tests.cpp
+++ b/tests/eosio.system_tests.cpp
@@ -5191,7 +5191,8 @@ BOOST_FIXTURE_TEST_CASE( b1_vesting, eosio_system_tester ) try {
 BOOST_AUTO_TEST_CASE( setabi_bios ) try {
    fc::temp_directory tempdir;
    validating_tester t( tempdir, true );
-   t.execute_setup_policy( setup_policy::preactivate_feature_only );
+   t.execute_setup_policy( setup_policy::full );
+
    abi_serializer abi_ser(fc::json::from_string( (const char*)contracts::bios_abi().data()).template as<abi_def>(), base_tester::abi_serializer_max_time);
    t.set_code( config::system_account_name, contracts::bios_wasm() );
    t.set_abi( config::system_account_name, contracts::bios_abi().data() );

--- a/tests/main.cpp
+++ b/tests/main.cpp
@@ -31,7 +31,12 @@ boost::unit_test::test_suite* init_unit_test_suite(int argc, char* argv[]) {
          break;
       }
    }
-   if(!is_verbose) fc::logger::get(DEFAULT_LOGGER).set_log_level(fc::log_level::off);
+   
+   if(is_verbose) {
+      fc::logger::get(DEFAULT_LOGGER).set_log_level(fc::log_level::debug);
+   } else {
+      fc::logger::get(DEFAULT_LOGGER).set_log_level(fc::log_level::off);
+   }
 
    // Register fc::exception translator
    boost::unit_test::unit_test_monitor.template register_exception_translator<fc::exception>(&translate_fc_exception);


### PR DESCRIPTION
## Change Description

Change `setprods` action of the eosio.bios contract to take a vector of `eosio::producer_authority` instead and use the new `set_proposed_producers_ex` intrinsic to propose producer schedules using weighted threshold multisig block signing authorities.

Add the `regproducer2` action to the eosio.system contract to allow block producers candidates to register a weighted threshold multisig block signing authority instead of just a single block signing key. The old `regproducer` action is still usable.

## Deployment Changes
- [X] Deployment Changes

The eosio.system contract and eosio.bios contract can now only be deployed on an EOSIO chain that has activated the [`WTMSIG_BLOCK_SIGNATURES`](https://github.com/EOSIO/eos/pull/7404) protocol feature.

## API Changes
- [X] API Changes

The eosio.bios contract's `setprods` action now takes a vector of `eosio::producer_authority` as the `schedule` rather than a vector of `eosio::producer_key`.

The eosio.system contract adds a new action `regproducer2` which does the same thing as the existing `regproducer` action except that it allows the block producer candidate to register a weighted threshold multisig block signing authority rather than just a single block signing key. 

This PR also adds a binary extension field `producer_authority` to the `producers` table of the eosio.system contract and it subtly changes the meaning of the `producer_key` field. The `producer_key` will still be set as it was before if the block producer candidate uses the `regproducer` action to register a block signing key or even if the `regproducer2` action is used to set a block signing authority consisting of a single key (that single key is repeated in `producer_key`). However, if a block signing authority with multiple keys is registered, then `producer_key` will be set to the null key (the same key it would have if the block producer candidate was disabled through `unregprod` or `rmvproducer`).

The changes in this PR introduce both variants (through `block_signing_authority`) and binary extensions (two new features of ABI 1.1) to the eosio.system contract ABI. They also introduce variants (through the `authority` field of `producer_authority`) to the eosio.bios contract ABI. Clients must be able to parse v1.1 ABIs to interact with this new version of the system contract.

## Documentation Additions
- [ ] Documentation Additions
