### PR TITLE
Increase minimum `bidname` to 1 EOS

### DIFF
--- a/contracts/eosio.system/src/name_bidding.cpp
+++ b/contracts/eosio.system/src/name_bidding.cpp
@@ -17,7 +17,7 @@ namespace eosiosystem {
       check( (newname.value & 0x1F0ull) == 0, "accounts with 12 character names and no dots can be created without bidding required" );
       check( !is_account( newname ), "account already exists" );
       check( bid.symbol == core_symbol(), "asset must be system token" );
-      check( bid.amount > 0, "insufficient bid" );
+      check( bid.amount > 10000, "insufficient bid" );
       token::transfer_action transfer_act{ token_account, { {bidder, active_permission} } };
       transfer_act.send( bidder, names_account, bid, std::string("bid name ")+ newname.to_string() );
       name_bid_table bids(get_self(), get_self().value);


### PR DESCRIPTION
Increase minimum `bidname` to `1.0000 EOS` (core symbol)

Reason for change:
- prevents bids lower then 1 EOS (name could possibly be never executed)
- deters exploit of using `eosio.names` as first signer from deferred transaction triggered by `bidname` refund
