### PR TITLE
Fix CMake warning due to no `project` specified in `tests/CMakeLists.txt`

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,5 +1,7 @@
 cmake_minimum_required( VERSION 3.5 )
 
+project(contract_tests)
+
 set(EOSIO_VERSION_MIN "2.0")
 set(EOSIO_VERSION_SOFT_MAX "2.0")
 #set(EOSIO_VERSION_HARD_MAX "")


### PR DESCRIPTION
Fixes verbose warning during compilation.

<hr>

Before:
![sc0](https://user-images.githubusercontent.com/35586806/70465384-d5087180-1a8e-11ea-93f1-1dfb96717be5.png)

After:
![sc1](https://user-images.githubusercontent.com/35586806/70465389-d9348f00-1a8e-11ea-9586-2861fd80ada6.png)
