### PR TITLE
docs: clean up @details for release/1.9.x

### DIFF
--- a/contracts/eosio.bios/include/eosio.bios/eosio.bios.hpp
+++ b/contracts/eosio.bios/include/eosio.bios/eosio.bios.hpp
@@ -10,7 +10,7 @@
 /**
  * EOSIO Contracts
  *
- * @details The design of the EOSIO blockchain calls for a number of smart contracts that are run at a
+ * The design of the EOSIO blockchain calls for a number of smart contracts that are run at a
  * privileged permission level in order to support functions such as block producer registration and
  * voting, token staking for CPU and network bandwidth, RAM purchasing, multi-sig, etc. These smart
  * contracts are referred to as the system, token, msig and wrap (formerly known as sudo) contracts.
@@ -89,9 +89,7 @@ namespace eosiobios {
       public:
          using contract::contract;
          /**
-          * New account action
-          *
-          * @details Called after a new account is created. This code enforces resource-limits rules
+          * New account action, called after a new account is created. This code enforces resource-limits rules
           * for new accounts as well as new account naming conventions.
           *
           * 1. accounts cannot contain '.' symbols which forces all acccounts to be 12
@@ -108,9 +106,7 @@ namespace eosiobios {
                           ignore<authority> owner,
                           ignore<authority> active){}
          /**
-          * Update authorization action.
-          *
-          * @details Updates pemission for an account.
+          * Update authorization action updates pemission for an account.
           *
           * @param account - the account for which the permission is updated,
           * @param pemission - the permission name which is updated,
@@ -124,9 +120,7 @@ namespace eosiobios {
                            ignore<authority> auth ) {}
 
          /**
-          * Delete authorization action.
-          *
-          * @details Deletes the authorization for an account's permision.
+          * Delete authorization action deletes the authorization for an account's permission.
           *
           * @param account - the account for which the permission authorization is deleted,
           * @param permission - the permission name been deleted.
@@ -136,9 +130,7 @@ namespace eosiobios {
                           ignore<name>  permission ) {}
 
          /**
-          * Link authorization action.
-          *
-          * @details Assigns a specific action from a contract to a permission you have created. Five system
+          * Link authorization action assigns a specific action from a contract to a permission you have created. Five system
           * actions can not be linked `updateauth`, `deleteauth`, `linkauth`, `unlinkauth`, and `canceldelay`.
           * This is useful because when doing authorization checks, the EOSIO based blockchain starts with the
           * action needed to be authorized (and the contract belonging to), and looks up which permission
@@ -159,9 +151,7 @@ namespace eosiobios {
                          ignore<name>    requirement  ) {}
 
          /**
-          * Unlink authorization action.
-          *
-          * @details It's doing the reverse of linkauth action, by unlinking the given action.
+          * Unlink authorization action it's doing the reverse of linkauth action, by unlinking the given action.
           *
           * @param account - the owner of the permission to be unlinked and the receiver of the freed RAM,
           * @param code - the owner of the action to be unlinked,
@@ -173,9 +163,7 @@ namespace eosiobios {
                           ignore<name>  type ) {}
 
          /**
-          * Cancel delay action.
-          *
-          * @details Cancels a deferred transaction.
+          * Cancel delay action cancels a deferred transaction.
           *
           * @param canceling_auth - the permission that authorizes this action,
           * @param trx_id - the deferred transaction id to be cancelled.
@@ -184,9 +172,7 @@ namespace eosiobios {
          void canceldelay( ignore<permission_level> canceling_auth, ignore<checksum256> trx_id ) {}
 
          /**
-          * Set code action.
-          *
-          * @details Sets the contract code for an account.
+          * Set code action sets the contract code for an account.
           *
           * @param account - the account for which to set the contract code.
           * @param vmtype - reserved, set it to zero.
@@ -199,9 +185,7 @@ namespace eosiobios {
          /** @}*/
 
          /**
-          * Set abi for contract.
-          *
-          * @details Set the abi for contract identified by `account` name. Creates an entry in the abi_hash_table
+          * Set abi action sets the abi for contract identified by `account` name. Creates an entry in the abi_hash_table
           * index, with `account` name as key, if it is not already present and sets its value with the abi hash.
           * Otherwise it is updating the current abi hash value for the existing `account` key.
           *
@@ -212,9 +196,7 @@ namespace eosiobios {
          void setabi( name account, const std::vector<char>& abi );
 
          /**
-          * On error action.
-          *
-          * @details Notification of this action is delivered to the sender of a deferred transaction
+          * On error action, notification of this action is delivered to the sender of a deferred transaction
           * when an objective error occurs while executing the deferred transaction.
           * This action is not meant to be called directly.
           *
@@ -225,9 +207,7 @@ namespace eosiobios {
          void onerror( ignore<uint128_t> sender_id, ignore<std::vector<char>> sent_trx );
 
          /**
-          * Set privilege status for an account.
-          *
-          * @details Allows to set privilege status for an account (turn it on/off).
+          * Set privilege action allows to set privilege status for an account (turn it on/off).
           * @param account - the account to set the privileged status for.
           * @param is_priv - 0 for false, > 0 for true.
           */
@@ -235,9 +215,7 @@ namespace eosiobios {
          void setpriv( name account, uint8_t is_priv );
 
          /**
-          * Set the resource limits of an account
-          *
-          * @details Set the resource limits of an account
+          * Sets the resource limits of an account
           *
           * @param account - name of the account whose resource limit to be set
           * @param ram_bytes - ram limit in absolute bytes
@@ -248,9 +226,7 @@ namespace eosiobios {
          void setalimits( name account, int64_t ram_bytes, int64_t net_weight, int64_t cpu_weight );
 
          /**
-          * Set a new list of active producers, that is, a new producers' schedule.
-          *
-          * @details Set a new list of active producers, by proposing a schedule change, once the block that
+          * Set producers action, sets a new list of active producers, by proposing a schedule change, once the block that
           * contains the proposal becomes irreversible, the schedule is promoted to "pending"
           * automatically. Once the block that promotes the schedule is irreversible, the schedule will
           * become "active".
@@ -261,9 +237,7 @@ namespace eosiobios {
          void setprods( const std::vector<eosio::producer_authority>& schedule );
 
          /**
-          * Set the blockchain parameters
-          *
-          * @details Set the blockchain parameters. By tuning these parameters, various degrees of customization can be achieved.
+          * Set params action, sets the blockchain parameters. By tuning these parameters, various degrees of customization can be achieved.
           *
           * @param params - New blockchain parameters to set
           */
@@ -271,9 +245,7 @@ namespace eosiobios {
          void setparams( const eosio::blockchain_parameters& params );
 
          /**
-          * Check if an account has authorization to access current action.
-          *
-          * @details Checks if the account name `from` passed in as param has authorization to access
+          * Require authorization action, checks if the account name `from` passed in as param has authorization to access
           * current action, that is, if it is listed in the action’s allowed permissions vector.
           *
           * @param from - the account name to authorize
@@ -282,9 +254,7 @@ namespace eosiobios {
          void reqauth( name from );
 
          /**
-          * Activates a protocol feature.
-          *
-          * @details Activates a protocol feature
+          * Activate action, activates a protocol feature
           *
           * @param feature_digest - hash of the protocol feature to activate.
           */
@@ -292,9 +262,7 @@ namespace eosiobios {
          void activate( const eosio::checksum256& feature_digest );
 
          /**
-          * Asserts that a protocol feature has been activated.
-          *
-          * @details Asserts that a protocol feature has been activated
+          * Require activated action, asserts that a protocol feature has been activated
           *
           * @param feature_digest - hash of the protocol feature to check for activation.
           */

--- a/contracts/eosio.msig/include/eosio.msig/eosio.msig.hpp
+++ b/contracts/eosio.msig/include/eosio.msig/eosio.msig.hpp
@@ -18,9 +18,7 @@ namespace eosio {
          using contract::contract;
 
          /**
-          * Create proposal
-          *
-          * @details Creates a proposal containing one transaction.
+          * Propose action, creates a proposal containing one transaction.
           * Allows an account `proposer` to make a proposal `proposal_name` which has `requested`
           * permission levels expected to approve the proposal, and if approved by all expected
           * permission levels then `trx` transaction can we executed by this proposal.
@@ -39,10 +37,7 @@ namespace eosio {
          void propose(ignore<name> proposer, ignore<name> proposal_name,
                ignore<std::vector<permission_level>> requested, ignore<transaction> trx);
          /**
-          * Approve proposal
-          *
-          * @details Approves an existing proposal
-          * Allows an account, the owner of `level` permission, to approve a proposal `proposal_name`
+          * Approve action approves an existing proposal. Allows an account, the owner of `level` permission, to approve a proposal `proposal_name`
           * proposed by `proposer`. If the proposal's requested approval list contains the `level`
           * permission then the `level` permission is moved from internal `requested_approvals` list to
           * internal `provided_approvals` list of the proposal, thus persisting the approval for
@@ -57,10 +52,7 @@ namespace eosio {
          void approve( name proposer, name proposal_name, permission_level level,
                        const eosio::binary_extension<eosio::checksum256>& proposal_hash );
          /**
-          * Revoke proposal
-          *
-          * @details Revokes an existing proposal
-          * This action is the reverse of the `approve` action: if all validations pass
+          * Unapprove action revokes an existing proposal. This action is the reverse of the `approve` action: if all validations pass
           * the `level` permission is erased from internal `provided_approvals` and added to the internal
           * `requested_approvals` list, and thus un-approve or revoke the proposal.
           *
@@ -71,9 +63,7 @@ namespace eosio {
          [[eosio::action]]
          void unapprove( name proposer, name proposal_name, permission_level level );
          /**
-          * Cancel proposal
-          *
-          * @details Cancels an existing proposal
+          * Cancel action cancels an existing proposal.
           *
           * @param proposer - The account proposing a transaction
           * @param proposal_name - The name of the proposal (should be an existing proposal)
@@ -86,9 +76,7 @@ namespace eosio {
          [[eosio::action]]
          void cancel( name proposer, name proposal_name, name canceler );
          /**
-          * Execute proposal
-          *
-          * @details Allows an `executer` account to execute a proposal.
+          * Exec action allows an `executer` account to execute a proposal.
           *
           * Preconditions:
           * - `executer` has authorization,
@@ -107,9 +95,7 @@ namespace eosio {
          [[eosio::action]]
          void exec( name proposer, name proposal_name, name executer );
          /**
-          * Invalidate proposal
-          *
-          * @details Allows an `account` to invalidate itself, that is, its name is added to
+          * Invalidate action allows an `account` to invalidate itself, that is, its name is added to
           * the invalidations table and this table will be cross referenced when exec is performed.
           *
           * @param account - The account invalidating the transaction

--- a/contracts/eosio.system/include/eosio.system/eosio.system.hpp
+++ b/contracts/eosio.system/include/eosio.system/eosio.system.hpp
@@ -79,6 +79,8 @@ namespace eosiosystem {
    static constexpr int64_t  default_votepay_factor        = 40000;   // per-block pay share = 10000 / 40000 = 25% of the producer pay
 
    /**
+    * eosio.system contract
+    * 
     * eosio.system contract defines the structures and actions needed for blockchain's core functionality.
     * - Users can stake tokens for CPU and Network bandwidth, and then vote for producers or
     *    delegate their vote to a proxy.
@@ -588,7 +590,7 @@ namespace eosiosystem {
 
 
          /**
-          * Activates a protocol feature
+          * The activate action, activates a protocol feature
           *
           * @param feature_digest - hash of the protocol feature to activate.
           */
@@ -615,9 +617,7 @@ namespace eosiosystem {
                           const asset& stake_net_quantity, const asset& stake_cpu_quantity, bool transfer );
 
          /**
-          * Setrex action.
-          *
-          * @details Sets total_rent balance of REX pool to the passed value.
+          * Setrex action, sets total_rent balance of REX pool to the passed value.
           * @param balance - amount to set the REX pool balance.
           */
          [[eosio::action]]
@@ -638,9 +638,7 @@ namespace eosiosystem {
          void deposit( const name& owner, const asset& amount );
 
          /**
-          * Withdraw from REX fund action.
-          *
-          * @details Withdraws core tokens from user REX fund.
+          * Withdraw from REX fund action, withdraws core tokens from user REX fund.
           * An inline token transfer to user balance is executed.
           *
           * @param owner - REX fund owner account,
@@ -650,7 +648,7 @@ namespace eosiosystem {
          void withdraw( const name& owner, const asset& amount );
 
          /**
-          * Buyrex action. Buys REX in exchange for tokens taken out of user's REX fund by transfering
+          * Buyrex action, buys REX in exchange for tokens taken out of user's REX fund by transfering
           * core tokens from user REX fund and converts them to REX stake. By buying REX, user is
           * lending tokens in order to be rented as CPU or NET resourses.
           * Storage change is billed to 'from' account.
@@ -669,7 +667,7 @@ namespace eosiosystem {
          void buyrex( const name& from, const asset& amount );
 
          /**
-          * Unstaketorex action. Use staked core tokens to buy REX.
+          * Unstaketorex action, uses staked core tokens to buy REX.
           * Storage change is billed to 'owner' account.
           *
           * @param owner - owner of staked tokens,
@@ -688,7 +686,7 @@ namespace eosiosystem {
          void unstaketorex( const name& owner, const name& receiver, const asset& from_net, const asset& from_cpu );
 
          /**
-          * Sellrex action. Sells REX in exchange for core tokens by converting REX stake back into core tokens
+          * Sellrex action, sells REX in exchange for core tokens by converting REX stake back into core tokens
           * at current exchange rate. If order cannot be processed, it gets queued until there is enough
           * in REX pool to fill order, and will be processed within 30 days at most. If successful, user
           * votes are updated, that is, proceeds are deducted from user's voting power. In case sell order
@@ -701,7 +699,7 @@ namespace eosiosystem {
          void sellrex( const name& from, const asset& rex );
 
          /**
-          * Cnclrexorder action. Cancels unfilled REX sell order by owner if one exists.
+          * Cnclrexorder action, cancels unfilled REX sell order by owner if one exists.
           *
           * @param owner - owner account name.
           *
@@ -711,7 +709,7 @@ namespace eosiosystem {
          void cnclrexorder( const name& owner );
 
          /**
-          * Rentcpu action. Use payment to rent as many SYS tokens as possible as determined by market price and
+          * Rentcpu action, uses payment to rent as many SYS tokens as possible as determined by market price and
           * stake them for CPU for the benefit of receiver, after 30 days the rented core delegation of CPU
           * will expire. At expiration, if balance is greater than or equal to `loan_payment`, `loan_payment`
           * is taken out of loan balance and used to renew the loan. Otherwise, the loan is closed and user
@@ -731,7 +729,7 @@ namespace eosiosystem {
          void rentcpu( const name& from, const name& receiver, const asset& loan_payment, const asset& loan_fund );
 
          /**
-          * Rentnet action. Use payment to rent as many SYS tokens as possible as determined by market price and
+          * Rentnet action, uses payment to rent as many SYS tokens as possible as determined by market price and
           * stake them for NET for the benefit of receiver, after 30 days the rented core delegation of NET
           * will expire. At expiration, if balance is greater than or equal to `loan_payment`, `loan_payment`
           * is taken out of loan balance and used to renew the loan. Otherwise, the loan is closed and user
@@ -751,7 +749,7 @@ namespace eosiosystem {
          void rentnet( const name& from, const name& receiver, const asset& loan_payment, const asset& loan_fund );
 
          /**
-          * Fundcpuloan action. Transfers tokens from REX fund to the fund of a specific CPU loan in order to
+          * Fundcpuloan action, transfers tokens from REX fund to the fund of a specific CPU loan in order to
           * be used for loan renewal at expiry.
           *
           * @param from - loan creator account,
@@ -762,7 +760,7 @@ namespace eosiosystem {
          void fundcpuloan( const name& from, uint64_t loan_num, const asset& payment );
 
          /**
-          * Fundnetloan action. Transfers tokens from REX fund to the fund of a specific NET loan in order to
+          * Fundnetloan action, transfers tokens from REX fund to the fund of a specific NET loan in order to
           * be used for loan renewal at expiry.
           *
           * @param from - loan creator account,
@@ -773,7 +771,7 @@ namespace eosiosystem {
          void fundnetloan( const name& from, uint64_t loan_num, const asset& payment );
 
          /**
-          * Defcpuloan action. Withdraws tokens from the fund of a specific CPU loan and adds them to REX fund.
+          * Defcpuloan action, withdraws tokens from the fund of a specific CPU loan and adds them to REX fund.
           *
           * @param from - loan creator account,
           * @param loan_num - loan id,
@@ -783,7 +781,7 @@ namespace eosiosystem {
          void defcpuloan( const name& from, uint64_t loan_num, const asset& amount );
 
          /**
-          * Defnetloan action. Withdraws tokens from the fund of a specific NET loan and adds them to REX fund.
+          * Defnetloan action, withdraws tokens from the fund of a specific NET loan and adds them to REX fund.
           *
           * @param from - loan creator account,
           * @param loan_num - loan id,
@@ -793,7 +791,7 @@ namespace eosiosystem {
          void defnetloan( const name& from, uint64_t loan_num, const asset& amount );
 
          /**
-          * Updaterex action. Updates REX owner vote weight to current value of held REX tokens.
+          * Updaterex action, updates REX owner vote weight to current value of held REX tokens.
           *
           * @param owner - REX owner account.
           */
@@ -801,7 +799,7 @@ namespace eosiosystem {
          void updaterex( const name& owner );
 
          /**
-          * Rexexec action. Processes max CPU loans, max NET loans, and max queued sellrex orders.
+          * Rexexec action, processes max CPU loans, max NET loans, and max queued sellrex orders.
           * Action does not execute anything related to a specific user.
           *
           * @param user - any account can execute this action,
@@ -811,7 +809,7 @@ namespace eosiosystem {
          void rexexec( const name& user, uint16_t max );
 
          /**
-          * Consolidate action. Consolidates REX maturity buckets into one bucket that can be sold after 4 days
+          * Consolidate action, consolidates REX maturity buckets into one bucket that can be sold after 4 days
           * starting from the end of the day.
           *
           * @param owner - REX owner account name.
@@ -820,7 +818,7 @@ namespace eosiosystem {
          void consolidate( const name& owner );
 
          /**
-          * Mvtosavings action. Moves a specified amount of REX into savings bucket. REX savings bucket
+          * Mvtosavings action, moves a specified amount of REX into savings bucket. REX savings bucket
           * never matures. In order for it to be sold, it has to be moved explicitly
           * out of that bucket. Then the moved amount will have the regular maturity
           * period of 4 days starting from the end of the day.
@@ -832,7 +830,7 @@ namespace eosiosystem {
          void mvtosavings( const name& owner, const asset& rex );
 
          /**
-          * Mvfrsavings action. Moves a specified amount of REX out of savings bucket. The moved amount
+          * Mvfrsavings action, moves a specified amount of REX out of savings bucket. The moved amount
           * will have the regular REX maturity period of 4 days.
           *
           * @param owner - REX owner account name.
@@ -842,7 +840,7 @@ namespace eosiosystem {
          void mvfrsavings( const name& owner, const asset& rex );
 
          /**
-          * Closerex action. Deletes owner records from REX tables and frees used RAM. Owner must not have
+          * Closerex action, deletes owner records from REX tables and frees used RAM. Owner must not have
           * an outstanding REX balance.
           *
           * @param owner - user account name.
@@ -856,7 +854,7 @@ namespace eosiosystem {
          void closerex( const name& owner );
 
          /**
-          * Undelegate bandwitdh action. Decreases the total tokens delegated by `from` to `receiver` and/or
+          * Undelegate bandwitdh action, decreases the total tokens delegated by `from` to `receiver` and/or
           * frees the memory associated with the delegation if there is nothing
           * left to delegate.
           * This will cause an immediate reduction in net/cpu bandwidth of the
@@ -887,7 +885,7 @@ namespace eosiosystem {
                             const asset& unstake_net_quantity, const asset& unstake_cpu_quantity );
 
          /**
-          * Buy ram action. Increases receiver's ram quota based upon current price and quantity of
+          * Buy ram action, increases receiver's ram quota based upon current price and quantity of
           * tokens provided. An inline transfer from receiver to system contract of
           * tokens will be executed.
           *
@@ -910,7 +908,7 @@ namespace eosiosystem {
          void buyrambytes( const name& payer, const name& receiver, uint32_t bytes );
 
          /**
-          * Sell ram action. Reduces quota by bytes and then performs an inline transfer of tokens
+          * Sell ram action, reduces quota by bytes and then performs an inline transfer of tokens
           * to receiver based upon the average purchase price of the original quota.
           *
           * @param account - the ram seller account,
@@ -920,7 +918,7 @@ namespace eosiosystem {
          void sellram( const name& account, int64_t bytes );
 
          /**
-          * Refund action. This action is called after the delegation-period to claim all pending
+          * Refund action, this action is called after the delegation-period to claim all pending
           * unstaked tokens belonging to owner.
           *
           * @param owner - the owner of the tokens claimed.
@@ -931,7 +929,7 @@ namespace eosiosystem {
          // functions defined in voting.cpp
 
          /**
-          * Register producer action. Register producer action, indicates that a particular account wishes to become a producer,
+          * Register producer action, indicates that a particular account wishes to become a producer,
           * this action will create a `producer_config` and a `producer_info` object for `producer` scope
           * in producers tables.
           *
@@ -947,9 +945,7 @@ namespace eosiosystem {
          void regproducer( const name& producer, const public_key& producer_key, const std::string& url, uint16_t location );
 
          /**
-          * Register producer action.
-          *
-          * @details Register producer action, indicates that a particular account wishes to become a producer,
+          * Register producer action, indicates that a particular account wishes to become a producer,
           * this action will create a `producer_config` and a `producer_info` object for `producer` scope
           * in producers tables.
           *
@@ -965,23 +961,23 @@ namespace eosiosystem {
          void regproducer2( const name& producer, const eosio::block_signing_authority& producer_authority, const std::string& url, uint16_t location );
 
          /**
-          * Unregister producer action. Deactivate the block producer with account name `producer`.
+          * Unregister producer action, deactivates the block producer with account name `producer`.
           *
-          * @details Deactivate the block producer with account name `producer`.
+          * Deactivate the block producer with account name `producer`.
           * @param producer - the block producer account to unregister.
           */
          [[eosio::action]]
          void unregprod( const name& producer );
 
          /**
-          * Set ram action sets the ram supply
+          * Set ram action sets the ram supply.
           * @param max_ram_size - the amount of ram supply to set.
           */
          [[eosio::action]]
          void setram( uint64_t max_ram_size );
 
          /**
-          * Set ram rate action. Sets the rate of increase of RAM in bytes per block. It is capped by the uint16_t to
+          * Set ram rate action, sets the rate of increase of RAM in bytes per block. It is capped by the uint16_t to
           * a maximum rate of 3 TB per year. If update_ram_supply hasn't been called for the most recent block,
           * then new ram will be allocated at the old rate up to the present block before switching the rate.
           *
@@ -991,7 +987,7 @@ namespace eosiosystem {
          void setramrate( uint16_t bytes_per_block );
 
          /**
-          * Vote producer action. Votes for a set of producers. This action updates the list of `producers` voted for,
+          * Vote producer action, votes for a set of producers. This action updates the list of `producers` voted for,
           * for `voter` account. If voting for a `proxy`, the producer votes will not change until the
           * proxy updates their own vote. Voter can vote for a proxy __or__ a list of at most 30 producers.
           * Storage change is billed to `voter`.
@@ -1017,7 +1013,7 @@ namespace eosiosystem {
          void voteproducer( const name& voter, const name& proxy, const std::vector<name>& producers );
 
          /**
-          * Register proxy action. Set `proxy` account as proxy.
+          * Register proxy action, sets `proxy` account as proxy.
           * An account marked as a proxy can vote with the weight of other accounts which
           * have selected it as a proxy. Other accounts must refresh their voteproducer to
           * update the proxy's weight.
@@ -1033,7 +1029,7 @@ namespace eosiosystem {
          void regproxy( const name& proxy, bool isproxy );
 
          /**
-          * Set the blockchain parameters Set the blockchain parameters. By tunning these parameters a degree of
+          * Set the blockchain parameters. By tunning these parameters a degree of
           * customization can be achieved.
           * @param params - New blockchain parameters to set.
           */
@@ -1041,7 +1037,7 @@ namespace eosiosystem {
          void setparams( const eosio::blockchain_parameters& params );
 
          /**
-          * Claim rewards action. Claim block producing and vote rewards.
+          * Claim rewards action, claims block producing and vote rewards.
           * @param owner - producer account claiming per-block and per-vote rewards.
           */
          [[eosio::action]]
@@ -1056,14 +1052,14 @@ namespace eosiosystem {
          void setpriv( const name& account, uint8_t is_priv );
 
          /**
-          * Remove producer action. Deactivates a producer by name, if not found asserts.
+          * Remove producer action, deactivates a producer by name, if not found asserts.
           * @param producer - the producer account to deactivate.
           */
          [[eosio::action]]
          void rmvproducer( const name& producer );
 
          /**
-          * Update revision action.  Updates the current revision.
+          * Update revision action, updates the current revision.
           * @param revision - it has to be incremented by 1 compared with current revision.
           *
           * @pre Current revision can not be higher than 254, and has to be smaller
@@ -1073,7 +1069,7 @@ namespace eosiosystem {
          void updtrevision( uint8_t revision );
 
          /**
-          * Bid name action. Allows an account `bidder` to place a bid for a name `newname`.
+          * Bid name action, allows an account `bidder` to place a bid for a name `newname`.
           * @param bidder - the account placing the bid,
           * @param newname - the name the bid is placed for,
           * @param bid - the amount of system tokens payed for the bid.
@@ -1092,7 +1088,7 @@ namespace eosiosystem {
          void bidname( const name& bidder, const name& newname, const asset& bid );
 
          /**
-          * Bid refund action. Allows the account `bidder` to get back the amount it bid so far on a `newname` name.
+          * Bid refund action, allows the account `bidder` to get back the amount it bid so far on a `newname` name.
           *
           * @param bidder - the account that gets refunded,
           * @param newname - the name for which the bid was placed and now it gets refunded for.
@@ -1102,18 +1098,15 @@ namespace eosiosystem {
 
          /**
           * Change the annual inflation rate of the core token supply and specify how
-          *          the new issued tokens will be distributed based on the following structure.
-
+          * the new issued tokens will be distributed based on the following structure.
           *
           * @param annual_rate - Annual inflation rate of the core token supply.
           *     (eg. For 5% Annual inflation => annual_rate=500
           *          For 1.5% Annual inflation => annual_rate=150
-          *
           * @param inflation_pay_factor - Inverse of the fraction of the inflation used to reward block producers.
           *     The remaining inflation will be sent to the `eosio.saving` account.
           *     (eg. For 20% of inflation going to block producer rewards   => inflation_pay_factor = 50000
           *          For 100% of inflation going to block producer rewards  => inflation_pay_factor = 10000).
-          *
           * @param votepay_factor - Inverse of the fraction of the block producer rewards to be distributed proportional to blocks produced.
           *     The remaining rewards will be distributed proportional to votes received.
           *     (eg. For 25% of block producer rewards going towards block pay => votepay_factor = 40000

--- a/contracts/eosio.system/include/eosio.system/exchange_state.hpp
+++ b/contracts/eosio.system/include/eosio.system/exchange_state.hpp
@@ -16,7 +16,7 @@ namespace eosiosystem {
    /**
     * Uses Bancor math to create a 50/50 relay between two asset types.
     *
-    * @details The state of the bancor exchange is entirely contained within this struct.
+    * The state of the bancor exchange is entirely contained within this struct.
     * There are no external side effects associated with using this API.
     */
    struct [[eosio::table, eosio::contract("eosio.system")]] exchange_state {

--- a/contracts/eosio.system/include/eosio.system/native.hpp
+++ b/contracts/eosio.system/include/eosio.system/native.hpp
@@ -24,7 +24,7 @@ namespace eosiosystem {
    /**
     * A weighted permission.
     *
-    * @details Defines a weighted permission, that is a permission which has a weight associated.
+    * Defines a weighted permission, that is a permission which has a weight associated.
     * A permission is defined by an account name plus a permission name.
     */
    struct permission_level_weight {
@@ -38,7 +38,7 @@ namespace eosiosystem {
    /**
     * Weighted key.
     *
-    * @details A weighted key is defined by a public key and an associated weight.
+    * A weighted key is defined by a public key and an associated weight.
     */
    struct key_weight {
       eosio::public_key  key;
@@ -51,7 +51,7 @@ namespace eosiosystem {
    /**
     * Wait weight.
     *
-    * @details A wait weight is defined by a number of seconds to wait for and a weight.
+    * A wait weight is defined by a number of seconds to wait for and a weight.
     */
    struct wait_weight {
       uint32_t           wait_sec;
@@ -64,7 +64,7 @@ namespace eosiosystem {
    /**
     * Blockchain authority.
     *
-    * @details An authority is defined by:
+    * An authority is defined by:
     * - a vector of key_weights (a key_weight is a public key plus a wieght),
     * - a vector of permission_level_weights, (a permission_level is an account name plus a permission name)
     * - a vector of wait_weights (a wait_weight is defined by a number of seconds to wait and a weight)
@@ -83,7 +83,7 @@ namespace eosiosystem {
    /**
     * Blockchain block header.
     *
-    * @details A block header is defined by:
+    * A block header is defined by:
     * - a timestamp,
     * - the producer that created it,
     * - a confirmed flag default as zero,
@@ -109,9 +109,7 @@ namespace eosiosystem {
    };
 
    /**
-    * abi_hash
-    *
-    * @details abi_hash is the structure underlying the abihash table and consists of:
+    * abi_hash is the structure underlying the abihash table and consists of:
     * - `owner`: the account owner of the contract's abi
     * - `hash`: is the sha256 hash of the abi/binary
     */
@@ -125,9 +123,7 @@ namespace eosiosystem {
 
    // Method parameters commented out to prevent generation of code that parses input data.
    /**
-    * The EOSIO core native contract that governs authorization and contracts' abi.
-    *
-    * @details
+    * The EOSIO core `native` contract that governs authorization and contracts' abi.
     */
    class [[eosio::contract("eosio.system")]] native : public eosio::contract {
       public:
@@ -136,16 +132,14 @@ namespace eosiosystem {
 
          /**
           * @{
-          * These actions map one-on-one with the ones defined in
-          * [Native Action Handlers](@ref native_action_handlers) section.
-          * They are present here so they can show up in the abi file and thus user can send them
+          * These actions map one-on-one with the ones defined in core layer of EOSIO, that's where their implementation
+          * actually is done.
+          * They are present here only so they can show up in the abi file and thus user can send them
           * to this contract, but they have no specific implementation at this contract level,
-          * they will execute the implementation at the core level and nothing else.
+          * they will execute the implementation at the core layer and nothing else.
           */
          /**
-          * New account action
-          *
-          * @details Called after a new account is created. This code enforces resource-limits rules
+          * New account action is called after a new account is created. This code enforces resource-limits rules
           * for new accounts as well as new account naming conventions.
           *
           * 1. accounts cannot contain '.' symbols which forces all acccounts to be 12
@@ -163,9 +157,7 @@ namespace eosiosystem {
                           ignore<authority> active);
 
          /**
-          * Update authorization action.
-          *
-          * @details Updates pemission for an account
+          * Update authorization action updates pemission for an account.
           *
           * @param account - the account for which the permission is updated
           * @param pemission - the permission name which is updated
@@ -179,9 +171,7 @@ namespace eosiosystem {
                           ignore<authority> auth ) {}
 
          /**
-          * Delete authorization action.
-          *
-          * @details Deletes the authorization for an account's permision.
+          * Delete authorization action deletes the authorization for an account's permission.
           *
           * @param account - the account for which the permission authorization is deleted,
           * @param permission - the permission name been deleted.
@@ -191,9 +181,7 @@ namespace eosiosystem {
                           ignore<name> permission ) {}
 
          /**
-          * Link authorization action.
-          *
-          * @details Assigns a specific action from a contract to a permission you have created. Five system
+          * Link authorization action assigns a specific action from a contract to a permission you have created. Five system
           * actions can not be linked `updateauth`, `deleteauth`, `linkauth`, `unlinkauth`, and `canceldelay`.
           * This is useful because when doing authorization checks, the EOSIO based blockchain starts with the
           * action needed to be authorized (and the contract belonging to), and looks up which permission
@@ -214,9 +202,7 @@ namespace eosiosystem {
                         ignore<name> requirement  ) {}
 
          /**
-          * Unlink authorization action.
-          *
-          * @details It's doing the reverse of linkauth action, by unlinking the given action.
+          * Unlink authorization action it's doing the reverse of linkauth action, by unlinking the given action.
           *
           * @param account - the owner of the permission to be unlinked and the receiver of the freed RAM,
           * @param code - the owner of the action to be unlinked,
@@ -228,9 +214,7 @@ namespace eosiosystem {
                           ignore<name> type ) {}
 
          /**
-          * Cancel delay action.
-          *
-          * @details Cancels a deferred transaction.
+          * Cancel delay action cancels a deferred transaction.
           *
           * @param canceling_auth - the permission that authorizes this action,
           * @param trx_id - the deferred transaction id to be cancelled.
@@ -239,9 +223,7 @@ namespace eosiosystem {
          void canceldelay( ignore<permission_level> canceling_auth, ignore<checksum256> trx_id ) {}
 
          /**
-          * On error action.
-          *
-          * @details Notification of this action is delivered to the sender of a deferred transaction
+          * On error action, notification of this action is delivered to the sender of a deferred transaction
           * when an objective error occurs while executing the deferred transaction.
           * This action is not meant to be called directly.
           *
@@ -252,9 +234,7 @@ namespace eosiosystem {
          void onerror( ignore<uint128_t> sender_id, ignore<std::vector<char>> sent_trx );
 
          /**
-          * Set abi action.
-          *
-          * @details Sets the contract abi for an account.
+          * Set abi action sets the contract abi for an account.
           *
           * @param account - the account for which to set the contract abi.
           * @param abi - the abi content to be set, in the form of a blob binary.
@@ -263,9 +243,7 @@ namespace eosiosystem {
          void setabi( const name& account, const std::vector<char>& abi );
 
          /**
-          * Set code action.
-          *
-          * @details Sets the contract code for an account.
+          * Set code action sets the contract code for an account.
           *
           * @param account - the account for which to set the contract code.
           * @param vmtype - reserved, set it to zero.

--- a/contracts/eosio.token/include/eosio.token/eosio.token.hpp
+++ b/contracts/eosio.token/include/eosio.token/eosio.token.hpp
@@ -15,7 +15,7 @@ namespace eosio {
 
    /**
     * eosio.token contract defines the structures and actions that allow users to create, issue, and manage
-    * tokens on eosio based blockchains.
+    * tokens on EOSIO based blockchains.
     */
    class [[eosio::contract("eosio.token")]] token : public contract {
       public:

--- a/contracts/eosio.wrap/include/eosio.wrap/eosio.wrap.hpp
+++ b/contracts/eosio.wrap/include/eosio.wrap/eosio.wrap.hpp
@@ -10,7 +10,7 @@ namespace eosio {
     * @ingroup eosiocontracts
     * eosio.wrap contract simplifies Block Producer superuser actions by making them more readable and easier to audit.
 
-    * @details It does not grant block producers any additional powers that do not already exist within the
+    * It does not grant block producers any additional powers that do not already exist within the
     * system. Currently, 15/21 block producers can already change an account's keys or modify an
     * account's contract at the request of ECAF or an account's owner. However, the current method
     * is opaque and leaves undesirable side effects on specific system accounts.
@@ -24,7 +24,7 @@ namespace eosio {
          /**
           * Execute action.
           *
-          * @details Execute a transaction while bypassing regular authorization checks.
+          * Execute a transaction while bypassing regular authorization checks.
           *
           * @param executer - account executing the transaction,
           * @param trx - the transaction to be executed.


### PR DESCRIPTION

## Change Description
clean up @details and other arrangements to support the mdjavadoc generator.
reason: @details in annotations are not compatible with mdjavadoc generator.