### PR TITLE
avoid updating total_activated_stake after activation - v1.9.x

### DIFF
--- a/contracts/eosio.system/src/delegate_bandwidth.cpp
+++ b/contracts/eosio.system/src/delegate_bandwidth.cpp
@@ -392,7 +392,7 @@ namespace eosiosystem {
       check( unstake_cpu_quantity >= zero_asset, "must unstake a positive amount" );
       check( unstake_net_quantity >= zero_asset, "must unstake a positive amount" );
       check( unstake_cpu_quantity.amount + unstake_net_quantity.amount > 0, "must unstake a positive amount" );
-      check( _gstate.total_activated_stake >= min_activated_stake,
+      check( _gstate.thresh_activated_stake_time != time_point(),
              "cannot undelegate bandwidth until the chain is activated (at least 15% of all tokens participate in voting)" );
 
       changebw( from, receiver, -unstake_net_quantity, -unstake_cpu_quantity, false);

--- a/contracts/eosio.system/src/producer_pay.cpp
+++ b/contracts/eosio.system/src/producer_pay.cpp
@@ -21,8 +21,8 @@ namespace eosiosystem {
       // is eventually completely removed, at which point this line can be removed.
       _gstate2.last_block_num = timestamp;
 
-      /** until activated stake crosses this threshold no new rewards are paid */
-      if( _gstate.total_activated_stake < min_activated_stake )
+      /** until activation, no new rewards are paid */
+      if( _gstate.thresh_activated_stake_time == time_point() )
          return;
 
       if( _gstate.last_pervote_bucket_fill == time_point() )  /// start the presses
@@ -71,7 +71,7 @@ namespace eosiosystem {
       const auto& prod = _producers.get( owner.value );
       check( prod.active(), "producer does not have an active key" );
 
-      check( _gstate.total_activated_stake >= min_activated_stake,
+      check( _gstate.thresh_activated_stake_time != time_point(),
                     "cannot claim rewards until the chain is activated (at least 15% of all tokens participate in voting)" );
 
       const auto ct = current_time_point();

--- a/contracts/eosio.system/src/voting.cpp
+++ b/contracts/eosio.system/src/voting.cpp
@@ -231,13 +231,13 @@ namespace eosiosystem {
       check( !proxy || !voter->is_proxy, "account registered as a proxy is not allowed to use a proxy" );
 
       /**
-       * The first time someone votes we calculate and set last_vote_weight, since they cannot unstake until
-       * after total_activated_stake hits threshold, we can use last_vote_weight to determine that this is
+       * The first time someone votes we calculate and set last_vote_weight. Since they cannot unstake until
+       * after the chain has been activated, we can use last_vote_weight to determine that this is
        * their first vote and should consider their stake activated.
        */
-      if( voter->last_vote_weight <= 0.0 ) {
+      if( _gstate.thresh_activated_stake_time == time_point() && voter->last_vote_weight <= 0.0 ) {
          _gstate.total_activated_stake += voter->staked;
-         if( _gstate.total_activated_stake >= min_activated_stake && _gstate.thresh_activated_stake_time == time_point() ) {
+         if( _gstate.total_activated_stake >= min_activated_stake ) {
             _gstate.thresh_activated_stake_time = current_time_point();
          }
       }


### PR DESCRIPTION
## Change Description

Avoid updating `total_activated_stake` after activation. Check for activation using `thresh_activated_stake_time` instead of `total_activated_stake`.

## Deployment Changes
- [ ] Deployment Changes

## API Changes
- [ ] API Changes

## Documentation Additions
- [ ] Documentation Additions
