### PR TITLE
[develop] Test metrics fix

### DIFF
--- a/.cicd/test.sh
+++ b/.cicd/test.sh
@@ -11,7 +11,7 @@ fi
 ARGS=${ARGS:-"--rm -v $(pwd):$MOUNTED_DIR"}
 CDT_COMMANDS="apt-get install -y wget && wget -q $CDT_URL -O eosio.cdt.deb && dpkg -i eosio.cdt.deb && export PATH=/usr/opt/eosio.cdt/$CDT_VERSION/bin:\\\$PATH"
 PRE_COMMANDS="$CDT_COMMANDS && cd $MOUNTED_DIR/build/tests"
-TEST_COMMANDS="ctest -j $JOBS --output-on-failure"
+TEST_COMMANDS="ctest -j $JOBS --output-on-failure -T Test"
 COMMANDS="$PRE_COMMANDS && $TEST_COMMANDS"
 set +e
 eval docker run $ARGS $(buildkite-intrinsics) $DOCKER_IMAGE bash -c \"$COMMANDS\"

--- a/.cicd/test.sh
+++ b/.cicd/test.sh
@@ -21,15 +21,9 @@ if [[ "$BUILDKITE" == 'true' ]]; then
     cd build
     # upload artifacts
     echo '+++ :arrow_up: Uploading Artifacts'
-    echo 'Compressing core dumps...'
-    [[ $((`ls -1 core.* 2>/dev/null | wc -l`)) != 0 ]] && tar czf core.tar.gz core.* || : # collect core dumps
     echo 'Exporting xUnit XML'
     mv -f ./tests/Testing/$(ls ./tests/Testing/ | grep '2' | tail -n 1)/Test.xml test-results.xml
     echo 'Uploading artifacts'
-    [[ -f config.ini ]] && buildkite-agent artifact upload config.ini
-    [[ -f core.tar.gz ]] && buildkite-agent artifact upload core.tar.gz
-    [[ -f genesis.json ]] && buildkite-agent artifact upload genesis.json
-    [[ -f mongod.log ]] && buildkite-agent artifact upload mongod.log
     buildkite-agent artifact upload test-results.xml
     echo 'Done uploading artifacts.'
 fi

--- a/.cicd/test.sh
+++ b/.cicd/test.sh
@@ -15,7 +15,7 @@ TEST_COMMANDS="ctest -j $JOBS --output-on-failure"
 COMMANDS="$PRE_COMMANDS && $TEST_COMMANDS"
 set +e
 eval docker run $ARGS $(buildkite-intrinsics) $DOCKER_IMAGE bash -c \"$COMMANDS\"
-$EXIT_STATUS=$?
+EXIT_STATUS=$?
 # buildkite
 if [[ "$BUILDKITE" == 'true' ]]; then
     cd build
@@ -24,7 +24,7 @@ if [[ "$BUILDKITE" == 'true' ]]; then
     echo 'Compressing core dumps...'
     [[ $((`ls -1 core.* 2>/dev/null | wc -l`)) != 0 ]] && tar czf core.tar.gz core.* || : # collect core dumps
     echo 'Exporting xUnit XML'
-    mv -f ./tests/Testing/$(ls ./Testing/ | grep '2' | tail -n 1)/Test.xml test-results.xml
+    mv -f ./tests/Testing/$(ls ./tests/Testing/ | grep '2' | tail -n 1)/Test.xml test-results.xml
     echo 'Uploading artifacts'
     [[ -f config.ini ]] && buildkite-agent artifact upload config.ini
     [[ -f core.tar.gz ]] && buildkite-agent artifact upload core.tar.gz

--- a/.cicd/test.sh
+++ b/.cicd/test.sh
@@ -15,6 +15,7 @@ TEST_COMMANDS="ctest -j $JOBS --output-on-failure"
 COMMANDS="$PRE_COMMANDS && $TEST_COMMANDS"
 set +e
 eval docker run $ARGS $(buildkite-intrinsics) $DOCKER_IMAGE bash -c \"$COMMANDS\"
+$EXIT_STATUS=$?
 # buildkite
 if [[ "$BUILDKITE" == 'true' ]]; then
     cd build

--- a/.cicd/test.sh
+++ b/.cicd/test.sh
@@ -13,4 +13,27 @@ CDT_COMMANDS="apt-get install -y wget && wget -q $CDT_URL -O eosio.cdt.deb && dp
 PRE_COMMANDS="$CDT_COMMANDS && cd $MOUNTED_DIR/build/tests"
 TEST_COMMANDS="ctest -j $JOBS --output-on-failure"
 COMMANDS="$PRE_COMMANDS && $TEST_COMMANDS"
+set +e
 eval docker run $ARGS $(buildkite-intrinsics) $DOCKER_IMAGE bash -c \"$COMMANDS\"
+# buildkite
+if [[ "$BUILDKITE" == 'true' ]]; then
+    cd build
+    # upload artifacts
+    echo '+++ :arrow_up: Uploading Artifacts'
+    echo 'Compressing core dumps...'
+    [[ $((`ls -1 core.* 2>/dev/null | wc -l`)) != 0 ]] && tar czf core.tar.gz core.* || : # collect core dumps
+    echo 'Exporting xUnit XML'
+    mv -f ./tests/Testing/$(ls ./Testing/ | grep '2' | tail -n 1)/Test.xml test-results.xml
+    echo 'Uploading artifacts'
+    [[ -f config.ini ]] && buildkite-agent artifact upload config.ini
+    [[ -f core.tar.gz ]] && buildkite-agent artifact upload core.tar.gz
+    [[ -f genesis.json ]] && buildkite-agent artifact upload genesis.json
+    [[ -f mongod.log ]] && buildkite-agent artifact upload mongod.log
+    buildkite-agent artifact upload test-results.xml
+    echo 'Done uploading artifacts.'
+fi
+# re-throw
+if [[ "$EXIT_STATUS" != 0 ]]; then
+    echo "Failing due to non-zero exit status from ctest: $EXIT_STATUS"
+    exit $EXIT_STATUS
+fi


### PR DESCRIPTION
<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->

## Change Description
<!-- Describe your changes, their justification, AND their impact. Reference issues or pull requests where possible (use '#XX' or 'GH-XX' where XX is the issue or pull request number). -->
Reviewing PR#713 in eosio.cdt revealed that we are currently not uploading test results in eosio.cdt and eosio.contract test steps. The test metrics step is falling back to parsing the Buildkite log, which is not ideal.

Fixed issue where test steps did not upload artifacts correctly.
- Test metric step now refers to test-results.xml as generated by ctest instead of defaulting to parsing log output.

## Deployment Changes
- [ ] Deployment Changes
<!-- checked [x] = Deployment changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces a change to the contracts that causes deployment to change, please describe the impact. -->


## API Changes
- [ ] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions
- [ ] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
