### PR TITLE
Distribute REX returns over time to REX owners

### DIFF
--- a/contracts/eosio.system/include/eosio.system/eosio.system.hpp
+++ b/contracts/eosio.system/include/eosio.system/eosio.system.hpp
@@ -345,24 +345,32 @@ namespace eosiosystem {
    // - `current_rate_of_increase` current amount to be added to the rex pool at a rate of per 30 days,
    // - `cummulative_proceeds` bookkeeping variable that tracks fees added to rex pool up to current time,
    // - `proceeds` bookkeeping variable that tracks fees added to rex return pool up to current time,
-   // - `return_buckets` 12-hour buckets containing amounts to be added to the rex pool and the times they become effective 
+   // - `return_buckets` 12-hour buckets containing amounts to be added to the rex pool and the times they become effective
    struct [[eosio::table,eosio::contract("eosio.system")]] rex_return_pool {
-      uint8_t                       version = 0;
-      
-      time_point                    last_update_time;
-      int64_t                       current_rate_of_increase = 0;
-      int64_t                       cummulative_proceeds = 0;
-      int64_t                       proceeds = 0;
-      std::map<time_point, int64_t> return_buckets;
+      uint8_t        version = 0;
+      time_point_sec last_dist_time;
+      time_point_sec pending_bucket_time      = time_point_sec::maximum();
+      time_point_sec oldest_bucket_time       = time_point_sec::min();
+      int64_t        pending_bucket_proceeds  = 0;
+      int64_t        current_rate_of_increase = 0;
 
-      static constexpr int64_t      total_duration   = 30 * useconds_per_day;
-      static constexpr int64_t      dist_interval    = 10 * 60 * 1000'000;  
-      static constexpr uint8_t      hours_per_bucket = 12;
+      static constexpr int32_t total_intervals  = 30 * 144; // 30 days
+      static constexpr int32_t dist_interval    = 10 * 60;  // 10 minutes
+      static constexpr uint8_t hours_per_bucket = 12;
 
       uint64_t primary_key()const { return 0; }
    };
 
    typedef eosio::multi_index< "rexretpool"_n, rex_return_pool > rex_return_pool_table;
+
+   struct [[eosio::table,eosio::contract("eosio.system")]] rex_return_buckets {
+      uint8_t                           version = 0;
+      std::map<time_point_sec, int64_t> return_buckets;
+
+      uint64_t primary_key()const { return 0; }
+   };
+
+   typedef eosio::multi_index< "retbuckets"_n, rex_return_buckets > rex_return_buckets_table;
 
    // `rex_fund` structure underlying the rex fund table. A rex fund table entry is defined by:
    // - `version` defaulted to zero,
@@ -461,23 +469,24 @@ namespace eosiosystem {
    class [[eosio::contract("eosio.system")]] system_contract : public native {
 
       private:
-         voters_table            _voters;
-         producers_table         _producers;
-         producers_table2        _producers2;
-         global_state_singleton  _global;
-         global_state2_singleton _global2;
-         global_state3_singleton _global3;
-         global_state4_singleton _global4;
-         eosio_global_state      _gstate;
-         eosio_global_state2     _gstate2;
-         eosio_global_state3     _gstate3;
-         eosio_global_state4     _gstate4;
-         rammarket               _rammarket;
-         rex_pool_table          _rexpool;
-         rex_return_pool_table   _rexretpool;
-         rex_fund_table          _rexfunds;
-         rex_balance_table       _rexbalance;
-         rex_order_table         _rexorders;
+         voters_table             _voters;
+         producers_table          _producers;
+         producers_table2         _producers2;
+         global_state_singleton   _global;
+         global_state2_singleton  _global2;
+         global_state3_singleton  _global3;
+         global_state4_singleton  _global4;
+         eosio_global_state       _gstate;
+         eosio_global_state2      _gstate2;
+         eosio_global_state3      _gstate3;
+         eosio_global_state4      _gstate4;
+         rammarket                _rammarket;
+         rex_pool_table           _rexpool;
+         rex_return_pool_table    _rexretpool;
+         rex_return_buckets_table _rexretbuckets;
+         rex_fund_table           _rexfunds;
+         rex_balance_table        _rexbalance;
+         rex_order_table          _rexorders;
 
       public:
          static constexpr eosio::name active_permission{"active"_n};

--- a/contracts/eosio.system/include/eosio.system/eosio.system.hpp
+++ b/contracts/eosio.system/include/eosio.system/eosio.system.hpp
@@ -340,9 +340,8 @@ namespace eosiosystem {
 
    struct [[eosio::table,eosio::contract("eosio.system")]] rex_return_pool {
       uint8_t                           version = 0;
-      int64_t                           current_rate_of_increase = 0;
-      int64_t                           residue = 0; 
       time_point_sec                    last_update_time;
+      int64_t                           current_rate_of_increase = 0;
       std::map<time_point_sec, int64_t> return_buckets;
 
       static constexpr uint32_t         total_duration = 30 * seconds_per_day;

--- a/contracts/eosio.system/include/eosio.system/eosio.system.hpp
+++ b/contracts/eosio.system/include/eosio.system/eosio.system.hpp
@@ -345,7 +345,8 @@ namespace eosiosystem {
    // - `pending_bucket_time` timestamp of the pending 12-hour return bucket,
    // - `oldest_bucket_time` cached timestamp of the oldest 12-hour return bucket, 
    // - `pending_bucket_proceeds` proceeds in the pending 12-hour return bucket, 
-   // - `current_rate_of_increase` the current rate per dist_interval at which proceeds are added to the rex pool
+   // - `current_rate_of_increase` the current rate per dist_interval at which proceeds are added to the rex pool,
+   // - `proceeds` the maximum amount of proceeds that can be added to the rex pool at any given time
    struct [[eosio::table,eosio::contract("eosio.system")]] rex_return_pool {
       uint8_t        version = 0;
       time_point_sec last_dist_time;
@@ -353,10 +354,12 @@ namespace eosiosystem {
       time_point_sec oldest_bucket_time       = time_point_sec::min();
       int64_t        pending_bucket_proceeds  = 0;
       int64_t        current_rate_of_increase = 0;
+      int64_t        proceeds                 = 0;
 
       static constexpr uint32_t total_intervals  = 30 * 144; // 30 days
       static constexpr uint32_t dist_interval    = 10 * 60;  // 10 minutes
       static constexpr uint8_t  hours_per_bucket = 12;
+      static_assert( total_intervals * dist_interval == 30 * seconds_per_day );
 
       uint64_t primary_key()const { return 0; }
    };

--- a/contracts/eosio.system/include/eosio.system/eosio.system.hpp
+++ b/contracts/eosio.system/include/eosio.system/eosio.system.hpp
@@ -339,13 +339,18 @@ namespace eosiosystem {
 
    typedef eosio::multi_index< "rexpool"_n, rex_pool > rex_pool_table;
 
+   // `rex_return_pool` structure underlying the rex return pool table. A rex return pool table entry is defined by:
+   // - `version` defaulted to zero,
+   // - `last_update_time` the last time returns from renting, ram fees, and name bids were added to the rex pool,
+   // - `current_rate_of_increase` current amount to be added to the rex pool at a rate of per 30 days,
+   // - `return_buckets` 12-hour buckets containing amounts to be added to the rex pool and the times they become effective 
    struct [[eosio::table,eosio::contract("eosio.system")]] rex_return_pool {
       uint8_t                       version = 0;
       time_point                    last_update_time;
       int64_t                       current_rate_of_increase = 0;
       std::map<time_point, int64_t> return_buckets;
 
-      static constexpr int64_t      total_duration = 30 * useconds_per_day;
+      static constexpr int64_t      total_duration   = 30 * useconds_per_day;
       static constexpr uint8_t      hours_per_bucket = 12;
 
       uint64_t primary_key()const { return 0; }

--- a/contracts/eosio.system/include/eosio.system/eosio.system.hpp
+++ b/contracts/eosio.system/include/eosio.system/eosio.system.hpp
@@ -340,11 +340,13 @@ namespace eosiosystem {
 
    struct [[eosio::table,eosio::contract("eosio.system")]] rex_return_pool {
       uint8_t                           version = 0;
-      uint8_t                           hours_per_bucket = 12;
       int64_t                           current_rate_of_increase = 0;
       int64_t                           residue = 0; 
       time_point_sec                    last_update_time;
       std::map<time_point_sec, int64_t> return_buckets;
+
+      static constexpr uint32_t         total_duration = 30 * seconds_per_day;
+      static constexpr uint8_t          hours_per_bucket = 12;
 
       uint64_t primary_key()const { return 0; }
    };

--- a/contracts/eosio.system/include/eosio.system/eosio.system.hpp
+++ b/contracts/eosio.system/include/eosio.system/eosio.system.hpp
@@ -341,11 +341,11 @@ namespace eosiosystem {
 
    // `rex_return_pool` structure underlying the rex return pool table. A rex return pool table entry is defined by:
    // - `version` defaulted to zero,
-   // - `last_update_time` the last time returns from renting, ram fees, and name bids were added to the rex pool,
-   // - `current_rate_of_increase` current amount to be added to the rex pool at a rate of per 30 days,
-   // - `cummulative_proceeds` bookkeeping variable that tracks fees added to rex pool up to current time,
-   // - `proceeds` bookkeeping variable that tracks fees added to rex return pool up to current time,
-   // - `return_buckets` 12-hour buckets containing amounts to be added to the rex pool and the times they become effective
+   // - `last_dist_time` the last time proceeds from renting, ram fees, and name bids were added to the rex pool,
+   // - `pending_bucket_time` timestamp of the pending 12-hour return bucket,
+   // - `oldest_bucket_time` cached timestamp of the oldest 12-hour return bucket, 
+   // - `pending_bucket_proceeds` proceeds in the pending 12-hour return bucket, 
+   // - `current_rate_of_increase` the current rate per dist_interval at which proceeds are added to the rex pool
    struct [[eosio::table,eosio::contract("eosio.system")]] rex_return_pool {
       uint8_t        version = 0;
       time_point_sec last_dist_time;
@@ -354,15 +354,18 @@ namespace eosiosystem {
       int64_t        pending_bucket_proceeds  = 0;
       int64_t        current_rate_of_increase = 0;
 
-      static constexpr int32_t total_intervals  = 30 * 144; // 30 days
-      static constexpr int32_t dist_interval    = 10 * 60;  // 10 minutes
-      static constexpr uint8_t hours_per_bucket = 12;
+      static constexpr uint32_t total_intervals  = 30 * 144; // 30 days
+      static constexpr uint32_t dist_interval    = 10 * 60;  // 10 minutes
+      static constexpr uint8_t  hours_per_bucket = 12;
 
       uint64_t primary_key()const { return 0; }
    };
 
    typedef eosio::multi_index< "rexretpool"_n, rex_return_pool > rex_return_pool_table;
 
+   // `rex_return_buckets` structure underlying the rex return buckets table. A rex return buckets table is defined by:
+   // - `version` defaulted to zero,
+   // - `return_buckets` buckets of proceeds accumulated in 12-hour intervals 
    struct [[eosio::table,eosio::contract("eosio.system")]] rex_return_buckets {
       uint8_t                           version = 0;
       std::map<time_point_sec, int64_t> return_buckets;

--- a/contracts/eosio.system/include/eosio.system/eosio.system.hpp
+++ b/contracts/eosio.system/include/eosio.system/eosio.system.hpp
@@ -343,14 +343,20 @@ namespace eosiosystem {
    // - `version` defaulted to zero,
    // - `last_update_time` the last time returns from renting, ram fees, and name bids were added to the rex pool,
    // - `current_rate_of_increase` current amount to be added to the rex pool at a rate of per 30 days,
+   // - `cummulative_proceeds` bookkeeping variable that tracks fees added to rex pool up to current time,
+   // - `proceeds` bookkeeping variable that tracks fees added to rex return pool up to current time,
    // - `return_buckets` 12-hour buckets containing amounts to be added to the rex pool and the times they become effective 
    struct [[eosio::table,eosio::contract("eosio.system")]] rex_return_pool {
       uint8_t                       version = 0;
+      
       time_point                    last_update_time;
       int64_t                       current_rate_of_increase = 0;
+      int64_t                       cummulative_proceeds = 0;
+      int64_t                       proceeds = 0;
       std::map<time_point, int64_t> return_buckets;
 
       static constexpr int64_t      total_duration   = 30 * useconds_per_day;
+      static constexpr int64_t      dist_interval    = 10 * 60 * 1000'000;  
       static constexpr uint8_t      hours_per_bucket = 12;
 
       uint64_t primary_key()const { return 0; }

--- a/contracts/eosio.system/include/eosio.system/eosio.system.hpp
+++ b/contracts/eosio.system/include/eosio.system/eosio.system.hpp
@@ -61,6 +61,7 @@ namespace eosiosystem {
 
    static constexpr uint32_t seconds_per_year      = 52 * 7 * 24 * 3600;
    static constexpr uint32_t seconds_per_day       = 24 * 3600;
+   static constexpr uint32_t seconds_per_hour      = 3600;
    static constexpr int64_t  useconds_per_year     = int64_t(seconds_per_year) * 1000'000ll;
    static constexpr int64_t  useconds_per_day      = int64_t(seconds_per_day) * 1000'000ll;
    static constexpr uint32_t blocks_per_day        = 2 * seconds_per_day; // half seconds per day
@@ -339,6 +340,7 @@ namespace eosiosystem {
 
    struct [[eosio::table,eosio::contract("eosio.system")]] rex_return_pool {
       uint8_t                           version = 0;
+      uint8_t                           hours_per_bucket = 12;
       int64_t                           current_rate_of_increase = 0;
       int64_t                           residue = 0; 
       time_point_sec                    last_update_time;

--- a/contracts/eosio.system/include/eosio.system/eosio.system.hpp
+++ b/contracts/eosio.system/include/eosio.system/eosio.system.hpp
@@ -337,6 +337,17 @@ namespace eosiosystem {
 
    typedef eosio::multi_index< "rexpool"_n, rex_pool > rex_pool_table;
 
+   struct [[eosio::table,eosio::contract("eosio.system")]] rex_return_pool {
+      uint8_t                           version = 0;
+      int64_t                           current_rate_of_increase = 0;
+      time_point_sec                    last_update_time;
+      std::map<time_point_sec, int64_t> return_buckets;
+
+      uint64_t primary_key()const { return 0; }
+   };
+
+   typedef eosio::multi_index< "rexretpool"_n, rex_return_pool > rex_return_pool_table;
+
    // `rex_fund` structure underlying the rex fund table. A rex fund table entry is defined by:
    // - `version` defaulted to zero,
    // - `owner` the owner of the rex fund,
@@ -447,6 +458,7 @@ namespace eosiosystem {
          eosio_global_state4     _gstate4;
          rammarket               _rammarket;
          rex_pool_table          _rexpool;
+         rex_return_pool_table   _rexretpool;
          rex_fund_table          _rexfunds;
          rex_balance_table       _rexbalance;
          rex_order_table         _rexorders;
@@ -1143,6 +1155,7 @@ namespace eosiosystem {
 
          // defined in rex.cpp
          void runrex( uint16_t max );
+         void update_rex_pool();
          void update_resource_limits( const name& from, const name& receiver, int64_t delta_net, int64_t delta_cpu );
          void check_voting_requirement( const name& owner,
                                         const char* error_msg = "must vote for at least 21 producers or for a proxy before buying REX" )const;
@@ -1164,6 +1177,7 @@ namespace eosiosystem {
          static time_point_sec get_rex_maturity();
          asset add_to_rex_balance( const name& owner, const asset& payment, const asset& rex_received );
          asset add_to_rex_pool( const asset& payment );
+         void add_to_rex_return_pool( const asset& fee );
          void process_rex_maturities( const rex_balance_table::const_iterator& bitr );
          void consolidate_rex_balance( const rex_balance_table::const_iterator& bitr,
                                        const asset& rex_in_sell_order );

--- a/contracts/eosio.system/include/eosio.system/eosio.system.hpp
+++ b/contracts/eosio.system/include/eosio.system/eosio.system.hpp
@@ -64,6 +64,7 @@ namespace eosiosystem {
    static constexpr uint32_t seconds_per_hour      = 3600;
    static constexpr int64_t  useconds_per_year     = int64_t(seconds_per_year) * 1000'000ll;
    static constexpr int64_t  useconds_per_day      = int64_t(seconds_per_day) * 1000'000ll;
+   static constexpr int64_t  useconds_per_hour     = int64_t(seconds_per_hour) * 1000'000ll;
    static constexpr uint32_t blocks_per_day        = 2 * seconds_per_day; // half seconds per day
 
    static constexpr int64_t  min_activated_stake   = 150'000'000'0000;
@@ -339,13 +340,13 @@ namespace eosiosystem {
    typedef eosio::multi_index< "rexpool"_n, rex_pool > rex_pool_table;
 
    struct [[eosio::table,eosio::contract("eosio.system")]] rex_return_pool {
-      uint8_t                           version = 0;
-      time_point_sec                    last_update_time;
-      int64_t                           current_rate_of_increase = 0;
-      std::map<time_point_sec, int64_t> return_buckets;
+      uint8_t                       version = 0;
+      time_point                    last_update_time;
+      int64_t                       current_rate_of_increase = 0;
+      std::map<time_point, int64_t> return_buckets;
 
-      static constexpr uint32_t         total_duration = 30 * seconds_per_day;
-      static constexpr uint8_t          hours_per_bucket = 12;
+      static constexpr int64_t      total_duration = 30 * useconds_per_day;
+      static constexpr uint8_t      hours_per_bucket = 12;
 
       uint64_t primary_key()const { return 0; }
    };

--- a/contracts/eosio.system/include/eosio.system/eosio.system.hpp
+++ b/contracts/eosio.system/include/eosio.system/eosio.system.hpp
@@ -340,6 +340,7 @@ namespace eosiosystem {
    struct [[eosio::table,eosio::contract("eosio.system")]] rex_return_pool {
       uint8_t                           version = 0;
       int64_t                           current_rate_of_increase = 0;
+      int64_t                           residue = 0; 
       time_point_sec                    last_update_time;
       std::map<time_point_sec, int64_t> return_buckets;
 

--- a/contracts/eosio.system/src/eosio.system.cpp
+++ b/contracts/eosio.system/src/eosio.system.cpp
@@ -27,6 +27,7 @@ namespace eosiosystem {
     _rammarket(get_self(), get_self().value),
     _rexpool(get_self(), get_self().value),
     _rexretpool(get_self(), get_self().value),
+    _rexretbuckets(get_self(), get_self().value),
     _rexfunds(get_self(), get_self().value),
     _rexbalance(get_self(), get_self().value),
     _rexorders(get_self(), get_self().value)

--- a/contracts/eosio.system/src/eosio.system.cpp
+++ b/contracts/eosio.system/src/eosio.system.cpp
@@ -26,11 +26,11 @@ namespace eosiosystem {
     _global4(get_self(), get_self().value),
     _rammarket(get_self(), get_self().value),
     _rexpool(get_self(), get_self().value),
+    _rexretpool(get_self(), get_self().value),
     _rexfunds(get_self(), get_self().value),
     _rexbalance(get_self(), get_self().value),
     _rexorders(get_self(), get_self().value)
    {
-      //print( "construct system\n" );
       _gstate  = _global.exists() ? _global.get() : get_default_parameters();
       _gstate2 = _global2.exists() ? _global2.get() : eosio_global_state2{};
       _gstate3 = _global3.exists() ? _global3.get() : eosio_global_state3{};

--- a/contracts/eosio.system/src/rex.cpp
+++ b/contracts/eosio.system/src/rex.cpp
@@ -1032,8 +1032,7 @@ namespace eosiosystem {
          });
       }
 
-      const uint8_t  hours_per_bucket = _rexretpool.begin()->hours_per_bucket;
-      const uint32_t bucket_interval  = hours_per_bucket * seconds_per_hour;
+      const uint32_t bucket_interval = _rexretpool.begin()->hours_per_bucket * seconds_per_hour;
 
       _rexretpool.modify( _rexretpool.begin(), same_payer, [&]( auto& return_pool ) {
          time_point_sec effective_time{ cts - cts % bucket_interval + bucket_interval };
@@ -1047,9 +1046,10 @@ namespace eosiosystem {
             if ( !return_buckets.empty() ) {
                uint32_t interval = cts - return_buckets.rbegin()->first.sec_since_epoch();
                residue = ( uint128_t(return_buckets.rbegin()->second) * interval ) / total_duration;
+               current_rate_of_increase += return_buckets.rbegin()->second;
             }
-            return_pool.residue           += residue;
-            current_rate_of_increase      += return_buckets.rbegin()->second;
+            return_pool.residue += residue;
+            //            current_rate_of_increase      += return_buckets.rbegin()->second;
             return_buckets[effective_time] = fee.amount;
          }
       });

--- a/contracts/eosio.system/src/rex.cpp
+++ b/contracts/eosio.system/src/rex.cpp
@@ -733,7 +733,7 @@ namespace eosiosystem {
       asset stake_change( 0, core_symbol() );
       bool  success = false;
 
-      const int64_t unlent_lower_bound = ( uint128_t(2) * rexitr->total_lent.amount ) / 10;
+      const int64_t unlent_lower_bound = rexitr->total_lent.amount / 10;
       const int64_t available_unlent   = rexitr->total_unlent.amount - unlent_lower_bound; // available_unlent <= 0 is possible
       if ( proceeds.amount <= available_unlent ) {
          const int64_t init_vote_stake_amount = bitr->vote_stake.amount;

--- a/contracts/eosio.system/src/rex.cpp
+++ b/contracts/eosio.system/src/rex.cpp
@@ -616,6 +616,9 @@ namespace eosiosystem {
 
    }
 
+   /**
+    * @brief Adds returns from the REX return pool to the REX pool
+    */
    void system_contract::update_rex_pool()
    {
       const time_point ct = current_time_point();
@@ -1013,6 +1016,11 @@ namespace eosiosystem {
       return rex_received;
    }
 
+   /**
+    * @brief Adds an amount of core tokens to the REX return pool
+    *
+    * @param fee - amount to be added
+    */
    void system_contract::add_to_rex_return_pool( const asset& fee )
    {
       update_rex_pool();

--- a/tests/eosio.system_tester.hpp
+++ b/tests/eosio.system_tester.hpp
@@ -666,6 +666,27 @@ public:
       return data.empty() ? fc::variant() : abi_ser.binary_to_variant( "rex_pool", data, abi_serializer_max_time );
    }
 
+   fc::variant get_rex_return_pool() const {
+      vector<char> data;
+      const auto& db = control->db();
+      namespace chain = eosio::chain;
+      const auto* t_id = db.find<eosio::chain::table_id_object, chain::by_code_scope_table>( boost::make_tuple( config::system_account_name, config::system_account_name, N(rexretpool) ) );
+      if ( !t_id ) {
+         return fc::variant();
+      }
+
+      const auto& idx = db.get_index<chain::key_value_index, chain::by_scope_primary>();
+
+      auto itr = idx.lower_bound( boost::make_tuple( t_id->id, 0 ) );
+      if ( itr == idx.end() || itr->t_id != t_id->id || 0 != itr->primary_key ) {
+         return fc::variant();
+      }
+
+      data.resize( itr->value.size() );
+      memcpy( data.data(), itr->value.data(), data.size() );
+      return data.empty() ? fc::variant() : abi_ser.binary_to_variant( "rex_return_pool", data, abi_serializer_max_time );
+   }
+
    void setup_rex_accounts( const std::vector<account_name>& accounts,
                             const asset& init_balance,
                             const asset& net = core_sym::from_string("80.0000"),

--- a/tests/eosio.system_tester.hpp
+++ b/tests/eosio.system_tester.hpp
@@ -687,6 +687,27 @@ public:
       return data.empty() ? fc::variant() : abi_ser.binary_to_variant( "rex_return_pool", data, abi_serializer_max_time );
    }
 
+   fc::variant get_rex_return_buckets() const {
+      vector<char> data;
+      const auto& db = control->db();
+      namespace chain = eosio::chain;
+      const auto* t_id = db.find<eosio::chain::table_id_object, chain::by_code_scope_table>( boost::make_tuple( config::system_account_name, config::system_account_name, N(retbuckets) ) );
+      if ( !t_id ) {
+         return fc::variant();
+      }
+
+      const auto& idx = db.get_index<chain::key_value_index, chain::by_scope_primary>();
+
+      auto itr = idx.lower_bound( boost::make_tuple( t_id->id, 0 ) );
+      if ( itr == idx.end() || itr->t_id != t_id->id || 0 != itr->primary_key ) {
+         return fc::variant();
+      }
+
+      data.resize( itr->value.size() );
+      memcpy( data.data(), itr->value.data(), data.size() );
+      return data.empty() ? fc::variant() : abi_ser.binary_to_variant( "rex_return_buckets", data, abi_serializer_max_time );
+   }
+      
    void setup_rex_accounts( const std::vector<account_name>& accounts,
                             const asset& init_balance,
                             const asset& net = core_sym::from_string("80.0000"),

--- a/tests/eosio.system_tests.cpp
+++ b/tests/eosio.system_tests.cpp
@@ -4088,8 +4088,8 @@ BOOST_FIXTURE_TEST_CASE( buy_sell_claim_rex, eosio_system_tester ) try {
    setup_rex_accounts( accounts, init_balance );
 
    const auto purchase1  = core_sym::from_string("50000.0000");
-   const auto purchase2  = core_sym::from_string("235500.0000");
-   const auto purchase3  = core_sym::from_string("234500.0000");
+   const auto purchase2  = core_sym::from_string("105500.0000");
+   const auto purchase3  = core_sym::from_string("104500.0000");
    const auto init_stake = get_voter_info(alice)["staked"].as<int64_t>();
    BOOST_REQUIRE_EQUAL( success(), buyrex( alice, purchase1) );
    BOOST_REQUIRE_EQUAL( success(), buyrex( bob,   purchase2) );
@@ -4108,12 +4108,12 @@ BOOST_FIXTURE_TEST_CASE( buy_sell_claim_rex, eosio_system_tester ) try {
    BOOST_REQUIRE_EQUAL( core_sym::from_string("20000.0000"), get_rex_pool()["total_rent"].as<asset>() );
 
    for (uint8_t i = 0; i < 4; ++i) {
-      BOOST_REQUIRE_EQUAL( success(), rentcpu( emily, emily, core_sym::from_string("20000.0000") ) );
+      BOOST_REQUIRE_EQUAL( success(), rentcpu( emily, emily, core_sym::from_string("12000.0000") ) );
    }
 
    produce_block( fc::days(25) );
 
-   const asset rent_payment = core_sym::from_string("40000.0000");
+   const asset rent_payment = core_sym::from_string("46000.0000");
    BOOST_REQUIRE_EQUAL( success(), rentcpu( frank, frank, rent_payment, rent_payment ) );
 
    produce_block( fc::days(4) );
@@ -4770,7 +4770,7 @@ BOOST_FIXTURE_TEST_CASE( rex_savings, eosio_system_tester ) try {
 
       produce_block( fc::days(5) );
 
-      BOOST_REQUIRE_EQUAL( success(),                       rentcpu( bob, bob, core_sym::from_string("2000.0000") ) );
+      BOOST_REQUIRE_EQUAL( success(),                       rentcpu( bob, bob, core_sym::from_string("3000.0000") ) );
       BOOST_REQUIRE_EQUAL( success(),                       sellrex( alice, asset( 9 * rex_bucket_amount / 10, rex_sym ) ) );
       BOOST_REQUIRE_EQUAL( rex_bucket,                      get_rex_balance( alice ) );
       BOOST_REQUIRE_EQUAL( success(),                       mvtosavings( alice, asset( rex_bucket_amount / 10, rex_sym ) ) );
@@ -5043,11 +5043,11 @@ BOOST_FIXTURE_TEST_CASE( rex_lower_bound, eosio_system_tester ) try {
    const int64_t tot_lent     = rex_pool["total_lent"].as<asset>().get_amount();
    const int64_t tot_lendable = rex_pool["total_lendable"].as<asset>().get_amount();
    double rex_per_eos = double(tot_rex) / double(tot_lendable);
-   int64_t sell_amount = rex_per_eos * ( tot_unlent - 0.19 * tot_lent );
+   int64_t sell_amount = rex_per_eos * ( tot_unlent - 0.09 * tot_lent );
    produce_block( fc::days(5) );
    BOOST_REQUIRE_EQUAL( success(), sellrex( alice, asset( sell_amount, rex_sym ) ) );
    BOOST_REQUIRE_EQUAL( success(), cancelrexorder( alice ) );
-   sell_amount = rex_per_eos * ( tot_unlent - 0.2 * tot_lent );
+   sell_amount = rex_per_eos * ( tot_unlent - 0.1 * tot_lent );
    BOOST_REQUIRE_EQUAL( success(), sellrex( alice, asset( sell_amount, rex_sym ) ) );
    BOOST_REQUIRE_EQUAL( wasm_assert_msg("no sellrex order is scheduled"),
                         cancelrexorder( alice ) );

--- a/tests/eosio.system_tests.cpp
+++ b/tests/eosio.system_tests.cpp
@@ -3985,14 +3985,17 @@ BOOST_FIXTURE_TEST_CASE( buy_rent_rex, eosio_system_tester ) try {
 
       rex_return_pool = get_rex_return_pool();
       BOOST_REQUIRE( !rex_return_pool.is_null() );
-      BOOST_REQUIRE_EQUAL( 0, rex_return_pool["residue"].as<int64_t>() );
-      BOOST_REQUIRE_EQUAL( 0, rex_return_pool["current_rate_of_increase"].as<int64_t>() );
+      BOOST_REQUIRE_EQUAL( 0,                rex_return_pool["residue"].as<int64_t>() );
+      BOOST_REQUIRE_EQUAL( fee.get_amount(), rex_return_pool["current_rate_of_increase"].as<int64_t>() );
 
       produce_block( fc::days(10) );
       // alice is finally able to sellrex, she gains the fee paid by bob
       BOOST_REQUIRE_EQUAL( success(),          sellrex( alice, get_rex_balance(alice) ) );
       BOOST_REQUIRE_EQUAL( 0,                  get_rex_balance(alice).get_amount() );
-      BOOST_REQUIRE_EQUAL( init_balance + fee, get_rex_fund(alice) );
+      auto expected_rex_fund = (init_balance + fee).get_amount();
+      auto actual_rex_fund   = get_rex_fund(alice).get_amount();
+      BOOST_REQUIRE_EQUAL( true,               within_one( expected_rex_fund, actual_rex_fund ) );
+      BOOST_REQUIRE( actual_rex_fund <= expected_rex_fund );
       // test that carol's resource limits have been updated properly when loan expires
       BOOST_REQUIRE_EQUAL( init_cpu_limit,     get_cpu_limit( carol ) );
       BOOST_REQUIRE_EQUAL( init_net_limit,     get_net_limit( carol ) );
@@ -4050,7 +4053,7 @@ BOOST_FIXTURE_TEST_CASE( buy_sell_sell_rex, eosio_system_tester ) try {
    const asset fee = core_sym::from_string("7.0000");
    BOOST_REQUIRE_EQUAL( success(),               rentcpu( bob, carol, fee ) );
    rex_pool = get_rex_pool();
-   BOOST_REQUIRE_EQUAL( init_tot_lendable + fee, rex_pool["total_lendable"].as<asset>() );
+   BOOST_REQUIRE_EQUAL( init_tot_lendable,       rex_pool["total_lendable"].as<asset>() );
    BOOST_REQUIRE_EQUAL( init_tot_rent + fee,     rex_pool["total_rent"].as<asset>() );
 
    produce_block( fc::days(5) );

--- a/tests/eosio.system_tests.cpp
+++ b/tests/eosio.system_tests.cpp
@@ -3984,7 +3984,8 @@ BOOST_FIXTURE_TEST_CASE( buy_rent_rex, eosio_system_tester ) try {
 
       rex_return_pool = get_rex_return_pool();
       BOOST_REQUIRE( !rex_return_pool.is_null() );
-      BOOST_REQUIRE_EQUAL( fee.get_amount(), rex_return_pool["current_rate_of_increase"].as<int64_t>() );
+      int64_t rate = fee.get_amount() / (30 * 144);
+      BOOST_REQUIRE_EQUAL( rate,               rex_return_pool["current_rate_of_increase"].as<int64_t>() );
 
       produce_block( fc::days(10) );
       // alice is finally able to sellrex, she gains the fee paid by bob
@@ -3992,8 +3993,7 @@ BOOST_FIXTURE_TEST_CASE( buy_rent_rex, eosio_system_tester ) try {
       BOOST_REQUIRE_EQUAL( 0,                  get_rex_balance(alice).get_amount() );
       auto expected_rex_fund = (init_balance + fee).get_amount();
       auto actual_rex_fund   = get_rex_fund(alice).get_amount();
-      BOOST_REQUIRE_EQUAL( true,               within_error( expected_rex_fund, actual_rex_fund, 2 ) );
-      BOOST_TEST_REQUIRE( actual_rex_fund <=   expected_rex_fund );
+      BOOST_REQUIRE_EQUAL( expected_rex_fund,  actual_rex_fund );
       // test that carol's resource limits have been updated properly when loan expires
       BOOST_REQUIRE_EQUAL( init_cpu_limit,     get_cpu_limit( carol ) );
       BOOST_REQUIRE_EQUAL( init_net_limit,     get_net_limit( carol ) );
@@ -4463,10 +4463,9 @@ BOOST_FIXTURE_TEST_CASE( ramfee_namebid_to_rex, eosio_system_tester ) try {
    produce_blocks( 1 );
 
    BOOST_REQUIRE_EQUAL( success(),                        rexexec( alice, 1 ) );
-
-   BOOST_TEST_REQUIRE( within_error( cur_rex_balance.get_amount(), get_rex_pool()["total_lendable"].as<asset>().get_amount(), 4 ) );
-   BOOST_TEST_REQUIRE( cur_rex_balance.get_amount() >= get_rex_pool()["total_lendable"].as<asset>().get_amount() );
-   BOOST_REQUIRE_EQUAL(  get_rex_pool()["total_lendable"].as<asset>(), get_rex_pool()["total_unlent"].as<asset>() );
+   BOOST_REQUIRE_EQUAL( cur_rex_balance,                  get_rex_pool()["total_lendable"].as<asset>() );
+   BOOST_REQUIRE_EQUAL( get_rex_pool()["total_lendable"].as<asset>(),
+                        get_rex_pool()["total_unlent"].as<asset>() );
 
 } FC_LOG_AND_RETHROW()
 
@@ -4899,8 +4898,8 @@ BOOST_FIXTURE_TEST_CASE( update_rex, eosio_system_tester, * boost::unit_test::to
    const int64_t init_alice_rex_stake = ( eosio::chain::uint128_t(init_rex.get_amount()) * total_lendable ) / total_rex;
    const asset rex_sell_amount( get_rex_balance(alice).get_amount() / 4, symbol( SY(4,REX) ) );
    BOOST_REQUIRE_EQUAL( success(),                                       sellrex( alice, rex_sell_amount ) );
-   BOOST_REQUIRE_EQUAL( init_rex,                                        get_rex_balance( alice ) + rex_sell_amount );
-   BOOST_TEST_REQUIRE( within_error( 3 * init_alice_rex_stake,           4 * get_rex_vote_stake( alice ).get_amount(), 2 ) );
+   BOOST_REQUIRE_EQUAL( init_rex,                                        get_rex_balance(alice) + rex_sell_amount );
+   BOOST_REQUIRE_EQUAL( 3 * init_alice_rex_stake,                         4 * get_rex_vote_stake(alice).get_amount() );
    BOOST_REQUIRE_EQUAL( get_voter_info( alice )["staked"].as<int64_t>(), init_stake + get_rex_vote_stake(alice).get_amount() );
    BOOST_TEST_REQUIRE( stake2votes( asset( get_voter_info( alice )["staked"].as<int64_t>(), symbol{CORE_SYM} ) )
                        == get_producer_info(producer_names[0])["total_votes"].as<double>() );
@@ -4979,14 +4978,14 @@ BOOST_FIXTURE_TEST_CASE( update_rex_vote, eosio_system_tester, * boost::unit_tes
    produce_block( fc::hours(30 * 24 + 13) );
    BOOST_REQUIRE_EQUAL( success(),                              rexexec( alice, 1 ) );
    BOOST_REQUIRE_EQUAL( success(),                              stake( alice, alice, to_net_stake, to_cpu_stake ) );
-   BOOST_TEST_REQUIRE(  within_error( (purchase + rent + rent).get_amount(), get_rex_vote_stake(alice).get_amount(), 2 ) );
+   BOOST_REQUIRE_EQUAL(  purchase + rent + rent,                get_rex_vote_stake(alice) );
    BOOST_TEST_REQUIRE ( stake2votes(init_stake + purchase + rent + rent + to_net_stake + to_cpu_stake) ==
                         get_producer_info(producer_names[0])["total_votes"].as_double() );
    BOOST_REQUIRE_EQUAL( success(),                              rentcpu( emily, bob, rent ) );
    produce_block( fc::hours(30 * 24 + 13) );
    BOOST_REQUIRE_EQUAL( success(),                              rexexec( alice, 1 ) );
    BOOST_REQUIRE_EQUAL( success(),                              unstake( alice, alice, to_net_stake, to_cpu_stake ) );
-   BOOST_TEST_REQUIRE(  within_error( (purchase + rent + rent + rent).get_amount(), get_rex_vote_stake(alice).get_amount(), 3 ) );
+   BOOST_REQUIRE_EQUAL( purchase + rent + rent + rent,          get_rex_vote_stake(alice) );
    BOOST_TEST_REQUIRE ( stake2votes(init_stake + get_rex_vote_stake(alice) ) ==
                         get_producer_info(producer_names[0])["total_votes"].as_double() );
 
@@ -5255,6 +5254,8 @@ BOOST_FIXTURE_TEST_CASE( b1_vesting, eosio_system_tester ) try {
 
 BOOST_FIXTURE_TEST_CASE( rex_return, eosio_system_tester ) try {
 
+   constexpr uint32_t total_intervals = 30 * 144;
+   constexpr uint32_t dist_interval   = 10 * 60;
    BOOST_REQUIRE_EQUAL( true,                get_rex_return_pool().is_null() );
 
    const asset init_balance = core_sym::from_string("100000.0000");
@@ -5278,16 +5279,17 @@ BOOST_FIXTURE_TEST_CASE( rex_return, eosio_system_tester ) try {
       auto rex_return_pool = get_rex_return_pool();
       BOOST_REQUIRE_EQUAL( false,            rex_return_pool.is_null() );
       BOOST_REQUIRE_EQUAL( 0,                rex_return_pool["current_rate_of_increase"].as<int64_t>() );
-      BOOST_REQUIRE_EQUAL( 1,                rex_return_pool["return_buckets"].get_array().size() );
-      int64_t t0 = rex_return_pool["last_update_time"].as<time_point>().time_since_epoch().count();
+      BOOST_REQUIRE_EQUAL( 0,                get_rex_return_buckets()["return_buckets"].get_array().size() );
+      int32_t t0 = rex_return_pool["last_dist_time"].as<time_point_sec>().sec_since_epoch();
 
       produce_block( fc::hours(13) );
       BOOST_REQUIRE_EQUAL( success(),        rexexec( bob, 1 ) );
       rex_return_pool = get_rex_return_pool();
-      BOOST_REQUIRE_EQUAL( fee.get_amount(), rex_return_pool["current_rate_of_increase"].as<int64_t>() );
+      int64_t rate    = fee.get_amount() / total_intervals;
+      BOOST_REQUIRE_EQUAL( rate,             rex_return_pool["current_rate_of_increase"].as<int64_t>() );
 
-      int64_t t1 = rex_return_pool["last_update_time"].as<time_point>().time_since_epoch().count();
-      int64_t  change   = (eosio::chain::uint128_t(t1-t0) * fee.get_amount()) / (30 * 24 * 3600 * 1000000ll);
+      int32_t t1 = rex_return_pool["last_dist_time"].as<time_point_sec>().sec_since_epoch();
+      int64_t  change   = rate * ((t1-t0) / dist_interval) + fee.get_amount() % total_intervals;
       int64_t  expected = payment.get_amount() + change;
 
       auto rex_pool = get_rex_pool();
@@ -5297,13 +5299,14 @@ BOOST_FIXTURE_TEST_CASE( rex_return, eosio_system_tester ) try {
       produce_block( fc::days(25) );
       BOOST_REQUIRE_EQUAL( success(),        rexexec( bob, 1 ) );
       rex_return_pool = get_rex_return_pool();
-      BOOST_REQUIRE_EQUAL( fee.get_amount(), rex_return_pool["current_rate_of_increase"].as<int64_t>() );
-      int64_t t2 = rex_return_pool["last_update_time"].as<time_point>().time_since_epoch().count();
-      change      = (eosio::chain::uint128_t(t2-t0) * fee.get_amount()) / (30 * 24 * 3600 * 1000000ll);
+      BOOST_REQUIRE_EQUAL( rate,             rex_return_pool["current_rate_of_increase"].as<int64_t>() );
+      BOOST_REQUIRE_EQUAL( 1,                get_rex_return_buckets()["return_buckets"].get_array().size() );
+      int64_t t2 = rex_return_pool["last_dist_time"].as<time_point_sec>().sec_since_epoch();
+      change      = rate * ((t2-t0) / dist_interval) + fee.get_amount() % total_intervals;
       expected    = payment.get_amount() + change;
 
       rex_pool = get_rex_pool();
-      BOOST_TEST_REQUIRE( within_one( expected,  rex_pool["total_lendable"].as<asset>().get_amount() ) );
+      BOOST_REQUIRE_EQUAL( expected,         rex_pool["total_lendable"].as<asset>().get_amount() );
 
       produce_blocks( 1 );
       produce_block( fc::days(5) );
@@ -5311,12 +5314,11 @@ BOOST_FIXTURE_TEST_CASE( rex_return, eosio_system_tester ) try {
 
       rex_return_pool = get_rex_return_pool();
       BOOST_REQUIRE_EQUAL( 0,                rex_return_pool["current_rate_of_increase"].as<int64_t>() );
-      BOOST_REQUIRE_EQUAL( 0,                rex_return_pool["return_buckets"].get_array().size() );
+      BOOST_REQUIRE_EQUAL( 0,                get_rex_return_buckets()["return_buckets"].get_array().size() );
 
       rex_pool = get_rex_pool();
       expected = payment.get_amount() + fee.get_amount();
-      BOOST_TEST_REQUIRE( within_error( expected, rex_pool["total_lendable"].as<asset>().get_amount(), 2 ) );
-      BOOST_TEST_REQUIRE( expected >= rex_pool["total_lendable"].as<asset>().get_amount() );
+      BOOST_REQUIRE_EQUAL( expected,         rex_pool["total_lendable"].as<asset>().get_amount() );
       BOOST_REQUIRE_EQUAL( rex_pool["total_lendable"].as<asset>(),
                            rex_pool["total_unlent"].as<asset>() );
    }
@@ -5328,38 +5330,39 @@ BOOST_FIXTURE_TEST_CASE( rex_return, eosio_system_tester ) try {
       const asset fee = core_sym::from_string("15.0000");
       BOOST_REQUIRE_EQUAL( success(),        rentcpu( bob, bob, fee ) );
       auto rex_return_pool = get_rex_return_pool();
-      int64_t t0 = rex_return_pool["last_update_time"].as<time_point>().time_since_epoch().count();
+      uint32_t t0 = rex_return_pool["last_dist_time"].as<time_point_sec>().sec_since_epoch();
       produce_block( fc::hours(1) );
       BOOST_REQUIRE_EQUAL( success(),        rentnet( bob, bob, fee ) );
       rex_return_pool = get_rex_return_pool();
       BOOST_REQUIRE_EQUAL( 0,                rex_return_pool["current_rate_of_increase"].as<int64_t>() );
-      BOOST_REQUIRE_EQUAL( 1,                rex_return_pool["return_buckets"].get_array().size() );
-      int64_t t1 = rex_return_pool["last_update_time"].as<time_point>().time_since_epoch().count();
-      BOOST_REQUIRE_EQUAL( t1,               t0 + 3600 * 1000000ll + 500000 );
+      BOOST_REQUIRE_EQUAL( 0,                get_rex_return_buckets()["return_buckets"].get_array().size() );
+      uint32_t t1 = rex_return_pool["last_dist_time"].as<time_point_sec>().sec_since_epoch();
+      BOOST_REQUIRE_EQUAL( t1,               t0 + 6 * dist_interval );
 
       produce_block( fc::hours(12) );
       BOOST_REQUIRE_EQUAL( success(),        rentnet( bob, bob, fee ) );
       rex_return_pool = get_rex_return_pool();
-      BOOST_REQUIRE_EQUAL( 2,                rex_return_pool["return_buckets"].get_array().size() );
-      BOOST_REQUIRE_EQUAL( 2 * fee.get_amount(), rex_return_pool["current_rate_of_increase"].as<int64_t>() );
+      BOOST_REQUIRE_EQUAL( 1,                get_rex_return_buckets()["return_buckets"].get_array().size() );
+      int64_t rate = 2 * fee.get_amount() / total_intervals;
+      BOOST_REQUIRE_EQUAL( rate,             rex_return_pool["current_rate_of_increase"].as<int64_t>() );
       produce_block( fc::hours(8) );
       BOOST_REQUIRE_EQUAL( success(),        rexexec( bob, 1 ) );
       rex_return_pool = get_rex_return_pool();
-      BOOST_REQUIRE_EQUAL( 2 * fee.get_amount(), rex_return_pool["current_rate_of_increase"].as<int64_t>() );
+      BOOST_REQUIRE_EQUAL( rate,             rex_return_pool["current_rate_of_increase"].as<int64_t>() );
 
       produce_block( fc::days(30) );
       BOOST_REQUIRE_EQUAL( success(),        rexexec( bob, 1 ) );
       rex_return_pool = get_rex_return_pool();
-      BOOST_REQUIRE_EQUAL( fee.get_amount(), rex_return_pool["current_rate_of_increase"].as<int64_t>() );
+      BOOST_REQUIRE_EQUAL( fee.get_amount() / total_intervals, rex_return_pool["current_rate_of_increase"].as<int64_t>() );
       BOOST_TEST_REQUIRE( (init_lendable + fee + fee).get_amount() < get_rex_pool()["total_lendable"].as<asset>().get_amount() );
 
       produce_block( fc::days(1) );
       BOOST_REQUIRE_EQUAL( success(),        rexexec( bob, 1 ) );
       rex_return_pool = get_rex_return_pool();
       BOOST_REQUIRE_EQUAL( 0,                rex_return_pool["current_rate_of_increase"].as<int64_t>() );
-      BOOST_REQUIRE_EQUAL( 0,                rex_return_pool["return_buckets"].get_array().size() );
-      BOOST_TEST_REQUIRE(  within_error( init_lendable.get_amount() + 3 * fee.get_amount(),
-                                         get_rex_pool()["total_lendable"].as<asset>().get_amount(), 3 ) );
+      BOOST_REQUIRE_EQUAL( 0,                get_rex_return_buckets()["return_buckets"].get_array().size() );
+      BOOST_REQUIRE_EQUAL( init_lendable.get_amount() + 3 * fee.get_amount(),
+                           get_rex_pool()["total_lendable"].as<asset>().get_amount() );
    }
 
    {
@@ -5369,24 +5372,42 @@ BOOST_FIXTURE_TEST_CASE( rex_return, eosio_system_tester ) try {
       BOOST_REQUIRE_EQUAL( success(),        rexexec( bob, 1 ) );
       auto rex_pool_0        = get_rex_pool();
       auto rex_return_pool_0 = get_rex_return_pool();
-      produce_block( fc::minutes(9) );
+      produce_block( fc::minutes(2) );
       BOOST_REQUIRE_EQUAL( success(),        rexexec( bob, 1 ) );
       auto rex_pool_1        = get_rex_pool();
       auto rex_return_pool_1 = get_rex_return_pool();
-      BOOST_REQUIRE_EQUAL( rex_return_pool_0["last_update_time"].as<time_point>().time_since_epoch().count(),
-                           rex_return_pool_1["last_update_time"].as<time_point>().time_since_epoch().count());
+      BOOST_REQUIRE_EQUAL( rex_return_pool_0["last_dist_time"].as<time_point_sec>().sec_since_epoch(),
+                           rex_return_pool_1["last_dist_time"].as<time_point_sec>().sec_since_epoch() );
       BOOST_REQUIRE_EQUAL( rex_pool_0["total_lendable"].as<asset>(),
-                           rex_pool_1["total_lendable"].as<asset>());
-      produce_block( fc::minutes(1) );
+                           rex_pool_1["total_lendable"].as<asset>() );
+      produce_block( fc::minutes(9) );
       BOOST_REQUIRE_EQUAL( success(),        rexexec( bob, 1 ) );
       auto rex_pool_2        = get_rex_pool();
       auto rex_return_pool_2 = get_rex_return_pool();
-      BOOST_TEST_REQUIRE( rex_return_pool_1["last_update_time"].as<time_point>().time_since_epoch().count() <
-                          rex_return_pool_2["last_update_time"].as<time_point>().time_since_epoch().count());
+      BOOST_TEST_REQUIRE( rex_return_pool_1["last_dist_time"].as<time_point_sec>().sec_since_epoch() <
+                          rex_return_pool_2["last_dist_time"].as<time_point_sec>().sec_since_epoch() );
       BOOST_TEST_REQUIRE( rex_pool_1["total_lendable"].as<asset>().get_amount() <
-                          rex_pool_2["total_lendable"].as<asset>().get_amount());
+                          rex_pool_2["total_lendable"].as<asset>().get_amount() );
+      produce_block( fc::days(31) );
+      produce_blocks( 1 );
+      BOOST_REQUIRE_EQUAL( success(),        rexexec( bob, 1 ) );
+      BOOST_REQUIRE_EQUAL( 0,                get_rex_return_buckets()["return_buckets"].get_array().size() );
+      BOOST_REQUIRE_EQUAL( 0,                get_rex_return_pool()["current_rate_of_increase"].as<int64_t>() );
    }
 
+   {
+      const asset fee = core_sym::from_string("30.0000");
+      for ( uint8_t i = 0; i < 5; ++i ) {
+         BOOST_REQUIRE_EQUAL( success(),        rentcpu( bob, bob, fee ) );
+         produce_block( fc::days(1) );
+      }
+      BOOST_REQUIRE_EQUAL( success(),        rexexec( bob, 1 ) );
+      BOOST_REQUIRE_EQUAL( 5,                get_rex_return_buckets()["return_buckets"].get_array().size() );
+      produce_block( fc::days(30) );
+      BOOST_REQUIRE_EQUAL( success(),        rexexec( bob, 1 ) );
+      BOOST_REQUIRE_EQUAL( 0,                get_rex_return_buckets()["return_buckets"].get_array().size() );
+   }
+   
 } FC_LOG_AND_RETHROW()
 
 

--- a/tests/eosio.system_tests.cpp
+++ b/tests/eosio.system_tests.cpp
@@ -4128,9 +4128,6 @@ BOOST_FIXTURE_TEST_CASE( buy_sell_claim_rex, eosio_system_tester ) try {
    BOOST_REQUIRE_EQUAL( success(), sellrex( alice, asset( 3 * get_rex_balance(alice).get_amount() / 4, symbol{SY(4,REX)} ) ) );
 
    BOOST_TEST_REQUIRE( within_one( init_alice_rex.get_amount() / 4, get_rex_balance(alice).get_amount() ) );
-   //   BOOST_TEST_REQUIRE( within_one( init_alice_rex_stake / 4,        get_rex_vote_stake( alice ).get_amount() ) );
-   //   BOOST_REQUIRE_EQUAL( init_alice_rex_stake / 4,        get_rex_vote_stake( alice ).get_amount() );
-   //   BOOST_TEST_REQUIRE( within_one( init_alice_rex_stake / 4,        get_voter_info(alice)["staked"].as<int64_t>() - init_stake ) );
 
    init_alice_rex = get_rex_balance(alice);
    BOOST_REQUIRE_EQUAL( success(), sellrex( bob,   get_rex_balance(bob) ) );

--- a/tests/eosio.system_tests.cpp
+++ b/tests/eosio.system_tests.cpp
@@ -3708,6 +3708,7 @@ BOOST_FIXTURE_TEST_CASE( rex_auth, eosio_system_tester ) try {
 
 } FC_LOG_AND_RETHROW()
 
+
 BOOST_FIXTURE_TEST_CASE( buy_sell_rex, eosio_system_tester ) try {
 
    const int64_t ratio        = 10000;
@@ -3945,19 +3946,27 @@ BOOST_FIXTURE_TEST_CASE( buy_rent_rex, eosio_system_tester ) try {
    BOOST_REQUIRE_EQUAL( ratio * init_tot_lendable.get_amount(), rex_pool["total_rex"].as<asset>().get_amount() );
    BOOST_REQUIRE_EQUAL( rex_pool["total_rex"].as<asset>(),      get_rex_balance(alice) );
 
+   BOOST_REQUIRE( get_rex_return_pool().is_null() );
+
    {
       // bob rents cpu for carol
       const asset fee = core_sym::from_string("17.0000");
       BOOST_REQUIRE_EQUAL( success(),          rentcpu( bob, carol, fee ) );
       BOOST_REQUIRE_EQUAL( init_balance - fee, get_rex_fund(bob) );
       rex_pool = get_rex_pool();
-      BOOST_REQUIRE_EQUAL( init_tot_lendable + fee, rex_pool["total_lendable"].as<asset>() ); // 65 + 17
+      BOOST_REQUIRE_EQUAL( init_tot_lendable,       rex_pool["total_lendable"].as<asset>() ); // 65
       BOOST_REQUIRE_EQUAL( init_tot_rent + fee,     rex_pool["total_rent"].as<asset>() );     // 100 + 17
       int64_t expected_total_lent = bancor_convert( init_tot_rent.get_amount(), init_tot_unlent.get_amount(), fee.get_amount() );
       BOOST_REQUIRE_EQUAL( expected_total_lent,
                            rex_pool["total_lent"].as<asset>().get_amount() );
       BOOST_REQUIRE_EQUAL( rex_pool["total_lent"].as<asset>() + rex_pool["total_unlent"].as<asset>(),
                            rex_pool["total_lendable"].as<asset>() );
+
+      auto rex_return_pool = get_rex_return_pool();
+      BOOST_REQUIRE( !rex_return_pool.is_null() );
+      BOOST_REQUIRE_EQUAL( 0, rex_return_pool["residue"].as<int64_t>() );
+      BOOST_REQUIRE_EQUAL( 0, rex_return_pool["current_rate_of_increase"].as<int64_t>() );
+
 
       // test that carol's resource limits have been updated properly
       BOOST_REQUIRE_EQUAL( expected_total_lent, get_cpu_limit( carol ) - init_cpu_limit );
@@ -3973,6 +3982,12 @@ BOOST_FIXTURE_TEST_CASE( buy_rent_rex, eosio_system_tester ) try {
       produce_block( fc::days(20) );
       BOOST_REQUIRE_EQUAL( success(), sellrex( alice, get_rex_balance(alice) ) );
       BOOST_REQUIRE_EQUAL( success(), cancelrexorder( alice ) );
+
+      rex_return_pool = get_rex_return_pool();
+      BOOST_REQUIRE( !rex_return_pool.is_null() );
+      BOOST_REQUIRE_EQUAL( 0, rex_return_pool["residue"].as<int64_t>() );
+      BOOST_REQUIRE_EQUAL( 0, rex_return_pool["current_rate_of_increase"].as<int64_t>() );
+
       produce_block( fc::days(10) );
       // alice is finally able to sellrex, she gains the fee paid by bob
       BOOST_REQUIRE_EQUAL( success(),          sellrex( alice, get_rex_balance(alice) ) );


### PR DESCRIPTION
<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->

## Change Description
<!-- Describe your changes, their justification, AND their impact. Reference issues or pull requests where possible (use '#XX' or 'GH-XX' where XX is the issue or pull request number). -->
The proceeds from CPU and network renting, RAM trading fees, and name bids are currently added immediately to the REX pool, thus instantly increasing the value of REX shares.
We change this pattern and channel the proceeds linearly with time over a period of 30 days. In order to achieve this in a CPU- and RAM-efficient way, we accumulate the proceeds accruing within 12-hour intervals into buckets. At the end of each interval, we start to channel the proceeds in the bucket to the REX pool linearly over 30 days. At the end of the 30 day period, the bucket is deleted. At any point in time, there can be up to a maximum of 60 buckets.

Another change is the `total_unlent` lower bound. It is changed from `20%` to `10%` of `total_lent`.

## Deployment Changes
- [ ] Deployment Changes
<!-- checked [x] = Deployment changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces a change to the contracts that causes deployment to change, please describe the impact. -->


## API Changes
- [ ] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions
- [ ] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
