### PR TITLE
rentbw additional changes

### DIFF
--- a/contracts/eosio.system/include/eosio.system/eosio.system.hpp
+++ b/contracts/eosio.system/include/eosio.system/eosio.system.hpp
@@ -486,21 +486,21 @@ namespace eosiosystem {
                                              //    current_weight_ratio == target_weight_ratio. Set this to 0 to preserve the
                                              //    existing setting.
       double         exponent;               // Exponent of resource price curve. Must be >= 1. Set this to 0 to preserve the
-                                             //    existing setting.
+                                             //    existing setting or use the default.
       uint32_t       decay_secs;             // Number of seconds for the gap between adjusted resource utilization and
                                              //    instantaneous utilization to shrink by 63%. Set this to 0 to preserve the
-                                             //    existing setting.
-      asset          target_price;           // Fee needed to rent the entire resource market weight. Set this to 0 to
-                                             //    preserve the existing setting.
+                                             //    existing setting or use the default.
+      asset          target_price;           // Fee needed to rent the entire resource market weight. Set the amount of this
+                                             //    asset to 0 to preserve the existing setting or use the default.
    };
 
    struct rentbw_config {
       rentbw_config_resource  net;              // NET market configuration
       rentbw_config_resource  cpu;              // CPU market configuration
       uint32_t                rent_days;        // `rentbw` `days` argument must match this. Set this to 0 to preserve the
-                                                //     existing setting.
-      asset                   min_rent_price;   // Rents below this amount are rejected. Set this to 0 to preserve the
-                                                //     existing setting.
+                                                //     existing setting or use the default.
+      asset                   min_rent_price;   // Rents below this amount are rejected. Set the amount of this asset to 0 to
+                                                //     preserve the existing setting or use the default.
    };
 
    struct rentbw_state_resource {

--- a/contracts/eosio.system/include/eosio.system/eosio.system.hpp
+++ b/contracts/eosio.system/include/eosio.system/eosio.system.hpp
@@ -540,9 +540,8 @@ namespace eosiosystem {
    };
 
    struct [[eosio::table("rent.state"),eosio::contract("eosio.system")]] rentbw_state {
-      static constexpr uint32_t default_rent_days      = 30 * seconds_per_day; // 30 day resource rentals
-      static constexpr int64_t  default_min_rent_price = 100ll;                // 0.0100 SYS
-                                                                               //   (assuming get_core_symbol() == symbol("SYS", 4))
+      static constexpr uint32_t default_rent_days      = 30;      // 30 day resource rentals
+      static constexpr int64_t  default_min_rent_price = 100ll;   // 0.0100 SYS (assuming get_core_symbol() == symbol("SYS", 4))
 
       uint8_t                 version        = 0;
       rentbw_state_resource   net            = {};                 // NET market state

--- a/contracts/eosio.system/include/eosio.system/eosio.system.hpp
+++ b/contracts/eosio.system/include/eosio.system/eosio.system.hpp
@@ -1270,7 +1270,7 @@ namespace eosiosystem {
          using setalimits_action = eosio::action_wrapper<"setalimits"_n, &system_contract::setalimits>;
          using setparams_action = eosio::action_wrapper<"setparams"_n, &system_contract::setparams>;
          using setinflation_action = eosio::action_wrapper<"setinflation"_n, &system_contract::setinflation>;
-         using configcpu_action = eosio::action_wrapper<"configrentbw"_n, &system_contract::configrentbw>;
+         using configrentbw_action = eosio::action_wrapper<"configrentbw"_n, &system_contract::configrentbw>;
          using rentbwexec_action = eosio::action_wrapper<"rentbwexec"_n, &system_contract::rentbwexec>;
          using rentbw_action = eosio::action_wrapper<"rentbw"_n, &system_contract::rentbw>;
 

--- a/contracts/eosio.system/include/eosio.system/eosio.system.hpp
+++ b/contracts/eosio.system/include/eosio.system/eosio.system.hpp
@@ -504,15 +504,16 @@ namespace eosiosystem {
    };
 
    struct rentbw_state_resource {
-      static constexpr double   default_exponent   = 2.0;                 // Exponent of 2.0 means that the price to rent a
-                                                                          //    tiny amount of resources increases linearly
-                                                                          //    with utilization.
-      static constexpr uint32_t default_decay_secs = 1 * seconds_per_day; // 1 day; if 100% of bandwidth resources are in a
-                                                                          //    single loan, then, assuming no further renting,
-                                                                          //    1 day after it expires the adjusted utilization
-                                                                          //    will be at approximately 37% and after 3 days the
-                                                                          //    adjusted utilization will be at least than 5%.
-
+      static constexpr double   default_exponent   = 2.0;                  // Exponent of 2.0 means that the price to rent a
+                                                                           //    tiny amount of resources increases linearly
+                                                                           //    with utilization.
+      static constexpr uint32_t default_decay_secs = 1 * seconds_per_day;  // 1 day; if 100% of bandwidth resources are in a
+                                                                           //    single loan, then, assuming no further renting,
+                                                                           //    1 day after it expires the adjusted utilization
+                                                                           //    will be at approximately 37% and after 3 days the
+                                                                           //    adjusted utilization will be at least than 5%.
+      static constexpr int64_t  default_target_price = 100'000'000'0000ll; // 100000000.0000 SYS
+                                                                           //   (assuming get_core_symbol() == symbol("SYS", 4));
 
       uint8_t        version                 = 0;
       int64_t        weight                  = 0;                  // resource market weight. calculated; varies over time.
@@ -539,7 +540,9 @@ namespace eosiosystem {
    };
 
    struct [[eosio::table("rent.state"),eosio::contract("eosio.system")]] rentbw_state {
-      static constexpr uint32_t default_rent_days  = 30 * seconds_per_day; // 30 day resource rentals
+      static constexpr uint32_t default_rent_days      = 30 * seconds_per_day; // 30 day resource rentals
+      static constexpr int64_t  default_min_rent_price = 100ll;                // 0.0100 SYS
+                                                                               //   (assuming get_core_symbol() == symbol("SYS", 4))
 
       uint8_t                 version        = 0;
       rentbw_state_resource   net            = {};                 // NET market state

--- a/contracts/eosio.system/include/eosio.system/eosio.system.hpp
+++ b/contracts/eosio.system/include/eosio.system/eosio.system.hpp
@@ -510,10 +510,10 @@ namespace eosiosystem {
       static constexpr uint32_t default_decay_secs = 1 * seconds_per_day;  // 1 day; if 100% of bandwidth resources are in a
                                                                            //    single loan, then, assuming no further renting,
                                                                            //    1 day after it expires the adjusted utilization
-                                                                           //    will be at approximately 37% and after 3 days the
-                                                                           //    adjusted utilization will be at least than 5%.
+                                                                           //    will be at approximately 37% and after 3 days
+                                                                           //    the adjusted utilization will be less than 5%.
       static constexpr int64_t  default_target_price = 100'000'000'0000ll; // 100000000.0000 SYS
-                                                                           //   (assuming get_core_symbol() == symbol("SYS", 4));
+                                                                           //   (assuming get_core_symbol() == symbol("SYS", 4))
 
       uint8_t        version                 = 0;
       int64_t        weight                  = 0;                  // resource market weight. calculated; varies over time.

--- a/contracts/eosio.system/src/rentbw.cpp
+++ b/contracts/eosio.system/src/rentbw.cpp
@@ -153,8 +153,12 @@ void system_contract::configrentbw(rentbw_config& args) {
          args.exponent = state.exponent;
       if (!args.decay_secs)
          args.decay_secs = state.decay_secs;
-      if (!args.target_price.amount && state.target_price.amount)
-         args.target_price = state.target_price;
+      if (!args.target_price.amount) {
+         if (state.target_price.amount)
+            args.target_price = state.target_price;
+         else
+            args.target_price.amount = rentbw_state_resource::default_target_price;
+      }
 
       if (args.current_weight_ratio == args.target_weight_ratio)
          args.target_timestamp = now;
@@ -186,8 +190,12 @@ void system_contract::configrentbw(rentbw_config& args) {
 
    if (!args.rent_days)
       args.rent_days = state.rent_days;
-   if (!args.min_rent_price.amount && state.min_rent_price.amount)
-      args.min_rent_price = state.min_rent_price;
+   if (!args.min_rent_price.amount) {
+      if (state.min_rent_price.amount)
+         args.min_rent_price = state.min_rent_price;
+      else
+         args.min_rent_price.amount = rentbw_state::default_min_rent_price;
+   }
 
    eosio::check(args.rent_days > 0, "rent_days must be > 0");
    eosio::check(args.min_rent_price.symbol == core_symbol, "min_rent_price doesn't match core symbol");

--- a/tests/eosio.rentbw_tests.cpp
+++ b/tests/eosio.rentbw_tests.cpp
@@ -231,8 +231,8 @@ BOOST_FIXTURE_TEST_CASE(config_tests, rentbw_tester) try {
    BOOST_REQUIRE_EQUAL(wasm_assert_msg("min_rent_price doesn't match core symbol"), configbw(make_config([&](auto& c) {
                           c.min_rent_price = asset::from_string("1000000.000 TST");
                        })));
-   BOOST_REQUIRE_EQUAL(wasm_assert_msg("min_rent_price must be positive"),
-                       configbw(make_config([&](auto& c) { c.min_rent_price = asset::from_string("0.0000 TST"); })));
+   //BOOST_REQUIRE_EQUAL(wasm_assert_msg("min_rent_price must be positive"),
+   //                    configbw(make_config([&](auto& c) { c.min_rent_price = asset::from_string("0.0000 TST"); }))); // needed only if min_rent_price does not have default
    BOOST_REQUIRE_EQUAL(wasm_assert_msg("min_rent_price must be positive"),
                        configbw(make_config([&](auto& c) { c.min_rent_price = asset::from_string("-1.0000 TST"); })));
 
@@ -260,8 +260,8 @@ BOOST_FIXTURE_TEST_CASE(config_tests, rentbw_tester) try {
    BOOST_REQUIRE_EQUAL(wasm_assert_msg("target_price doesn't match core symbol"), configbw(make_config([&](auto& c) {
                           c.net.target_price = asset::from_string("1000000.000 TST");
                        })));
-   BOOST_REQUIRE_EQUAL(wasm_assert_msg("target_price must be positive"),
-                       configbw(make_config([&](auto& c) { c.net.target_price = asset::from_string("0.0000 TST"); })));
+   //BOOST_REQUIRE_EQUAL(wasm_assert_msg("target_price must be positive"),
+   //                    configbw(make_config([&](auto& c) { c.net.target_price = asset::from_string("0.0000 TST"); }))); // needed only if target_price does not have default
    BOOST_REQUIRE_EQUAL(wasm_assert_msg("target_price must be positive"),
                        configbw(make_config([&](auto& c) { c.net.target_price = asset::from_string("-1.0000 TST"); })));
 
@@ -289,8 +289,8 @@ BOOST_FIXTURE_TEST_CASE(config_tests, rentbw_tester) try {
    BOOST_REQUIRE_EQUAL(wasm_assert_msg("target_price doesn't match core symbol"), configbw(make_config([&](auto& c) {
                           c.cpu.target_price = asset::from_string("1000000.000 TST");
                        })));
-   BOOST_REQUIRE_EQUAL(wasm_assert_msg("target_price must be positive"),
-                       configbw(make_config([&](auto& c) { c.cpu.target_price = asset::from_string("0.0000 TST"); })));
+   //BOOST_REQUIRE_EQUAL(wasm_assert_msg("target_price must be positive"),
+   //                    configbw(make_config([&](auto& c) { c.cpu.target_price = asset::from_string("0.0000 TST"); }))); // needed only if target_price does not have default
    BOOST_REQUIRE_EQUAL(wasm_assert_msg("target_price must be positive"),
                        configbw(make_config([&](auto& c) { c.cpu.target_price = asset::from_string("-1.0000 TST"); })));
 } // config_tests

--- a/tests/eosio.rentbw_tests.cpp
+++ b/tests/eosio.rentbw_tests.cpp
@@ -515,7 +515,7 @@ BOOST_AUTO_TEST_CASE(rent_tests) try {
             t.rentbw(N(bob111111111), N(alice1111111), 30, rentbw_frac, rentbw_frac + 1,
                      asset::from_string("1.0000 TST")));
       BOOST_REQUIRE_EQUAL(
-            t.wasm_assert_msg("calculated fee exceeds max_payment"), //
+            t.wasm_assert_msg("max_payment is less than calculated fee: 3000000.0000 TST"), //
             t.rentbw(N(bob111111111), N(alice1111111), 30, rentbw_frac, rentbw_frac, asset::from_string("1.0000 TST")));
       BOOST_REQUIRE_EQUAL(t.wasm_assert_msg("can't channel fees to rex"), //
                           t.rentbw(N(bob111111111), N(alice1111111), 30, rentbw_frac, rentbw_frac,
@@ -573,9 +573,9 @@ BOOST_AUTO_TEST_CASE(rent_tests) try {
       // (.35 ^ 2) * 1000000.0000 -  90000.0000 =  32500.0000
       // (.5  ^ 3) * 2000000.0000 - 128000.0000 = 122000.0000
       //                                  total = 154500.0000
-      t.transfer(config::system_account_name, N(aaaaaaaaaaaa), core_sym::from_string("154499.9999"));
+      t.transfer(config::system_account_name, N(aaaaaaaaaaaa), core_sym::from_string("154500.0000"));
       t.check_rentbw(N(aaaaaaaaaaaa), N(bbbbbbbbbbbb), 30, rentbw_frac * .05, rentbw_frac * .10,
-                     asset::from_string("154499.9999 TST"), net_weight * .05, cpu_weight * .10);
+                     asset::from_string("154500.0000 TST"), net_weight * .05, cpu_weight * .10);
    }
 
    {
@@ -650,9 +650,9 @@ BOOST_AUTO_TEST_CASE(rent_tests) try {
       // [((e^-2 + 1.0) ^ 2) - ((e^-2) ^ 2) ] * 1000000.0000 = 1270670.5664
       // [((e^-2 + 1.0) ^ 3) - ((e^-2) ^ 3) ] * 2000000.0000 = 2921905.5327
       //                                               total = 4192576.0991
-      t.transfer(config::system_account_name, N(aaaaaaaaaaaa), core_sym::from_string("4192561.0244"));
+      t.transfer(config::system_account_name, N(aaaaaaaaaaaa), core_sym::from_string("4192561.0246"));
       t.check_rentbw(N(aaaaaaaaaaaa), N(bbbbbbbbbbbb), 30, rentbw_frac, rentbw_frac,
-                     asset::from_string("4192561.0244 TST"), net_weight, cpu_weight);
+                     asset::from_string("4192561.0246 TST"), net_weight, cpu_weight);
    }
 
    {
@@ -673,9 +673,9 @@ BOOST_AUTO_TEST_CASE(rent_tests) try {
       // (.3 ^ 2) * 1000000.0000 - 10000.0000 =  80000.0000
       // (.4 ^ 3) * 2000000.0000 - 16000.0000 = 112000.0000
       //                                total = 192000.0000
-      t.transfer(config::system_account_name, N(aaaaaaaaaaaa), core_sym::from_string("191999.9999"));
+      t.transfer(config::system_account_name, N(aaaaaaaaaaaa), core_sym::from_string("192000.0001"));
       t.check_rentbw(N(aaaaaaaaaaaa), N(bbbbbbbbbbbb), 30, rentbw_frac * .2, rentbw_frac * .2,
-                     asset::from_string("191999.9999 TST"), net_weight * .2, cpu_weight * .2);
+                     asset::from_string("192000.0001 TST"), net_weight * .2, cpu_weight * .2);
 
       // Start decay
       t.produce_block(fc::days(15) - fc::milliseconds(1000));

--- a/tests/eosio.rentbw_tests.cpp
+++ b/tests/eosio.rentbw_tests.cpp
@@ -226,8 +226,8 @@ BOOST_FIXTURE_TEST_CASE(config_tests, rentbw_tester) try {
                        push_action(N(alice1111111), N(configrentbw), mvo()("args", make_config())));
    BOOST_REQUIRE_EQUAL(wasm_assert_msg("rentbw hasn't been initialized"), rentbwexec(N(alice1111111), 10));
 
-   BOOST_REQUIRE_EQUAL(wasm_assert_msg("rent_days must be > 0"),
-                       configbw(make_config([&](auto& c) { c.rent_days = 0; })));
+   //BOOST_REQUIRE_EQUAL(wasm_assert_msg("rent_days must be > 0"),
+   //                    configbw(make_config([&](auto& c) { c.rent_days = 0; }))); // needed only if rent_days does not have default
    BOOST_REQUIRE_EQUAL(wasm_assert_msg("min_rent_price doesn't match core symbol"), configbw(make_config([&](auto& c) {
                           c.min_rent_price = asset::from_string("1000000.000 TST");
                        })));
@@ -255,8 +255,8 @@ BOOST_FIXTURE_TEST_CASE(config_tests, rentbw_tester) try {
                        })));
    BOOST_REQUIRE_EQUAL(wasm_assert_msg("exponent must be >= 1"),
                        configbw(make_config([&](auto& c) { c.net.exponent = .999; })));
-   BOOST_REQUIRE_EQUAL(wasm_assert_msg("decay_secs must be >= 1"),
-                       configbw(make_config([&](auto& c) { c.net.decay_secs = 0; })));
+   //BOOST_REQUIRE_EQUAL(wasm_assert_msg("decay_secs must be >= 1"),
+   //                    configbw(make_config([&](auto& c) { c.net.decay_secs = 0; }))); // needed only if decay_secs does not have default
    BOOST_REQUIRE_EQUAL(wasm_assert_msg("target_price doesn't match core symbol"), configbw(make_config([&](auto& c) {
                           c.net.target_price = asset::from_string("1000000.000 TST");
                        })));
@@ -284,8 +284,8 @@ BOOST_FIXTURE_TEST_CASE(config_tests, rentbw_tester) try {
                        })));
    BOOST_REQUIRE_EQUAL(wasm_assert_msg("exponent must be >= 1"),
                        configbw(make_config([&](auto& c) { c.cpu.exponent = .999; })));
-   BOOST_REQUIRE_EQUAL(wasm_assert_msg("decay_secs must be >= 1"),
-                       configbw(make_config([&](auto& c) { c.cpu.decay_secs = 0; })));
+   //BOOST_REQUIRE_EQUAL(wasm_assert_msg("decay_secs must be >= 1"),
+   //                    configbw(make_config([&](auto& c) { c.cpu.decay_secs = 0; }))); // needed only if decay_secs does not have default
    BOOST_REQUIRE_EQUAL(wasm_assert_msg("target_price doesn't match core symbol"), configbw(make_config([&](auto& c) {
                           c.cpu.target_price = asset::from_string("1000000.000 TST");
                        })));


### PR DESCRIPTION
## Change Description

Changes:
   * More cleanup
   * Fix name of `configrentbw` action wrapper type.
   * Add defaults for `rent_days` (30 days), `decay_secs` (1 day), and `exponent` (2.0).
   * Also added defaults for `min_rent_price` and `target_price`. Assuming a core symbol of `symbol("SYS", 4)`, the default for `min_rent_price` would be `0.0100 SYS` and the default for `target_price` would be `100,000,000.0000 SYS`.
   * Include calculated rental fee in error message when `max_payment` is too low so that the user has an idea of how much the `max_payment` needs to be under current market conditions.
   * Change rounding used in fee calculation to not give an advantage to very small rentals under particular situations (but still under the condition of `utilization >= adjusted_utilization`).


## Deployment Changes
- [ ] Deployment Changes

## API Changes
- [ ] API Changes

## Documentation Additions
- [ ] Documentation Additions

