### PR TITLE
rentbw even more changes

### DIFF
--- a/contracts/eosio.system/include/eosio.system/eosio.system.hpp
+++ b/contracts/eosio.system/include/eosio.system/eosio.system.hpp
@@ -492,11 +492,15 @@ namespace eosiosystem {
                                                             //    utilization and instantaneous resource utilization to shrink
                                                             //    by 63%. Do not specify to preserve the existing setting or
                                                             //    use the default.
-      std::optional<asset>          target_price;           // Fee needed to rent the entire resource market weight. Do not
-                                                            //    specify to preserve the existing setting (no default exists).
+      std::optional<asset>          min_price;              // Fee needed to rent the entire resource market weight at the
+                                                            //    minimum price. Do not specify to preserve the existing
+                                                            //    setting or use the default.
+      std::optional<asset>          max_price;              // Fee needed to rent the entire resource market weight at the
+                                                            //    maximum price. Do not specify to preserve the existing
+                                                            //    setting (no default exists).
 
       EOSLIB_SERIALIZE( rentbw_config_resource, (current_weight_ratio)(target_weight_ratio)(assumed_stake_weight)
-                                                (target_timestamp)(exponent)(decay_secs)(target_price)            )
+                                                (target_timestamp)(exponent)(decay_secs)(min_price)(max_price)    )
    };
 
    struct rentbw_config {
@@ -536,7 +540,10 @@ namespace eosiosystem {
       double         exponent                = default_exponent;   // Exponent of resource price curve.
       uint32_t       decay_secs              = default_decay_secs; // Number of seconds for the gap between adjusted resource
                                                                    //    utilization and instantaneous utilization to shrink by 63%.
-      asset          target_price            = {};                 // Fee needed to rent the entire resource market weight.
+      asset          min_price               = {};                 // Fee needed to rent the entire resource market weight at
+                                                                   //    the minimum price (defaults to 0).
+      asset          max_price               = {};                 // Fee needed to rent the entire resource market weight at
+                                                                   //    the maximum price.
       int64_t        utilization             = 0;                  // Instantaneous resource utilization. This is the current
                                                                    //    amount sold. utilization <= weight.
       int64_t        adjusted_utilization    = 0;                  // Adjusted resource utilization. This is >= utilization and

--- a/contracts/eosio.system/include/eosio.system/eosio.system.hpp
+++ b/contracts/eosio.system/include/eosio.system/eosio.system.hpp
@@ -495,12 +495,12 @@ namespace eosiosystem {
    };
 
    struct rentbw_config {
-      rentbw_config_resource  net;              // NET market configuration
-      rentbw_config_resource  cpu;              // CPU market configuration
-      uint32_t                rent_days;        // `rentbw` `days` argument must match this. Set this to 0 to preserve the
-                                                //     existing setting or use the default.
-      asset                   min_rent_price;   // Rents below this amount are rejected. Set the amount of this asset to 0 to
-                                                //     preserve the existing setting.
+      rentbw_config_resource  net;           // NET market configuration
+      rentbw_config_resource  cpu;           // CPU market configuration
+      uint32_t                rent_days;     // `rentbw` `days` argument must match this. Set this to 0 to preserve the
+                                             //     existing setting or use the default.
+      asset                   min_rent_fee;  // Rental fees below this amount are rejected. Set the amount of this asset to 0
+                                             //     to preserve the existing setting.
    };
 
    struct rentbw_state_resource {
@@ -538,13 +538,13 @@ namespace eosiosystem {
    };
 
    struct [[eosio::table("rent.state"),eosio::contract("eosio.system")]] rentbw_state {
-      static constexpr uint32_t default_rent_days      = 30;      // 30 day resource rentals
+      static constexpr uint32_t default_rent_days = 30; // 30 day resource rentals
 
-      uint8_t                 version        = 0;
-      rentbw_state_resource   net            = {};                 // NET market state
-      rentbw_state_resource   cpu            = {};                 // CPU market state
-      uint32_t                rent_days      = default_rent_days;  // `rentbw` `days` argument must match this.
-      asset                   min_rent_price = {};                 // Rents below this amount are rejected
+      uint8_t                 version      = 0;
+      rentbw_state_resource   net          = {};                 // NET market state
+      rentbw_state_resource   cpu          = {};                 // CPU market state
+      uint32_t                rent_days    = default_rent_days;  // `rentbw` `days` argument must match this.
+      asset                   min_rent_fee = {};                 // Rental fees below this amount are rejected
 
       uint64_t primary_key()const { return 0; }
    };

--- a/contracts/eosio.system/include/eosio.system/eosio.system.hpp
+++ b/contracts/eosio.system/include/eosio.system/eosio.system.hpp
@@ -469,38 +469,45 @@ namespace eosiosystem {
    };
 
    struct rentbw_config_resource {
-      int64_t        current_weight_ratio;   // Immediately set weight_ratio to this amount. 1x = 10^15. 0.01x = 10^13. Set this
-                                             //    to 0 to preserve the existing setting or use the default; this avoids sudden
-                                             //    price jumps. For new chains which don't need to gradually phase out staking
-                                             //    and REX, 0.01x (10^13) is a good value for both current_weight_ratio and
-                                             //    target_weight_ratio.
-      int64_t        target_weight_ratio;    // Linearly shrink weight_ratio to this amount. 1x = 10^15. 0.01x = 10^13. Set this
-                                             //    to 0 to preserve the existing setting or use the default.
-      int64_t        assumed_stake_weight;   // Assumed stake weight for ratio calculations. Use the sum of total staked and
-                                             //    total rented by REX at the time the rentbw market is first activated. Set
-                                             //    this to 0 to preserve the existing setting; this avoids sudden price jumps.
-                                             //    For new chains which don't need to phase out staking and REX, 10^12 is
-                                             //    probably a good value.
-      time_point_sec target_timestamp;       // Stop automatic weight_ratio shrinkage at this time. Once this
-                                             //    time hits, weight_ratio will be target_weight_ratio. Ignored if
-                                             //    current_weight_ratio == target_weight_ratio. Set this to 0 to preserve the
-                                             //    existing setting.
-      double         exponent;               // Exponent of resource price curve. Must be >= 1. Set this to 0 to preserve the
-                                             //    existing setting or use the default.
-      uint32_t       decay_secs;             // Number of seconds for the gap between adjusted resource utilization and
-                                             //    instantaneous utilization to shrink by 63%. Set this to 0 to preserve the
-                                             //    existing setting or use the default.
-      asset          target_price;           // Fee needed to rent the entire resource market weight. Set the amount of this
-                                             //    asset to 0 to preserve the existing setting.
+      std::optional<int64_t>        current_weight_ratio;   // Immediately set weight_ratio to this amount. 1x = 10^15. 0.01x = 10^13.
+                                                            //    Do not specify to preserve the existing setting or use the default;
+                                                            //    this avoids sudden price jumps. For new chains which don't need
+                                                            //    to gradually phase out staking and REX, 0.01x (10^13) is a good
+                                                            //    value for both current_weight_ratio and target_weight_ratio.
+      std::optional<int64_t>        target_weight_ratio;    // Linearly shrink weight_ratio to this amount. 1x = 10^15. 0.01x = 10^13.
+                                                            //    Do not specify to preserve the existing setting or use the default.
+      std::optional<int64_t>        assumed_stake_weight;   // Assumed stake weight for ratio calculations. Use the sum of total
+                                                            //    staked and total rented by REX at the time the rentbw market
+                                                            //    is first activated. Do not specify to preserve the existing
+                                                            //    setting (no default exists); this avoids sudden price jumps.
+                                                            //    For new chains which don't need to phase out staking and REX,
+                                                            //    10^12 is probably a good value.
+      std::optional<time_point_sec> target_timestamp;       // Stop automatic weight_ratio shrinkage at this time. Once this
+                                                            //    time hits, weight_ratio will be target_weight_ratio. Ignored
+                                                            //    if current_weight_ratio == target_weight_ratio. Do not specify
+                                                            //    this to preserve the existing setting (no default exists).
+      std::optional<double>         exponent;               // Exponent of resource price curve. Must be >= 1. Do not specify
+                                                            //    to preserve the existing setting or use the default.
+      std::optional<uint32_t>       decay_secs;             // Number of seconds for the gap between adjusted resource
+                                                            //    utilization and instantaneous resource utilization to shrink
+                                                            //    by 63%. Do not specify to preserve the existing setting or
+                                                            //    use the default.
+      std::optional<asset>          target_price;           // Fee needed to rent the entire resource market weight. Do not
+                                                            //    specify to preserve the existing setting (no default exists).
+
+      EOSLIB_SERIALIZE( rentbw_config_resource, (current_weight_ratio)(target_weight_ratio)(assumed_stake_weight)
+                                                (target_timestamp)(exponent)(decay_secs)(target_price)            )
    };
 
    struct rentbw_config {
       rentbw_config_resource  net;           // NET market configuration
       rentbw_config_resource  cpu;           // CPU market configuration
-      uint32_t                rent_days;     // `rentbw` `days` argument must match this. Set this to 0 to preserve the
+      std::optional<uint32_t> rent_days;     // `rentbw` `days` argument must match this. Do not specify to preserve the
                                              //     existing setting or use the default.
-      asset                   min_rent_fee;  // Rental fees below this amount are rejected. Set the amount of this asset to 0
-                                             //     to preserve the existing setting.
+      std::optional<asset>    min_rent_fee;  // Rental fees below this amount are rejected. Do not specify to preserve the
+                                             //     existing setting (no default exists).
+
+      EOSLIB_SERIALIZE( rentbw_config, (net)(cpu)(rent_days)(min_rent_fee) )
    };
 
    struct rentbw_state_resource {

--- a/contracts/eosio.system/src/rentbw.cpp
+++ b/contracts/eosio.system/src/rentbw.cpp
@@ -186,15 +186,15 @@ void system_contract::configrentbw(rentbw_config& args) {
 
    if (!args.rent_days)
       args.rent_days = state.rent_days;
-   if (!args.min_rent_price.amount && state.min_rent_price.amount)
-      args.min_rent_price = state.min_rent_price;
+   if (!args.min_rent_fee.amount && state.min_rent_fee.amount)
+      args.min_rent_fee = state.min_rent_fee;
 
    eosio::check(args.rent_days > 0, "rent_days must be > 0");
-   eosio::check(args.min_rent_price.symbol == core_symbol, "min_rent_price doesn't match core symbol");
-   eosio::check(args.min_rent_price.amount > 0, "min_rent_price must be positive");
+   eosio::check(args.min_rent_fee.symbol == core_symbol, "min_rent_fee doesn't match core symbol");
+   eosio::check(args.min_rent_fee.amount > 0, "min_rent_fee must be positive");
 
-   state.rent_days      = args.rent_days;
-   state.min_rent_price = args.min_rent_price;
+   state.rent_days    = args.rent_days;
+   state.min_rent_fee = args.min_rent_fee;
 
    update(state.net, args.net);
    update(state.cpu, args.cpu);
@@ -320,7 +320,7 @@ void system_contract::rentbw(const name& payer, const name& receiver, uint32_t d
       error_msg += fee.to_string();
       eosio::check(false, error_msg);
    }
-   eosio::check(fee >= state.min_rent_price, "calculated fee is below minimum; try renting more");
+   eosio::check(fee >= state.min_rent_fee, "calculated fee is below minimum; try renting more");
 
    orders.emplace(payer, [&](auto& order) {
       order.id         = orders.available_primary_key();

--- a/contracts/eosio.system/src/rentbw.cpp
+++ b/contracts/eosio.system/src/rentbw.cpp
@@ -252,7 +252,6 @@ void system_contract::configrentbw(rentbw_config& args) {
 } // system_contract::configrentbw
 
 /**
- *  @pre 0 == state.min_price.amount (for now)
  *  @pre 0 <= state.min_price.amount <= state.max_price.amount
  *  @pre 0 < state.max_price.amount
  *  @pre 1.0 <= state.exponent

--- a/contracts/eosio.system/src/rentbw.cpp
+++ b/contracts/eosio.system/src/rentbw.cpp
@@ -176,9 +176,18 @@ void system_contract::configrentbw(rentbw_config& args) {
          *args.decay_secs = state.decay_secs;
       }
 
-      if (!args.target_price) {
-         eosio::check(!is_default_asset(state.target_price), "target_price does not have a default value");
-         *args.target_price = state.target_price;
+      if (!args.max_price) {
+         eosio::check(!is_default_asset(state.max_price), "max_price does not have a default value");
+         *args.max_price = state.max_price;
+      }
+
+      if (!args.min_price) {
+         if (is_default_asset(state.min_price)) {
+            *args.min_price = *args.max_price; // just to copy symbol of max_price
+            args.min_price->amount = 0;        // min_price has a default of zero.
+         } else {
+            *args.min_price = state.min_price;
+         }
       }
 
       eosio::check(*args.current_weight_ratio > 0, "current_weight_ratio is too small");
@@ -190,10 +199,16 @@ void system_contract::configrentbw(rentbw_config& args) {
       eosio::check(*args.assumed_stake_weight * int128_t(rentbw_frac) / *args.target_weight_ratio <=
                          std::numeric_limits<int64_t>::max(),
                    "assumed_stake_weight/target_weight_ratio is too large");
-      eosio::check(*args.exponent >= 1, "exponent must be >= 1");
+      eosio::check(*args.exponent >= 1.0, "exponent must be >= 1");
       eosio::check(*args.decay_secs >= 1, "decay_secs must be >= 1");
-      eosio::check(args.target_price->symbol == core_symbol, "target_price doesn't match core symbol");
-      eosio::check(args.target_price->amount > 0, "target_price must be positive");
+      eosio::check(args.max_price->symbol == core_symbol, "max_price doesn't match core symbol");
+      eosio::check(args.max_price->amount > 0, "max_price must be positive");
+      eosio::check(args.min_price->symbol == core_symbol, "min_price doesn't match core symbol");
+      eosio::check(args.min_price->amount >= 0, "min_price must be non-negative");
+      eosio::check(args.min_price->amount <= args.max_price->amount, "min_price cannot exceed max_price");
+      if (*args.exponent == 1.0) {
+         eosio::check(args.min_price->amount == args.max_price->amount, "min_price and max_price must be the same if the exponent is 1");
+      }
 
       state.assumed_stake_weight = *args.assumed_stake_weight;
       state.initial_weight_ratio = *args.current_weight_ratio;
@@ -202,7 +217,8 @@ void system_contract::configrentbw(rentbw_config& args) {
       state.target_timestamp     = *args.target_timestamp;
       state.exponent             = *args.exponent;
       state.decay_secs           = *args.decay_secs;
-      state.target_price         = *args.target_price;
+      state.min_price            = *args.min_price;
+      state.max_price            = *args.max_price;
    };
 
    if (!args.rent_days) {
@@ -236,7 +252,9 @@ void system_contract::configrentbw(rentbw_config& args) {
 } // system_contract::configrentbw
 
 /**
- *  @pre 0 < state.target_price.amount
+ *  @pre 0 == state.min_price.amount (for now)
+ *  @pre 0 <= state.min_price.amount <= state.max_price.amount
+ *  @pre 0 < state.max_price.amount
  *  @pre 1.0 <= state.exponent
  *  @pre 0 <= state.utilization <= state.adjusted_utilization <= state.weight
  *  @pre 0 <= utilization_increase <= (state.weight - state.utilization)
@@ -247,26 +265,36 @@ int64_t calc_rentbw_fee(const rentbw_state_resource& state, int64_t utilization_
    // Let p(u) = price as a function of the utilization fraction u which is defined for u in [0.0, 1.0].
    // Let f(u) = integral of the price function p(x) from x = 0.0 to x = u, again defined for u in [0.0, 1.0].
 
+   // In particular we choose f(u) = min_price * u + ((max_price - min_price) / exponent) * (u ^ exponent).
+   // And so p(u) = min_price + (max_price - min_price) * (u ^ (exponent - 1.0)).
+
    // Returns f(double(end_utilization)/state.weight) - f(double(start_utilization)/state.weight) which is equivalent to
    // the integral of p(x) from x = double(start_utilization)/state.weight to x = double(end_utilization)/state.weight.
    // @pre 0 <= start_utilization <= end_utilization <= state.weight
    auto price_integral_delta = [&state](int64_t start_utilization, int64_t end_utilization) -> double {
-      return state.target_price.amount * std::pow(double(end_utilization) / state.weight, state.exponent) -
-               state.target_price.amount * std::pow(double(start_utilization) / state.weight, state.exponent);
+      double coefficient = (state.max_price.amount - state.min_price.amount) / state.exponent;
+      double start_u     = double(start_utilization) / state.weight;
+      double end_u       = double(end_utilization) / state.weight;
+      return state.min_price.amount * end_u - state.min_price.amount * start_u +
+               coefficient * std::pow(end_u, state.exponent) - coefficient * std::pow(start_u, state.exponent);
    };
 
    // Returns p(double(utilization)/state.weight).
    // @pre 0 <= utilization <= state.weight
    auto price_function = [&state](int64_t utilization) -> double {
+      double price = state.min_price.amount;
       // state.exponent >= 1.0, therefore the exponent passed into std::pow is >= 0.0.
       // Since the exponent passed into std::pow could be 0.0 and simultaneously so could double(utilization)/state.weight,
       // the safest thing to do is handle that as a special case explicitly rather than relying on std::pow to return 1.0
       // instead of triggering a domain error.
       double new_exponent = state.exponent - 1.0;
-      if (new_exponent <= 0.0)
-         return state.target_price.amount;
-      else
-         return state.exponent * state.target_price.amount * std::pow(double(utilization) / state.weight, new_exponent);
+      if (new_exponent <= 0.0) {
+         return state.max_price.amount;
+      } else {
+         price += (state.max_price.amount - state.min_price.amount) * std::pow(double(utilization) / state.weight, new_exponent);
+      }
+
+      return price;
    };
 
    double  fee = 0.0;

--- a/tests/eosio.rentbw_tests.cpp
+++ b/tests/eosio.rentbw_tests.cpp
@@ -22,11 +22,12 @@ struct rentbw_config_resource {
    fc::optional<time_point_sec> target_timestamp     = {};
    fc::optional<double>         exponent             = {};
    fc::optional<uint32_t>       decay_secs           = {};
-   fc::optional<asset>          target_price         = {};
+   fc::optional<asset>          min_price            = {};
+   fc::optional<asset>          max_price            = {};
 };
 FC_REFLECT(rentbw_config_resource,                                                             //
            (current_weight_ratio)(target_weight_ratio)(assumed_stake_weight)(target_timestamp) //
-           (exponent)(decay_secs)(target_price))
+           (exponent)(decay_secs)(min_price)(max_price))
 
 struct rentbw_config {
    rentbw_config_resource net          = {};
@@ -47,14 +48,15 @@ struct rentbw_state_resource {
    time_point_sec target_timestamp;
    double         exponent;
    uint32_t       decay_secs;
-   asset          target_price;
+   asset          min_price;
+   asset          max_price;
    int64_t        utilization;
    int64_t        adjusted_utilization;
    time_point_sec utilization_timestamp;
 };
 FC_REFLECT(rentbw_state_resource,                                                                           //
            (version)(weight)(weight_ratio)(assumed_stake_weight)(initial_weight_ratio)(target_weight_ratio) //
-           (initial_timestamp)(target_timestamp)(exponent)(decay_secs)(target_price)(utilization)           //
+           (initial_timestamp)(target_timestamp)(exponent)(decay_secs)(min_price)(max_price)(utilization)   //
            (adjusted_utilization)(utilization_timestamp))
 
 struct rentbw_state {
@@ -99,7 +101,8 @@ struct rentbw_tester : eosio_system_tester {
       config.net.target_timestamp     = control->head_block_time() + fc::days(100);
       config.net.exponent             = 2;
       config.net.decay_secs           = fc::days(1).to_seconds();
-      config.net.target_price         = asset::from_string("1000000.0000 TST");
+      config.net.min_price            = asset::from_string("0.0000 TST");
+      config.net.max_price            = asset::from_string("1000000.0000 TST");
 
       config.cpu.current_weight_ratio = rentbw_frac;
       config.cpu.target_weight_ratio  = rentbw_frac / 100;
@@ -107,7 +110,8 @@ struct rentbw_tester : eosio_system_tester {
       config.cpu.target_timestamp     = control->head_block_time() + fc::days(100);
       config.cpu.exponent             = 2;
       config.cpu.decay_secs           = fc::days(1).to_seconds();
-      config.cpu.target_price         = asset::from_string("1000000.0000 TST");
+      config.cpu.min_price            = asset::from_string("0.0000 TST");
+      config.cpu.max_price            = asset::from_string("1000000.0000 TST");
 
       config.rent_days    = 30;
       config.min_rent_fee = asset::from_string("1.0000 TST");
@@ -142,7 +146,8 @@ struct rentbw_tester : eosio_system_tester {
                      ("target_timestamp",     optional_to_variant(c.target_timestamp))
                      ("exponent",             optional_to_variant(c.exponent))
                      ("decay_secs",           optional_to_variant(c.decay_secs))
-                     ("target_price",         optional_to_variant(c.target_price))
+                     ("min_price",            optional_to_variant(c.min_price))
+                     ("max_price",            optional_to_variant(c.max_price))
          ;
       };
 
@@ -291,15 +296,25 @@ BOOST_FIXTURE_TEST_CASE(config_tests, rentbw_tester) try {
                        configbw(make_config([&](auto& c) { c.net.exponent = .999; })));
    BOOST_REQUIRE_EQUAL(wasm_assert_msg("decay_secs must be >= 1"),
                        configbw(make_config([&](auto& c) { c.net.decay_secs = 0; })));
-   BOOST_REQUIRE_EQUAL(wasm_assert_msg("target_price does not have a default value"),
-                       configbw(make_config([&](auto& c) { c.net.target_price = {}; })));
-   BOOST_REQUIRE_EQUAL(wasm_assert_msg("target_price doesn't match core symbol"), configbw(make_config([&](auto& c) {
-                          c.net.target_price = asset::from_string("1000000.000 TST");
+   BOOST_REQUIRE_EQUAL(wasm_assert_msg("max_price does not have a default value"),
+                       configbw(make_config([&](auto& c) { c.net.max_price = {}; })));
+   BOOST_REQUIRE_EQUAL(wasm_assert_msg("max_price doesn't match core symbol"), configbw(make_config([&](auto& c) {
+                          c.net.max_price = asset::from_string("1000000.000 TST");
                        })));
-   BOOST_REQUIRE_EQUAL(wasm_assert_msg("target_price must be positive"),
-                       configbw(make_config([&](auto& c) { c.net.target_price = asset::from_string("0.0000 TST"); })));
-   BOOST_REQUIRE_EQUAL(wasm_assert_msg("target_price must be positive"),
-                       configbw(make_config([&](auto& c) { c.net.target_price = asset::from_string("-1.0000 TST"); })));
+   BOOST_REQUIRE_EQUAL(wasm_assert_msg("max_price must be positive"),
+                       configbw(make_config([&](auto& c) { c.net.max_price = asset::from_string("0.0000 TST"); })));
+   BOOST_REQUIRE_EQUAL(wasm_assert_msg("max_price must be positive"),
+                       configbw(make_config([&](auto& c) { c.net.max_price = asset::from_string("-1.0000 TST"); })));
+   BOOST_REQUIRE_EQUAL(wasm_assert_msg("min_price doesn't match core symbol"), configbw(make_config([&](auto& c) {
+                          c.net.min_price = asset::from_string("1000000.000 TST");
+                       })));
+   BOOST_REQUIRE_EQUAL(wasm_assert_msg("min_price must be non-negative"),
+                       configbw(make_config([&](auto& c) { c.net.min_price = asset::from_string("-1.0000 TST"); })));
+   BOOST_REQUIRE_EQUAL(wasm_assert_msg("min_price cannot exceed max_price"),
+                       configbw(make_config([&](auto& c) {
+                          c.net.min_price = asset::from_string("3.0000 TST");
+                          c.net.max_price = asset::from_string("2.0000 TST");
+                       })));
 
    // cpu assertions
    BOOST_REQUIRE_EQUAL(wasm_assert_msg("current_weight_ratio is too large"),
@@ -326,15 +341,25 @@ BOOST_FIXTURE_TEST_CASE(config_tests, rentbw_tester) try {
                        configbw(make_config([&](auto& c) { c.cpu.exponent = .999; })));
    BOOST_REQUIRE_EQUAL(wasm_assert_msg("decay_secs must be >= 1"),
                        configbw(make_config([&](auto& c) { c.cpu.decay_secs = 0; })));
-   BOOST_REQUIRE_EQUAL(wasm_assert_msg("target_price does not have a default value"),
-                       configbw(make_config([&](auto& c) { c.cpu.target_price = {}; })));
-   BOOST_REQUIRE_EQUAL(wasm_assert_msg("target_price doesn't match core symbol"), configbw(make_config([&](auto& c) {
-                          c.cpu.target_price = asset::from_string("1000000.000 TST");
+   BOOST_REQUIRE_EQUAL(wasm_assert_msg("max_price does not have a default value"),
+                       configbw(make_config([&](auto& c) { c.cpu.max_price = {}; })));
+   BOOST_REQUIRE_EQUAL(wasm_assert_msg("max_price doesn't match core symbol"), configbw(make_config([&](auto& c) {
+                          c.cpu.max_price = asset::from_string("1000000.000 TST");
                        })));
-   BOOST_REQUIRE_EQUAL(wasm_assert_msg("target_price must be positive"),
-                       configbw(make_config([&](auto& c) { c.cpu.target_price = asset::from_string("0.0000 TST"); })));
-   BOOST_REQUIRE_EQUAL(wasm_assert_msg("target_price must be positive"),
-                       configbw(make_config([&](auto& c) { c.cpu.target_price = asset::from_string("-1.0000 TST"); })));
+   BOOST_REQUIRE_EQUAL(wasm_assert_msg("max_price must be positive"),
+                       configbw(make_config([&](auto& c) { c.cpu.max_price = asset::from_string("0.0000 TST"); })));
+   BOOST_REQUIRE_EQUAL(wasm_assert_msg("max_price must be positive"),
+                       configbw(make_config([&](auto& c) { c.cpu.max_price = asset::from_string("-1.0000 TST"); })));
+   BOOST_REQUIRE_EQUAL(wasm_assert_msg("min_price doesn't match core symbol"), configbw(make_config([&](auto& c) {
+                          c.cpu.min_price = asset::from_string("1000000.000 TST");
+                       })));
+   BOOST_REQUIRE_EQUAL(wasm_assert_msg("min_price must be non-negative"),
+                       configbw(make_config([&](auto& c) { c.cpu.min_price = asset::from_string("-1.0000 TST"); })));
+   BOOST_REQUIRE_EQUAL(wasm_assert_msg("min_price cannot exceed max_price"),
+                       configbw(make_config([&](auto& c) {
+                          c.cpu.min_price = asset::from_string("3.0000 TST");
+                          c.cpu.max_price = asset::from_string("2.0000 TST");
+                       })));
 } // config_tests
 FC_LOG_AND_RETHROW()
 
@@ -479,13 +504,15 @@ BOOST_AUTO_TEST_CASE(rent_tests) try {
          config.net.target_weight_ratio  = rentbw_frac;
          config.net.assumed_stake_weight = stake_weight;
          config.net.exponent             = 1;
-         config.net.target_price         = asset::from_string("1000000.0000 TST");
+         config.net.min_price            = asset::from_string("1000000.0000 TST");
+         config.net.max_price            = asset::from_string("1000000.0000 TST");
 
          config.cpu.current_weight_ratio = rentbw_frac;
          config.cpu.target_weight_ratio  = rentbw_frac;
          config.cpu.assumed_stake_weight = stake_weight;
          config.cpu.exponent             = 1;
-         config.cpu.target_price         = asset::from_string("1000000.0000 TST");
+         config.cpu.min_price            = asset::from_string("1000000.0000 TST");
+         config.cpu.max_price            = asset::from_string("1000000.0000 TST");
 
          config.rent_days    = 30;
          config.min_rent_fee = asset::from_string("1.0000 TST");
@@ -500,6 +527,53 @@ BOOST_AUTO_TEST_CASE(rent_tests) try {
       BOOST_REQUIRE_EQUAL(
             t.wasm_assert_msg("market doesn't have resources available"), //
             t.rentbw(N(bob111111111), N(alice1111111), 30, rentbw_frac, 0, asset::from_string("1.0000 TST")));
+
+      BOOST_REQUIRE_EQUAL("", t.configbw(t.make_default_config([&](auto& config) {
+         // weight = stake_weight
+         config.net.current_weight_ratio = rentbw_frac/2;
+         config.net.target_weight_ratio  = rentbw_frac/2;
+
+         // weight = stake_weight
+         config.cpu.current_weight_ratio = rentbw_frac/2;
+         config.cpu.target_weight_ratio  = rentbw_frac/2;
+      })));
+
+      auto net_weight = stake_weight;
+      auto cpu_weight = stake_weight;
+
+      t.start_rex();
+      t.create_account_with_resources(N(aaaaaaaaaaaa), config::system_account_name, core_sym::from_string("1.0000"),
+                                      false, core_sym::from_string("500.0000"), core_sym::from_string("500.0000"));
+
+      // 10%, 20%
+      // (.1) * 1000000.0000 = 100000.0000
+      // (.2) * 1000000.0000 = 200000.0000
+      //               total = 300000.0000
+      t.transfer(config::system_account_name, N(aaaaaaaaaaaa), core_sym::from_string("300000.0000"));
+      t.check_rentbw(N(aaaaaaaaaaaa), N(aaaaaaaaaaaa), 30, rentbw_frac * .1, rentbw_frac * .2,
+                     asset::from_string("300000.0000 TST"), net_weight * .1, cpu_weight * .2);
+
+      // Start decay
+      t.produce_block(fc::days(30) - fc::milliseconds(500));
+      BOOST_REQUIRE_EQUAL("", t.rentbwexec(config::system_account_name, 10));
+      BOOST_REQUIRE(near(t.get_state().net.adjusted_utilization, .1 * net_weight, 0));
+      BOOST_REQUIRE(near(t.get_state().cpu.adjusted_utilization, .2 * cpu_weight, 0));
+
+      // 2 days of decay from (10%, 20%) to (1.35%, 2.71%)
+      t.produce_block(fc::days(2) - fc::milliseconds(500));
+      BOOST_REQUIRE_EQUAL("", t.rentbwexec(config::system_account_name, 10));
+      BOOST_REQUIRE(near(t.get_state().net.adjusted_utilization, int64_t(.1 * net_weight * exp(-2)),
+                         int64_t(.1 * net_weight * exp(-2)) / 1000));
+      BOOST_REQUIRE(near(t.get_state().cpu.adjusted_utilization, int64_t(.2 * cpu_weight * exp(-2)),
+                         int64_t(.2 * cpu_weight * exp(-2)) / 1000));
+
+      // 2%, 2%
+      // (0.0135 + 0.02 - 0.0135) * 1000000.0000 = 20000.0000
+      // (.02) * 1000000.0000                    = 20000.0000
+      //                                   total = 40000.0000
+      t.transfer(config::system_account_name, N(aaaaaaaaaaaa), core_sym::from_string("40000.0001"));
+      t.check_rentbw(N(aaaaaaaaaaaa), N(aaaaaaaaaaaa), 30, rentbw_frac * .02, rentbw_frac * .02,
+                     asset::from_string("40000.0001 TST"), net_weight * .02, cpu_weight * .02);
    }
 
    auto init = [](auto& t, bool rex) {
@@ -510,14 +584,14 @@ BOOST_AUTO_TEST_CASE(rent_tests) try {
          config.net.target_weight_ratio  = rentbw_frac / 4;
          config.net.assumed_stake_weight = stake_weight;
          config.net.exponent             = 2;
-         config.net.target_price         = asset::from_string("1000000.0000 TST");
+         config.net.max_price            = asset::from_string("2000000.0000 TST");
 
          // weight = stake_weight * 4 / 2
          config.cpu.current_weight_ratio = rentbw_frac / 5;
          config.cpu.target_weight_ratio  = rentbw_frac / 5;
          config.cpu.assumed_stake_weight = stake_weight / 2;
          config.cpu.exponent             = 3;
-         config.cpu.target_price         = asset::from_string("2000000.0000 TST");
+         config.cpu.max_price            = asset::from_string("6000000.0000 TST");
 
          config.rent_days    = 30;
          config.min_rent_fee = asset::from_string("1.0000 TST");
@@ -605,19 +679,55 @@ BOOST_AUTO_TEST_CASE(rent_tests) try {
    {
       rentbw_tester t;
       init(t, true);
-      // (.3 ^ 2) * 1000000.0000 =  90000.0000
-      // (.4 ^ 3) * 2000000.0000 = 128000.0000
-      //                   total = 218000.0000
+      // (.3 ^ 2) * 2000000.0000 / 2 =  90000.0000
+      // (.4 ^ 3) * 6000000.0000 / 3 = 128000.0000
+      //                       total = 218000.0000
       t.transfer(config::system_account_name, N(aaaaaaaaaaaa), core_sym::from_string("218000.0001"));
       t.check_rentbw(N(aaaaaaaaaaaa), N(bbbbbbbbbbbb), 30, rentbw_frac * .3, rentbw_frac * .4,
                      asset::from_string("218000.0001 TST"), net_weight * .3, cpu_weight * .4);
 
-      // (.35 ^ 2) * 1000000.0000 -  90000.0000 =  32500.0000
-      // (.5  ^ 3) * 2000000.0000 - 128000.0000 = 122000.0000
-      //                                  total = 154500.0000
+      // (.35 ^ 2) * 2000000.0000 / 2 -  90000.0000 =  32500.0000
+      // (.5  ^ 3) * 6000000.0000 / 3 - 128000.0000 = 122000.0000
+      //                                      total = 154500.0000
       t.transfer(config::system_account_name, N(aaaaaaaaaaaa), core_sym::from_string("154500.0000"));
       t.check_rentbw(N(aaaaaaaaaaaa), N(bbbbbbbbbbbb), 30, rentbw_frac * .05, rentbw_frac * .10,
                      asset::from_string("154500.0000 TST"), net_weight * .05, cpu_weight * .10);
+   }
+
+   // net:50%, cpu:50% (but with non-zero min_price and also an exponent of 2 to simplify the math)
+   {
+      rentbw_tester t;
+      init(t, true);
+      BOOST_REQUIRE_EQUAL("", t.configbw(t.make_default_config([&](auto& config) {
+         config.cpu.exponent             = 2;
+         config.net.min_price            = asset::from_string("1200000.0000 TST");
+         config.net.max_price            = asset::from_string("2000000.0000 TST");
+
+         config.cpu.exponent             = 2;
+         config.cpu.min_price            = asset::from_string("4000000.0000 TST");
+         config.cpu.max_price            = asset::from_string("6000000.0000 TST");
+      })));
+
+      // At 0% utilization for both NET and CPU, the cost (in TST) for renting an infinitesimal amount of resources (dr) is
+      //    1200000.0000 * dr for NET and 4000000.0000 * dr for CPU.
+      // At 50% utilization for both NET and CPU, the cost (in TST for renting an infinitesimal amount of resources (dr) is
+      //    1600000.0000 * dr for NET and 5000000.0000 * dr for CPU.
+
+      // The fee for renting 50% of NET (starting from 0% utilization) is expected to be somewhere between
+      //    1200000.0000 * 0.5 (= 600000.0000) and 1600000.0000 * 0.5 (= 800000.0000).
+      //    In fact, the cost ends up being 700000.0000.
+
+      // The fee for renting 50% of CPU (starting from 0% utilization) is expected to be somewhere between
+      //    4000000.0000 * 0.5 (= 2000000.0000) and 5000000.0000 * 0.5 (= 2500000.0000).
+      //    In fact, the cost ends up being 2250000.0000.
+
+
+      // 1200000.0000 * .5 +  (800000.0000 / 2) * (.5 ^ 2) =  700000.0000
+      // 4000000.0000 * .5 + (2000000.0000 / 2) * (.5 ^ 2) = 2250000.0000
+      //                                             total = 2950000.0000
+      t.transfer(config::system_account_name, N(aaaaaaaaaaaa), core_sym::from_string("2950000.0000"));
+      t.check_rentbw(N(aaaaaaaaaaaa), N(bbbbbbbbbbbb), 30, rentbw_frac * .5, rentbw_frac * .5,
+                     asset::from_string("2950000.0000 TST"), net_weight * .5, cpu_weight * .5);
    }
 
    {
@@ -644,9 +754,9 @@ BOOST_AUTO_TEST_CASE(rent_tests) try {
 
       // immediate renewal: adjusted_utilization doesn't have time to fall
       //
-      // 2 * (1.0 ^ 1) * 1000000.0000 = 2000000.0000
-      // 3 * (1.0 ^ 2) * 2000000.0000 = 6000000.0000
-      //                        total = 8000000.0000
+      // (1.0 ^ 1) * 2000000.0000 = 2000000.0000
+      // (1.0 ^ 2) * 6000000.0000 = 6000000.0000
+      //                    total = 8000000.0000
       t.transfer(config::system_account_name, N(aaaaaaaaaaaa), core_sym::from_string("8000000.0000"));
       t.check_rentbw(N(aaaaaaaaaaaa), N(bbbbbbbbbbbb), 30, rentbw_frac, rentbw_frac,
                      asset::from_string("8000000.0000 TST"), 0, 0);
@@ -689,9 +799,9 @@ BOOST_AUTO_TEST_CASE(rent_tests) try {
 
       // 100% after 2 days of decay
       //
-      // [ [2 * ((e^-2) ^ 1)]*(e^-2 - 0.0) + ((1.0) ^ 2) - ((e^-2) ^ 2) ] * 1000000.0000 = 1018315.6389
-      // [ [3 * ((e^-2) ^ 2)]*(e^-2 - 0.0) + ((1.0) ^ 3) - ((e^-2) ^ 3) ] * 2000000.0000 = 2009915.0087
-      //                                                                           total = 3028230.6476
+      // [ ((e^-2) ^ 1)*(e^-2 - 0.0) + ((1.0) ^ 2)/2 - ((e^-2) ^ 2)/2 ] * 2000000.0000 = 1018315.6389
+      // [ ((e^-2) ^ 2)*(e^-2 - 0.0) + ((1.0) ^ 3)/3 - ((e^-2) ^ 3)/3 ] * 6000000.0000 = 2009915.0087
+      //                                                                         total = 3028230.6476
       t.transfer(config::system_account_name, N(aaaaaaaaaaaa), core_sym::from_string("3028229.8795"));
       t.check_rentbw(N(aaaaaaaaaaaa), N(bbbbbbbbbbbb), 30, rentbw_frac, rentbw_frac,
                      asset::from_string("3028229.8795 TST"), net_weight, cpu_weight);
@@ -702,9 +812,9 @@ BOOST_AUTO_TEST_CASE(rent_tests) try {
       init(t, true);
 
       // 10%, 20%
-      // (.1 ^ 2) * 1000000.0000 = 10000.0000
-      // (.2 ^ 3) * 2000000.0000 = 16000.0000
-      //                   total = 26000.0000
+      // (.1 ^ 2) * 2000000.0000 / 2 = 10000.0000
+      // (.2 ^ 3) * 6000000.0000 / 3 = 16000.0000
+      //                       total = 26000.0000
       t.transfer(config::system_account_name, N(aaaaaaaaaaaa), core_sym::from_string("26000.0002"));
       t.check_rentbw(N(aaaaaaaaaaaa), N(bbbbbbbbbbbb), 30, rentbw_frac * .1, rentbw_frac * .2,
                      asset::from_string("26000.0002 TST"), net_weight * .1, cpu_weight * .2);
@@ -712,16 +822,15 @@ BOOST_AUTO_TEST_CASE(rent_tests) try {
       t.produce_block(fc::days(15) - fc::milliseconds(500));
 
       // 20%, 20%
-      // (.3 ^ 2) * 1000000.0000 - 10000.0000 =  80000.0000
-      // (.4 ^ 3) * 2000000.0000 - 16000.0000 = 112000.0000
-      //                                total = 192000.0000
+      // (.3 ^ 2) * 2000000.0000 / 2 - 10000.0000 =  80000.0000
+      // (.4 ^ 3) * 6000000.0000 / 3 - 16000.0000 = 112000.0000
+      //                                    total = 192000.0000
       t.transfer(config::system_account_name, N(aaaaaaaaaaaa), core_sym::from_string("192000.0001"));
       t.check_rentbw(N(aaaaaaaaaaaa), N(bbbbbbbbbbbb), 30, rentbw_frac * .2, rentbw_frac * .2,
                      asset::from_string("192000.0001 TST"), net_weight * .2, cpu_weight * .2);
 
       // Start decay
       t.produce_block(fc::days(15) - fc::milliseconds(1000));
-      BOOST_REQUIRE_EQUAL("", t.rentbwexec(config::system_account_name, 10));
       BOOST_REQUIRE_EQUAL("", t.rentbwexec(config::system_account_name, 10));
       BOOST_REQUIRE(near(t.get_state().net.adjusted_utilization, .3 * net_weight, 0));
       BOOST_REQUIRE(near(t.get_state().cpu.adjusted_utilization, .4 * cpu_weight, 0));

--- a/tests/eosio.rentbw_tests.cpp
+++ b/tests/eosio.rentbw_tests.cpp
@@ -602,12 +602,12 @@ BOOST_AUTO_TEST_CASE(rent_tests) try {
 
       // immediate renewal: adjusted_utilization doesn't have time to fall
       //
-      // (2.0 ^ 2) * 1000000.0000 - 1000000.0000 =  3000000.0000
-      // (2.0 ^ 3) * 2000000.0000 - 2000000.0000 = 14000000.0000
-      //                                   total = 17000000.0000
-      t.transfer(config::system_account_name, N(aaaaaaaaaaaa), core_sym::from_string("17000000.0000"));
+      // 2 * (1.0 ^ 1) * 1000000.0000 = 2000000.0000
+      // 3 * (1.0 ^ 2) * 2000000.0000 = 6000000.0000
+      //                        total = 8000000.0000
+      t.transfer(config::system_account_name, N(aaaaaaaaaaaa), core_sym::from_string("8000000.0000"));
       t.check_rentbw(N(aaaaaaaaaaaa), N(bbbbbbbbbbbb), 30, rentbw_frac, rentbw_frac,
-                     asset::from_string("17000000.0000 TST"), 0, 0);
+                     asset::from_string("8000000.0000 TST"), 0, 0);
 
       // No more available for 30 days
       BOOST_REQUIRE_EQUAL(t.wasm_assert_msg("market doesn't have enough resources available"), //
@@ -647,12 +647,12 @@ BOOST_AUTO_TEST_CASE(rent_tests) try {
 
       // 100% after 2 days of decay
       //
-      // [((e^-2 + 1.0) ^ 2) - ((e^-2) ^ 2) ] * 1000000.0000 = 1270670.5664
-      // [((e^-2 + 1.0) ^ 3) - ((e^-2) ^ 3) ] * 2000000.0000 = 2921905.5327
-      //                                               total = 4192576.0991
-      t.transfer(config::system_account_name, N(aaaaaaaaaaaa), core_sym::from_string("4192561.0246"));
+      // [ [2 * ((e^-2) ^ 1)]*(e^-2 - 0.0) + ((1.0) ^ 2) - ((e^-2) ^ 2) ] * 1000000.0000 = 1018315.6389
+      // [ [3 * ((e^-2) ^ 2)]*(e^-2 - 0.0) + ((1.0) ^ 3) - ((e^-2) ^ 3) ] * 2000000.0000 = 2009915.0087
+      //                                                                           total = 3028230.6476
+      t.transfer(config::system_account_name, N(aaaaaaaaaaaa), core_sym::from_string("3028229.8795"));
       t.check_rentbw(N(aaaaaaaaaaaa), N(bbbbbbbbbbbb), 30, rentbw_frac, rentbw_frac,
-                     asset::from_string("4192561.0246 TST"), net_weight, cpu_weight);
+                     asset::from_string("3028229.8795 TST"), net_weight, cpu_weight);
    }
 
    {

--- a/tests/eosio.rentbw_tests.cpp
+++ b/tests/eosio.rentbw_tests.cpp
@@ -29,12 +29,12 @@ FC_REFLECT(rentbw_config_resource,                                              
            (exponent)(decay_secs)(target_price))
 
 struct rentbw_config {
-   rentbw_config_resource net            = {};
-   rentbw_config_resource cpu            = {};
-   uint32_t               rent_days      = {};
-   asset                  min_rent_price = asset{};
+   rentbw_config_resource net          = {};
+   rentbw_config_resource cpu          = {};
+   uint32_t               rent_days    = {};
+   asset                  min_rent_fee = asset{};
 };
-FC_REFLECT(rentbw_config, (net)(cpu)(rent_days)(min_rent_price))
+FC_REFLECT(rentbw_config, (net)(cpu)(rent_days)(min_rent_fee))
 
 struct rentbw_state_resource {
    uint8_t        version;
@@ -62,9 +62,9 @@ struct rentbw_state {
    rentbw_state_resource net;
    rentbw_state_resource cpu;
    uint32_t              rent_days;
-   asset                 min_rent_price;
+   asset                 min_rent_fee;
 };
-FC_REFLECT(rentbw_state, (version)(net)(cpu)(rent_days)(min_rent_price))
+FC_REFLECT(rentbw_state, (version)(net)(cpu)(rent_days)(min_rent_fee))
 
 using namespace eosio_system;
 
@@ -109,8 +109,8 @@ struct rentbw_tester : eosio_system_tester {
       config.cpu.decay_secs           = fc::days(1).to_seconds();
       config.cpu.target_price         = asset::from_string("1000000.0000 TST");
 
-      config.rent_days      = 30;
-      config.min_rent_price = asset::from_string("1.0000 TST");
+      config.rent_days    = 30;
+      config.min_rent_fee = asset::from_string("1.0000 TST");
 
       f(config);
       return config;
@@ -228,13 +228,13 @@ BOOST_FIXTURE_TEST_CASE(config_tests, rentbw_tester) try {
 
    //BOOST_REQUIRE_EQUAL(wasm_assert_msg("rent_days must be > 0"),
    //                    configbw(make_config([&](auto& c) { c.rent_days = 0; }))); // needed only if rent_days does not have default
-   BOOST_REQUIRE_EQUAL(wasm_assert_msg("min_rent_price doesn't match core symbol"), configbw(make_config([&](auto& c) {
-                          c.min_rent_price = asset::from_string("1000000.000 TST");
+   BOOST_REQUIRE_EQUAL(wasm_assert_msg("min_rent_fee doesn't match core symbol"), configbw(make_config([&](auto& c) {
+                          c.min_rent_fee = asset::from_string("1000000.000 TST");
                        })));
-   BOOST_REQUIRE_EQUAL(wasm_assert_msg("min_rent_price must be positive"),
-                       configbw(make_config([&](auto& c) { c.min_rent_price = asset::from_string("0.0000 TST"); })));
-   BOOST_REQUIRE_EQUAL(wasm_assert_msg("min_rent_price must be positive"),
-                       configbw(make_config([&](auto& c) { c.min_rent_price = asset::from_string("-1.0000 TST"); })));
+   BOOST_REQUIRE_EQUAL(wasm_assert_msg("min_rent_fee must be positive"),
+                       configbw(make_config([&](auto& c) { c.min_rent_fee = asset::from_string("0.0000 TST"); })));
+   BOOST_REQUIRE_EQUAL(wasm_assert_msg("min_rent_fee must be positive"),
+                       configbw(make_config([&](auto& c) { c.min_rent_fee = asset::from_string("-1.0000 TST"); })));
 
    // net assertions
    BOOST_REQUIRE_EQUAL(wasm_assert_msg("current_weight_ratio is too large"),
@@ -445,8 +445,8 @@ BOOST_AUTO_TEST_CASE(rent_tests) try {
          config.cpu.exponent             = 1;
          config.cpu.target_price         = asset::from_string("1000000.0000 TST");
 
-         config.rent_days      = 30;
-         config.min_rent_price = asset::from_string("1.0000 TST");
+         config.rent_days    = 30;
+         config.min_rent_fee = asset::from_string("1.0000 TST");
       })));
 
       BOOST_REQUIRE_EQUAL(
@@ -477,8 +477,8 @@ BOOST_AUTO_TEST_CASE(rent_tests) try {
          config.cpu.exponent             = 3;
          config.cpu.target_price         = asset::from_string("2000000.0000 TST");
 
-         config.rent_days      = 30;
-         config.min_rent_price = asset::from_string("1.0000 TST");
+         config.rent_days    = 30;
+         config.min_rent_fee = asset::from_string("1.0000 TST");
       })));
 
       if (rex)


### PR DESCRIPTION
## Change Description

Changes:
   * Rename `min_rent_price` to `min_rent_fee` which is a more accurate name.
   * Use optionals rather than 0 for config parameters to signal that it should preserve the existing value (or use default when appropriate).
   * Modify fee calculation to not give advantage to very small rentals even under the scenario of `utilization <= adjusted_utilization`.
   * Add a `min_price` so that the market can be configured to prevent early renters from getting too cheap of a price (defaults to 0).
   * Replace `target_price` with the more meaningful `max_price` which also complements `min_price` well. Note: Assuming `min_price` is 0, this modified price model can be directly compared to the prior one. In fact, under that condition, `max_price` can be thought of as `target_price * exponent`.

## Deployment Changes
- [ ] Deployment Changes

## API Changes
- [ ] API Changes

## Documentation Additions
- [ ] Documentation Additions

