### PR TITLE
[develop] Wait for CDT binary.

### DIFF
--- a/.cicd/build.sh
+++ b/.cicd/build.sh
@@ -15,10 +15,21 @@ else
     export DOCKER_IMAGE
 fi
 ARGS=${ARGS:-"--rm -v $(pwd):$MOUNTED_DIR"}
-CDT_COMMANDS="apt-get install -y wget && wget -q $CDT_URL -O eosio.cdt.deb && dpkg -i eosio.cdt.deb && export PATH=/usr/opt/eosio.cdt/\\\$(ls /usr/opt/eosio.cdt/)/bin:\\\$PATH"
+CDT_COMMANDS="dpkg -i $MOUNTED_DIR/eosio.cdt.deb && export PATH=/usr/opt/eosio.cdt/\\\$(ls /usr/opt/eosio.cdt/)/bin:\\\$PATH"
 PRE_COMMANDS="$CDT_COMMANDS && cd $MOUNTED_DIR/build"
 BUILD_COMMANDS="cmake -DBUILD_TESTS=true .. && make -j $JOBS"
 COMMANDS="$PRE_COMMANDS && $BUILD_COMMANDS"
+# Test CDT binary download to prevent failures due to eosio.cdt pipeline.
+INDEX='1'
+echo "$ curl -sSf $CDT_URL --output eosio.cdt.deb"
+while ! $(curl -sSf $CDT_URL --output eosio.cdt.deb); do
+    echo "ERROR: Expected CDT binary for commit ${CDT_COMMIT:0:7} from $CDT_VERSION. It does not exist at $CDT_URL!"
+    printf "There must be a successful build against ${CDT_COMMIT:0:7} \033]1339;url=https://buildkite.com/EOSIO/eosio-dot-cdt/builds?commit=$CDT_COMMIT;content=here\a for this package to exist.\n"
+    echo "Attempt $INDEX, retry in 60 seconds..."
+    echo ''
+    INDEX=$(( $INDEX + 1 ))
+    sleep 60
+done
 # retry docker pull to protect against failures due to race conditions with eosio pipeline
 INDEX='1'
 echo "$ docker pull $DOCKER_IMAGE"

--- a/.cicd/pipeline.yml
+++ b/.cicd/pipeline.yml
@@ -8,7 +8,7 @@ steps:
       buildkite-agent artifact upload build.tar.gz
     agents:
       queue: "automation-eks-eos-builder-fleet"
-    timeout: "${TIMEOUT:-40}"
+    timeout: "${TIMEOUT:-60}"
     skip: "$SKIP_UBUNTU_18"
 
   - wait

--- a/.cicd/test.sh
+++ b/.cicd/test.sh
@@ -9,10 +9,11 @@ if [[ "$BUILDKITE" == 'true' ]]; then
     DOCKER_IMAGE="$(buildkite-agent meta-data get docker-image)"
 fi
 ARGS=${ARGS:-"--rm -v $(pwd):$MOUNTED_DIR"}
-CDT_COMMANDS="apt-get install -y wget && wget -q $CDT_URL -O eosio.cdt.deb && dpkg -i eosio.cdt.deb && export PATH=/usr/opt/eosio.cdt/$CDT_VERSION/bin:\\\$PATH"
+CDT_COMMANDS="dpkg -i $MOUNTED_DIR/eosio.cdt.deb && export PATH=/usr/opt/eosio.cdt/$CDT_VERSION/bin:\\\$PATH"
 PRE_COMMANDS="$CDT_COMMANDS && cd $MOUNTED_DIR/build/tests"
 TEST_COMMANDS="ctest -j $JOBS --output-on-failure -T Test"
 COMMANDS="$PRE_COMMANDS && $TEST_COMMANDS"
+curl -sSf $CDT_URL --output eosio.cdt.deb
 set +e
 eval docker run $ARGS $(buildkite-intrinsics) $DOCKER_IMAGE bash -c \"$COMMANDS\"
 EXIT_STATUS=$?

--- a/pipeline.jsonc
+++ b/pipeline.jsonc
@@ -5,7 +5,7 @@
         "dependencies": // dependencies to pull for a build of contracts, by branch, tag, or commit hash
         {
             "eosio": "329071ae8ae7c8e467f42079ebdb09e675d7e702", // eventually update to release/2.0.x
-            "eosio.cdt": "d1f5dd4dcf28c73f222d4d2b6883d61a5084216a" // eventually update to release/1.7.x
+            "eosio.cdt": "aad0c4729b848c9cbe409aa1fdd917797a4d91e7" // eventually update to release/1.7.x
         }
     }
 }

--- a/pipeline.jsonc
+++ b/pipeline.jsonc
@@ -5,7 +5,7 @@
         "dependencies": // dependencies to pull for a build of contracts, by branch, tag, or commit hash
         {
             "eosio": "329071ae8ae7c8e467f42079ebdb09e675d7e702", // eventually update to release/2.0.x
-            "eosio.cdt": "aad0c4729b848c9cbe409aa1fdd917797a4d91e7" // eventually update to release/1.7.x
+            "eosio.cdt": "d1f5dd4dcf28c73f222d4d2b6883d61a5084216a" // eventually update to release/1.7.x
         }
     }
 }


### PR DESCRIPTION
<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->

## Change Description
<!-- Describe your changes, their justification, AND their impact. Reference issues or pull requests where possible (use '#XX' or 'GH-XX' where XX is the issue or pull request number). -->
PR #338 introduced logic to wait for the dependent Docker image with EOS installed as listed in `pipeline.jsonc` to be built and pushed if it does not exist. [Build #978](https://buildkite.com/EOSIO/eosio-dot-contracts/builds/978#0b3391c8-3115-4f60-9f2a-df1804d60cb1) illustrated a need for the same logic to be applied when downloading the dependent CDT binary:

- Added logic to retry downloading the dependent CDT binary.
- Improved logging output:
  - Logs show the command being used to download CDT.
  - Logs detail failures when downloading CDT every minute, including a link to the expected build which should have created the artifact.
- Updated build/test commands to support new logic:
  - The download is retried until it succeeds. The artifact is now mounted into the build/test container, meaning we no longer need to download it at that time.
- Increased timeout to support extended time of CDT builds.

See:
[Build #999](https://buildkite.com/EOSIO/eosio-dot-contracts/builds/999#871a86a2-6938-4986-bcf2-663fe6596cf4) | This exercises the retry functionality when downloading CDT. It waits for an artifact to be produced from [this CDT build](https://buildkite.com/EOSIO/eosio-dot-cdt/builds/937).
[Build #1001](https://buildkite.com/EOSIO/eosio-dot-contracts/builds/1001) | This PR build.
[Build #421](https://travis-ci.com/EOSIO/eosio.contracts/builds/145014461) | Travis build.

## Deployment Changes
- [ ] Deployment Changes
<!-- checked [x] = Deployment changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces a change to the contracts that causes deployment to change, please describe the impact. -->


## API Changes
- [ ] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions
- [ ] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
