### PR TITLE
[develop-deprecate-deferred-trx] Deprecate Deferred Transactions

### DIFF
--- a/contracts/eosio.msig/include/eosio.msig/eosio.msig.hpp
+++ b/contracts/eosio.msig/include/eosio.msig/eosio.msig.hpp
@@ -6,10 +6,6 @@
 #include <eosio/transaction.hpp>
 
 namespace eosio {
-
-   // transaction_header get_trx_header(const char* ptr, size_t sz);
-   // bool trx_is_authorized(const std::vector<permission_level>& approvals, const std::vector<char>& packed_trx);
-
    /**
     * The `eosio.msig` system contract allows for creation of proposed transactions which require authorization from a list of accounts, approval of the proposed transactions by those accounts required to approve it, and finally, it also allows the execution of the approved transactions on the blockchain.
     *

--- a/contracts/eosio.msig/include/eosio.msig/eosio.msig.hpp
+++ b/contracts/eosio.msig/include/eosio.msig/eosio.msig.hpp
@@ -7,8 +7,8 @@
 
 namespace eosio {
 
-   transaction_header get_trx_header(const char* ptr, size_t sz);
-   bool trx_is_authorized(const std::vector<permission_level>& approvals, const std::vector<char>& packed_trx);
+   // transaction_header get_trx_header(const char* ptr, size_t sz);
+   // bool trx_is_authorized(const std::vector<permission_level>& approvals, const std::vector<char>& packed_trx);
 
    /**
     * The `eosio.msig` system contract allows for creation of proposed transactions which require authorization from a list of accounts, approval of the proposed transactions by those accounts required to approve it, and finally, it also allows the execution of the approved transactions on the blockchain.

--- a/contracts/eosio.msig/include/eosio.msig/eosio.msig.hpp
+++ b/contracts/eosio.msig/include/eosio.msig/eosio.msig.hpp
@@ -38,8 +38,8 @@ namespace eosio {
           * @param trx - Proposed transaction
           */
          [[eosio::action]]
-         void propose(ignore<name> proposer, ignore<name> proposal_name,
-               ignore<std::vector<permission_level>> requested, ignore<transaction> trx);
+         void propose(name proposer, name proposal_name,
+                      std::vector<permission_level> requested, ignore<transaction> trx);
          /**
           * Approve proposal
           *

--- a/contracts/eosio.msig/include/eosio.msig/eosio.msig.hpp
+++ b/contracts/eosio.msig/include/eosio.msig/eosio.msig.hpp
@@ -132,9 +132,9 @@ namespace eosio {
 
       private:
          struct [[eosio::table]] proposal {
-            name                                proposal_name;
-            std::vector<char>                   packed_transaction;
-            eosio::binary_extension<time_point> earliest_exec_time;
+            name                                                 proposal_name;
+            std::vector<char>                                    packed_transaction;
+            eosio::binary_extension< std::optional<time_point> > earliest_exec_time;
 
             uint64_t primary_key()const { return proposal_name.value; }
          };

--- a/contracts/eosio.msig/include/eosio.msig/eosio.msig.hpp
+++ b/contracts/eosio.msig/include/eosio.msig/eosio.msig.hpp
@@ -175,7 +175,6 @@ namespace eosio {
          typedef eosio::multi_index< "invals"_n, invalidation > invalidations;
 
       private:
-
          transaction_header _get_trx_header(const char* ptr, size_t sz) {
             datastream<const char*> ds{ptr, sz};
             transaction_header trx_header;

--- a/contracts/eosio.msig/include/eosio.msig/eosio.msig.hpp
+++ b/contracts/eosio.msig/include/eosio.msig/eosio.msig.hpp
@@ -129,8 +129,9 @@ namespace eosio {
 
       private:
          struct [[eosio::table]] proposal {
-            name                            proposal_name;
-            std::vector<char>               packed_transaction;
+            name                                proposal_name;
+            std::vector<char>                   packed_transaction;
+            eosio::binary_extension<time_point> earliest_exec_time;
 
             uint64_t primary_key()const { return proposal_name.value; }
          };
@@ -172,5 +173,61 @@ namespace eosio {
          };
 
          typedef eosio::multi_index< "invals"_n, invalidation > invalidations;
+
+      transaction_header _get_trx_header(const char* ptr, size_t sz) {
+         datastream<const char*> ds{ptr, sz};
+         transaction_header trx_header;
+         ds >> trx_header;
+         return trx_header;
+      }
+
+      template<typename ProposalType, typename Function>
+      bool _resolve_approvals(name proposer, name proposal_name, ProposalType prop, Function&& table_op) {
+         std::vector<permission_level> approvals = _get_approvals_and_adjust_table(proposer, proposal_name, table_op);
+         if ( _trx_is_authorized(approvals, prop.packed_transaction) ) {
+            return true;
+         } else {
+            return false;
+         }
+      }
+
+      bool _trx_is_authorized(const std::vector<permission_level>& approvals, const std::vector<char>& packed_trx) {
+         auto packed_requeted = pack(approvals);
+         return check_transaction_authorization(
+            packed_trx.data(), packed_trx.size(),
+            (const char*)0, 0,
+            packed_requeted.data(), packed_requeted.size()
+         );
+      }
+
+      template<typename Function>
+      std::vector<permission_level> _get_approvals_and_adjust_table(name proposer, name proposal_name, Function&& f) {
+         approvals approval_table( get_self(), proposer.value );
+         auto approval_table_iter = approval_table.find( proposal_name.value );
+         std::vector<permission_level> approvals;
+         invalidations invalidations_table( get_self(), get_self().value );
+
+         if ( approval_table_iter != approval_table.end() ) {
+            approvals.reserve( approval_table_iter->provided_approvals.size() );
+            for ( auto& permission : approval_table_iter->provided_approvals ) {
+               auto iter = invalidations_table.find( permission.level.actor.value );
+               if ( iter == invalidations_table.end() || iter->last_invalidation_time < permission.time ) {
+                  approvals.push_back(permission.level);
+               }
+            }
+            f( approval_table, approval_table_iter );
+         } else {
+            old_approvals old_approval_table( get_self(), proposer.value );
+            auto& old_approvals_iter = old_approval_table.get( proposal_name.value, "proposal not found" );
+            for ( auto& permission : old_approvals_iter.provided_approvals ) {
+               auto iter = invalidations_table.find( permission.actor.value );
+               if ( iter == invalidations_table.end() ) {
+                  approvals.push_back( permission );
+               }
+            }
+            f( old_approval_table, old_approvals_iter );
+         }
+         return approvals;
+      }
    };
 } /// namespace eosio

--- a/contracts/eosio.msig/src/eosio.msig.cpp
+++ b/contracts/eosio.msig/src/eosio.msig.cpp
@@ -197,7 +197,7 @@ void multisig::exec( name proposer, name proposal_name, name executer ) {
    } else {
       check( trx_header.delay_sec.value == 0, "old proposals are not allowed to have non-zero `delay_sec`; cancel and retry" );
    }
-   
+
    datastream<const char*> ds = {prop.packed_transaction.data(), prop.packed_transaction.size()};
    transaction_header _;
    std::vector<action> context_free_actions;

--- a/contracts/eosio.msig/src/eosio.msig.cpp
+++ b/contracts/eosio.msig/src/eosio.msig.cpp
@@ -74,9 +74,9 @@ void multisig::approve( name proposer, name proposal_name, permission_level leve
       check( itr != apps_it->requested_approvals.end(), "approval is not on the list of requested approvals" );
 
       apptable.modify( apps_it, proposer, [&]( auto& a ) {
-         a.provided_approvals.push_back( approval{ level, current_time_point() } );
-         a.requested_approvals.erase( itr );
-      });
+            a.provided_approvals.push_back( approval{ level, current_time_point() } );
+            a.requested_approvals.erase( itr );
+         });
    } else {
       old_approvals old_apptable( get_self(), proposer.value );
       auto& apps = old_apptable.get( proposal_name.value, "proposal not found" );
@@ -85,14 +85,14 @@ void multisig::approve( name proposer, name proposal_name, permission_level leve
       check( itr != apps.requested_approvals.end(), "approval is not on the list of requested approvals" );
 
       old_apptable.modify( apps, proposer, [&]( auto& a ) {
-         a.provided_approvals.push_back( level );
-         a.requested_approvals.erase( itr );
-      });
+            a.provided_approvals.push_back( level );
+            a.requested_approvals.erase( itr );
+         });
    }
-    
+
    transaction_header trx_header = _get_trx_header(prop.packed_transaction.data(), prop.packed_transaction.size());
    check( prop.earliest_exec_time.has_value() || (trx_header.delay_sec.value == 0), "no `earliest_exec_time` and no `delay_sec` is not 0" );
-   
+
    if (prop.earliest_exec_time.has_value()) {
       if ( prop.earliest_exec_time.value() != time_point{eosio::microseconds::maximum()} ) {
          return;
@@ -101,8 +101,8 @@ void multisig::approve( name proposer, name proposal_name, permission_level leve
          if ( _resolve_approvals(proposer, proposal_name, prop, table_op) ) {
             auto prop_it = proptable.find( proposal_name.value );
             proptable.modify( prop_it, proposer, [&]( auto& p ) {
-               p.earliest_exec_time = current_time_point() + eosio::seconds(trx_header.delay_sec.value);
-            });
+                  p.earliest_exec_time = current_time_point() + eosio::seconds(trx_header.delay_sec.value);
+               });
          } else {
             return;
          }
@@ -112,27 +112,27 @@ void multisig::approve( name proposer, name proposal_name, permission_level leve
 
 void multisig::unapprove( name proposer, name proposal_name, permission_level level ) {
    require_auth( level );
-   
+
    approvals apptable( get_self(), proposer.value );
    auto apps_it = apptable.find( proposal_name.value );
    if ( apps_it != apptable.end() ) {
       auto itr = std::find_if( apps_it->provided_approvals.begin(), apps_it->provided_approvals.end(), [&](const approval& a) { return a.level == level; } );
       check( itr != apps_it->provided_approvals.end(), "no approval previously granted" );
       apptable.modify( apps_it, proposer, [&]( auto& a ) {
-         a.requested_approvals.push_back( approval{ level, current_time_point() } );
-         a.provided_approvals.erase( itr );
-      });
+            a.requested_approvals.push_back( approval{ level, current_time_point() } );
+            a.provided_approvals.erase( itr );
+         });
    } else {
       old_approvals old_apptable( get_self(), proposer.value );
       auto& apps = old_apptable.get( proposal_name.value, "proposal not found" );
       auto itr = std::find( apps.provided_approvals.begin(), apps.provided_approvals.end(), level );
       check( itr != apps.provided_approvals.end(), "no approval previously granted" );
       old_apptable.modify( apps, proposer, [&]( auto& a ) {
-         a.requested_approvals.push_back( level );
-         a.provided_approvals.erase( itr );
-      });
+            a.requested_approvals.push_back( level );
+            a.provided_approvals.erase( itr );
+         });
    }
-   
+
    proposals proptable( get_self(), proposer.value );
    auto& prop = proptable.get( proposal_name.value, "proposal not found" );
 
@@ -141,7 +141,7 @@ void multisig::unapprove( name proposer, name proposal_name, permission_level le
 
    if (prop.earliest_exec_time.has_value()) {
       if ( prop.earliest_exec_time.value() == time_point{eosio::microseconds::maximum()} ) {
-         return; 
+         return;
       } else {
          auto table_op = [](auto&&, auto&&){};
          if ( _resolve_approvals(proposer, proposal_name, prop, table_op) ) {
@@ -200,11 +200,11 @@ void multisig::exec( name proposer, name proposal_name, name executer ) {
    check( prop.earliest_exec_time.value() <= time_point{current_time_point()}, "`earliest_exec_time` cannot execute just yet" );
 
    auto [context_free_actions, actions] = _get_actions(prop.packed_transaction.data(), prop.packed_transaction.size());
-   
+
    for (const auto& act : context_free_actions) {
       act.send();
    }
-   
+
    for (const auto& act : actions) {
       act.send();
    }

--- a/contracts/eosio.msig/src/eosio.msig.cpp
+++ b/contracts/eosio.msig/src/eosio.msig.cpp
@@ -191,26 +191,32 @@ void multisig::exec( name proposer, name proposal_name, name executer ) {
    auto table_op = [](auto&& table, auto&& table_iter) { table.erase(table_iter); };
    check( _resolve_approvals(proposer, proposal_name, prop, table_op), "transaction authorization failed" );
 
-   // /// TODO:
-   // //  Enforce that `earliest_exec_time` exists.
-   // //  Enforce that `earliest_exec_time` is <= `current_time_point()`
-   // //  Else fail.
-   // //  *** add test that triggers this failure of not meeting the time contraints. ***
-   // 
-   // check( prop.earliest_exec_time.value() <= time_point{current_time_point()}, "`earliest_exec_time` cannot execute just yet" );
-   // 
-   // auto [context_free_actions, actions] = _get_actions(prop.packed_transaction.data(), prop.packed_transaction.size());
-   // 
-   // for (const auto& act : context_free_actions) {
-   //    act.send();
-   // }
-   // 
-   // for (const auto& act : actions) {
-   //    act.send();
-   // }
+   /// TODO:
+   //  [X] Enforce that `earliest_exec_time` exists.
+   //  [X] Enforce that `earliest_exec_time` is <= `current_time_point()`
+   //  [X] Else fail.
+   //  [ ] *** add test that triggers this failure of not meeting the time contraints. ***
 
-   send_deferred( (uint128_t(proposer.value) << 64) | proposal_name.value, executer,
-                  prop.packed_transaction.data(), prop.packed_transaction.size() );
+   /// TODO For Monday:
+   // [ ]  Fix the suggestions Areg has made.
+   // [ ]  Make sure each test is consistently checking the same thing.
+   // [ ]  Do the same thing to the `eosio.wrap` tests.
+   // [ ]  Do any more refactoring that needs to be done.
+   // [ ]  Documentation: Make a short little tutorial on `deferred_transactions` and
+   //      inline actions to clear up any confusion.
+   // [X]  Make sure the pipelines are updated correctly.
+   
+   check( prop.earliest_exec_time.value() <= time_point{current_time_point()}, "`earliest_exec_time` cannot execute just yet" );
+   
+   auto [context_free_actions, actions] = _get_actions(prop.packed_transaction.data(), prop.packed_transaction.size());
+   
+   for (const auto& act : context_free_actions) {
+      act.send();
+   }
+   
+   for (const auto& act : actions) {
+      act.send();
+   }
 
    proptable.erase(prop);
 }

--- a/contracts/eosio.msig/src/eosio.msig.cpp
+++ b/contracts/eosio.msig/src/eosio.msig.cpp
@@ -246,14 +246,14 @@ std::vector<permission_level> get_approvals_and_adjust_table(name self, name pro
       table_op( approval_table, approval_table_iter );
    } else {
       old_approvals old_approval_table( self, proposer.value );
-      auto& old_approvals_iter = old_approval_table.get( proposal_name.value, "proposal not found" );
-      for ( const auto& permission : old_approvals_iter.provided_approvals ) {
+      const auto& old_approvals_obj = old_approval_table.get( proposal_name.value, "proposal not found" );
+      for ( const auto& permission : old_approvals_obj.provided_approvals ) {
          auto iter = invalidations_table.find( permission.actor.value );
          if ( iter == invalidations_table.end() ) {
             approvals_vector.push_back( permission );
          }
       }
-      table_op( old_approval_table, old_approvals_iter );
+      table_op( old_approval_table, old_approvals_obj );
    }
    return approvals_vector;
 }

--- a/contracts/eosio.msig/src/eosio.msig.cpp
+++ b/contracts/eosio.msig/src/eosio.msig.cpp
@@ -91,10 +91,7 @@ void multisig::approve( name proposer, name proposal_name, permission_level leve
 
    transaction_header trx_header = get_trx_header(prop.packed_transaction.data(), prop.packed_transaction.size());
 
-   eosio::print("here0\n");
    if ( prop.earliest_exec_time.has_value() ) {
-      eosio::print("here1\n");
-      eosio::print(prop.earliest_exec_time.has_value());
       if ( prop.earliest_exec_time.value().has_value() ) {
          return;
       } else {
@@ -102,12 +99,6 @@ void multisig::approve( name proposer, name proposal_name, permission_level leve
          if ( approvals_satisfy_trx_authorization(proposer, proposal_name, prop.packed_transaction, table_op) ) {
             auto prop_it = proptable.find( proposal_name.value );
             proptable.modify( prop_it, proposer, [&]( auto& p ) {
-               eosio::print("************\n");
-               eosio::print(current_time_point().sec_since_epoch());
-               eosio::print("\n");
-               eosio::print(trx_header.delay_sec.value);
-               eosio::print("\n************\n");
-               eosio::print_f("approve: current_time = %, delay_sec = %\n", current_time_point().sec_since_epoch(), trx_header.delay_sec.value );
                p.earliest_exec_time = std::optional<time_point>{ current_time_point() + eosio::seconds(trx_header.delay_sec.value)};
             });
          } else {
@@ -202,11 +193,6 @@ void multisig::exec( name proposer, name proposal_name, name executer ) {
    check( ok, "transaction authorization failed" );
 
    if ( prop.earliest_exec_time.has_value() && prop.earliest_exec_time.value().has_value() ) {
-      eosio::print("-------\n");
-      eosio::print(prop.earliest_exec_time.value().value().sec_since_epoch());
-      eosio::print("\n");
-      eosio::print(current_time_point().sec_since_epoch());
-      eosio::print("\n-------\n");
       check( prop.earliest_exec_time.value().value() <= current_time_point(), "too early to execute" );
    } else {
       check( trx_header.delay_sec.value == 0, "old proposals are not allowed to have non-zero `delay_sec`; cancel and retry" );

--- a/contracts/eosio.msig/src/eosio.msig.cpp
+++ b/contracts/eosio.msig/src/eosio.msig.cpp
@@ -191,23 +191,26 @@ void multisig::exec( name proposer, name proposal_name, name executer ) {
    auto table_op = [](auto&& table, auto&& table_iter) { table.erase(table_iter); };
    check( _resolve_approvals(proposer, proposal_name, prop, table_op), "transaction authorization failed" );
 
-   /// TODO:
-   //  Enforce that `earliest_exec_time` exists.
-   //  Enforce that `earliest_exec_time` is <= `current_time_point()`
-   //  Else fail.
-   //  *** add test that triggers this failure of not meeting the time contraints. ***
+   // /// TODO:
+   // //  Enforce that `earliest_exec_time` exists.
+   // //  Enforce that `earliest_exec_time` is <= `current_time_point()`
+   // //  Else fail.
+   // //  *** add test that triggers this failure of not meeting the time contraints. ***
+   // 
+   // check( prop.earliest_exec_time.value() <= time_point{current_time_point()}, "`earliest_exec_time` cannot execute just yet" );
+   // 
+   // auto [context_free_actions, actions] = _get_actions(prop.packed_transaction.data(), prop.packed_transaction.size());
+   // 
+   // for (const auto& act : context_free_actions) {
+   //    act.send();
+   // }
+   // 
+   // for (const auto& act : actions) {
+   //    act.send();
+   // }
 
-   check( prop.earliest_exec_time.value() <= time_point{current_time_point()}, "`earliest_exec_time` cannot execute just yet" );
-
-   auto [context_free_actions, actions] = _get_actions(prop.packed_transaction.data(), prop.packed_transaction.size());
-
-   for (const auto& act : context_free_actions) {
-      act.send();
-   }
-
-   for (const auto& act : actions) {
-      act.send();
-   }
+   send_deferred( (uint128_t(proposer.value) << 64) | proposal_name.value, executer,
+                  prop.packed_transaction.data(), prop.packed_transaction.size() );
 
    proptable.erase(prop);
 }

--- a/contracts/eosio.msig/src/eosio.msig.cpp
+++ b/contracts/eosio.msig/src/eosio.msig.cpp
@@ -19,12 +19,10 @@ void multisig::propose( ignore<name> proposer,
    _ds >> _proposer >> _proposal_name >> _requested;
 
    const char* trx_pos = _ds.pos();
-   size_t size    = _ds.remaining();
-   _ds >> _trx_header;
-
+   size_t size = _ds.remaining();
+   _trx_header = _get_trx_header(trx_pos, size);
    require_auth( _proposer );
    check( _trx_header.expiration >= eosio::time_point_sec(current_time_point()), "transaction expired" );
-   //check( trx_header.actions.size() > 0, "transaction must have at least one action" );
 
    proposals proptable( get_self(), _proposer.value );
    check( proptable.find( _proposal_name.value ) == proptable.end(), "proposal with the same name exists" );
@@ -42,13 +40,14 @@ void multisig::propose( ignore<name> proposer,
    pkd_trans.resize(size);
    memcpy((char*)pkd_trans.data(), trx_pos, size);
    proptable.emplace( _proposer, [&]( auto& prop ) {
-      prop.proposal_name       = _proposal_name;
-      prop.packed_transaction  = pkd_trans;
+      prop.proposal_name      = _proposal_name;
+      prop.packed_transaction = pkd_trans;
+      prop.earliest_exec_time = time_point{eosio::microseconds::maximum()};
    });
 
    approvals apptable( get_self(), _proposer.value );
    apptable.emplace( _proposer, [&]( auto& a ) {
-      a.proposal_name       = _proposal_name;
+      a.proposal_name = _proposal_name;
       a.requested_approvals.reserve( _requested.size() );
       for ( auto& level : _requested ) {
          a.requested_approvals.push_back( approval{ level, time_point{ microseconds{0} } } );
@@ -61,9 +60,10 @@ void multisig::approve( name proposer, name proposal_name, permission_level leve
 {
    require_auth( level );
 
+   proposals proptable( get_self(), proposer.value );
+   auto& prop = proptable.get( proposal_name.value, "proposal not found" );
+
    if( proposal_hash ) {
-      proposals proptable( get_self(), proposer.value );
-      auto& prop = proptable.get( proposal_name.value, "proposal not found" );
       assert_sha256( prop.packed_transaction.data(), prop.packed_transaction.size(), *proposal_hash );
    }
 
@@ -74,9 +74,9 @@ void multisig::approve( name proposer, name proposal_name, permission_level leve
       check( itr != apps_it->requested_approvals.end(), "approval is not on the list of requested approvals" );
 
       apptable.modify( apps_it, proposer, [&]( auto& a ) {
-            a.provided_approvals.push_back( approval{ level, current_time_point() } );
-            a.requested_approvals.erase( itr );
-         });
+         a.provided_approvals.push_back( approval{ level, current_time_point() } );
+         a.requested_approvals.erase( itr );
+      });
    } else {
       old_approvals old_apptable( get_self(), proposer.value );
       auto& apps = old_apptable.get( proposal_name.value, "proposal not found" );
@@ -85,33 +85,74 @@ void multisig::approve( name proposer, name proposal_name, permission_level leve
       check( itr != apps.requested_approvals.end(), "approval is not on the list of requested approvals" );
 
       old_apptable.modify( apps, proposer, [&]( auto& a ) {
-            a.provided_approvals.push_back( level );
-            a.requested_approvals.erase( itr );
-         });
+         a.provided_approvals.push_back( level );
+         a.requested_approvals.erase( itr );
+      });
+   }
+    
+   transaction_header trx_header = _get_trx_header(prop.packed_transaction.data(), prop.packed_transaction.size());
+   check( prop.earliest_exec_time.has_value() || (trx_header.delay_sec.value == 0), "no `earliest_exec_time` and no `delay_sec` is not 0" );
+   
+   if (prop.earliest_exec_time.has_value()) {
+      if ( prop.earliest_exec_time.value() != time_point{eosio::microseconds::maximum()} ) {
+         return;
+      } else {
+         auto table_op = [](auto&&, auto&&){};
+         if ( _resolve_approvals(proposer, proposal_name, prop, table_op) ) {
+            auto prop_it = proptable.find( proposal_name.value );
+            proptable.modify( prop_it, proposer, [&]( auto& p ) {
+               p.earliest_exec_time = current_time_point() + eosio::seconds(trx_header.delay_sec.value);
+            });
+         } else {
+            return;
+         }
+      }
    }
 }
 
 void multisig::unapprove( name proposer, name proposal_name, permission_level level ) {
    require_auth( level );
-
+   
    approvals apptable( get_self(), proposer.value );
    auto apps_it = apptable.find( proposal_name.value );
    if ( apps_it != apptable.end() ) {
       auto itr = std::find_if( apps_it->provided_approvals.begin(), apps_it->provided_approvals.end(), [&](const approval& a) { return a.level == level; } );
       check( itr != apps_it->provided_approvals.end(), "no approval previously granted" );
       apptable.modify( apps_it, proposer, [&]( auto& a ) {
-            a.requested_approvals.push_back( approval{ level, current_time_point() } );
-            a.provided_approvals.erase( itr );
-         });
+         a.requested_approvals.push_back( approval{ level, current_time_point() } );
+         a.provided_approvals.erase( itr );
+      });
    } else {
       old_approvals old_apptable( get_self(), proposer.value );
       auto& apps = old_apptable.get( proposal_name.value, "proposal not found" );
       auto itr = std::find( apps.provided_approvals.begin(), apps.provided_approvals.end(), level );
       check( itr != apps.provided_approvals.end(), "no approval previously granted" );
       old_apptable.modify( apps, proposer, [&]( auto& a ) {
-            a.requested_approvals.push_back( level );
-            a.provided_approvals.erase( itr );
-         });
+         a.requested_approvals.push_back( level );
+         a.provided_approvals.erase( itr );
+      });
+   }
+   
+   proposals proptable( get_self(), proposer.value );
+   auto& prop = proptable.get( proposal_name.value, "proposal not found" );
+
+   transaction_header trx_header = _get_trx_header(prop.packed_transaction.data(), prop.packed_transaction.size());
+   check( prop.earliest_exec_time.has_value() || (trx_header.delay_sec.value == 0), "no `earliest_exec_time` and no `delay_sec` is not 0" );
+
+   if (prop.earliest_exec_time.has_value()) {
+      if ( prop.earliest_exec_time.value() == time_point{eosio::microseconds::maximum()} ) {
+         return; 
+      } else {
+         auto table_op = [](auto&&, auto&&){};
+         if ( _resolve_approvals(proposer, proposal_name, prop, table_op) ) {
+            return;
+         } else {
+            auto prop_it = proptable.find( proposal_name.value );
+            proptable.modify( prop_it, proposer, [&]( auto& p ) {
+               p.earliest_exec_time = time_point{eosio::microseconds::maximum()};
+            });
+         }
+      }
    }
 }
 
@@ -149,38 +190,14 @@ void multisig::exec( name proposer, name proposal_name, name executer ) {
    ds >> trx_header;
    check( trx_header.expiration >= eosio::time_point_sec(current_time_point()), "transaction expired" );
 
-   approvals apptable( get_self(), proposer.value );
-   auto apps_it = apptable.find( proposal_name.value );
-   std::vector<permission_level> approvals;
-   invalidations inv_table( get_self(), get_self().value );
-   if ( apps_it != apptable.end() ) {
-      approvals.reserve( apps_it->provided_approvals.size() );
-      for ( auto& p : apps_it->provided_approvals ) {
-         auto it = inv_table.find( p.level.actor.value );
-         if ( it == inv_table.end() || it->last_invalidation_time < p.time ) {
-            approvals.push_back(p.level);
-         }
-      }
-      apptable.erase(apps_it);
-   } else {
-      old_approvals old_apptable( get_self(), proposer.value );
-      auto& apps = old_apptable.get( proposal_name.value, "proposal not found" );
-      for ( auto& level : apps.provided_approvals ) {
-         auto it = inv_table.find( level.actor.value );
-         if ( it == inv_table.end() ) {
-            approvals.push_back( level );
-         }
-      }
-      old_apptable.erase(apps);
-   }
-   auto packed_provided_approvals = pack(approvals);
-   auto res =  check_transaction_authorization(
-                  prop.packed_transaction.data(), prop.packed_transaction.size(),
-                  (const char*)0, 0,
-                  packed_provided_approvals.data(), packed_provided_approvals.size()
-               );
+   auto table_op = [](auto&& table, auto&& table_iter) { table.erase(table_iter); };
+   check( _resolve_approvals(proposer, proposal_name, prop, table_op), "transaction authorization failed" );
 
-   check( res > 0, "transaction authorization failed" );
+   /// TODO:
+   //  Enforce that `earliest_exec_time` exists.
+   //  Enforce that `earliest_exec_time` is <= `current_time_point()`
+   //  Else fail.
+   //  *** add test that triggers this failure of not meeting the time contraints. ***
 
    send_deferred( (uint128_t(proposer.value) << 64) | proposal_name.value, executer,
                   prop.packed_transaction.data(), prop.packed_transaction.size() );

--- a/contracts/eosio.system/src/delegate_bandwidth.cpp
+++ b/contracts/eosio.system/src/delegate_bandwidth.cpp
@@ -323,18 +323,18 @@ namespace eosiosystem {
             } // else stake increase requested with no existing row in refunds_tbl -> nothing to do with refunds_tbl
          } /// end if is_delegating_to_self || is_undelegating
 
-         if ( need_deferred_trx ) {
-            eosio::transaction out;
-            out.actions.emplace_back( permission_level{from, active_permission},
-                                      get_self(), "refund"_n,
-                                      from
-            );
-            out.delay_sec = refund_delay_sec;
-            eosio::cancel_deferred( from.value ); // TODO: Remove this line when replacing deferred trxs is fixed
-            out.send( from.value, from, true );
-         } else {
-            eosio::cancel_deferred( from.value );
-         }
+         // if ( need_deferred_trx ) {
+         //    eosio::transaction out;
+         //    out.actions.emplace_back( permission_level{from, active_permission},
+         //                              get_self(), "refund"_n,
+         //                              from
+         //    );
+         //    out.delay_sec = refund_delay_sec;
+         //    eosio::cancel_deferred( from.value ); // TODO: Remove this line when replacing deferred trxs is fixed
+         //    out.send( from.value, from, true );
+         // } else {
+         //    eosio::cancel_deferred( from.value );
+         // }
 
          auto transfer_amount = net_balance + cpu_balance;
          if ( 0 < transfer_amount.amount ) {

--- a/contracts/eosio.system/src/delegate_bandwidth.cpp
+++ b/contracts/eosio.system/src/delegate_bandwidth.cpp
@@ -298,11 +298,7 @@ namespace eosiosystem {
 
                if ( req->is_empty() ) {
                   refunds_tbl.erase( req );
-                  // // // need_deferred_trx = false;
                }
-               // // // else {
-               // // //    need_deferred_trx = true;
-               // // // }
             } else if ( net_balance.amount < 0 || cpu_balance.amount < 0 ) { //need to create refund
                refunds_tbl.emplace( from, [&]( refund_request& r ) {
                   r.owner = from;
@@ -320,22 +316,8 @@ namespace eosiosystem {
                   }
                   r.request_time = current_time_point();
                });
-               // // // need_deferred_trx = true;
             } // else stake increase requested with no existing row in refunds_tbl -> nothing to do with refunds_tbl
          } /// end if is_delegating_to_self || is_undelegating
-
-         // // // if ( need_deferred_trx ) {
-         // // //    eosio::transaction out;
-         // // //    out.actions.emplace_back( permission_level{from, active_permission},
-         // // //                              get_self(), "refund"_n,
-         // // //                              from
-         // // //    );
-         // // //    out.delay_sec = refund_delay_sec;
-         // // //    eosio::cancel_deferred( from.value ); // TODO: Remove this line when replacing deferred trxs is fixed
-         // // //    out.send( from.value, from, true );
-         // // // } else {
-         // // //    eosio::cancel_deferred( from.value );
-         // // // }
 
          auto transfer_amount = net_balance + cpu_balance;
          if ( 0 < transfer_amount.amount ) {

--- a/contracts/eosio.system/src/delegate_bandwidth.cpp
+++ b/contracts/eosio.system/src/delegate_bandwidth.cpp
@@ -263,7 +263,7 @@ namespace eosiosystem {
          //create/update/delete refund
          auto net_balance = stake_net_delta;
          auto cpu_balance = stake_cpu_delta;
-         bool need_deferred_trx = false;
+         // // // bool need_deferred_trx = false;
 
 
          // net and cpu are same sign by assertions in delegatebw and undelegatebw
@@ -298,10 +298,11 @@ namespace eosiosystem {
 
                if ( req->is_empty() ) {
                   refunds_tbl.erase( req );
-                  need_deferred_trx = false;
-               } else {
-                  need_deferred_trx = true;
+                  // // // need_deferred_trx = false;
                }
+               // // // else {
+               // // //    need_deferred_trx = true;
+               // // // }
             } else if ( net_balance.amount < 0 || cpu_balance.amount < 0 ) { //need to create refund
                refunds_tbl.emplace( from, [&]( refund_request& r ) {
                   r.owner = from;
@@ -319,22 +320,22 @@ namespace eosiosystem {
                   }
                   r.request_time = current_time_point();
                });
-               need_deferred_trx = true;
+               // // // need_deferred_trx = true;
             } // else stake increase requested with no existing row in refunds_tbl -> nothing to do with refunds_tbl
          } /// end if is_delegating_to_self || is_undelegating
 
-         // if ( need_deferred_trx ) {
-         //    eosio::transaction out;
-         //    out.actions.emplace_back( permission_level{from, active_permission},
-         //                              get_self(), "refund"_n,
-         //                              from
-         //    );
-         //    out.delay_sec = refund_delay_sec;
-         //    eosio::cancel_deferred( from.value ); // TODO: Remove this line when replacing deferred trxs is fixed
-         //    out.send( from.value, from, true );
-         // } else {
-         //    eosio::cancel_deferred( from.value );
-         // }
+         // // // if ( need_deferred_trx ) {
+         // // //    eosio::transaction out;
+         // // //    out.actions.emplace_back( permission_level{from, active_permission},
+         // // //                              get_self(), "refund"_n,
+         // // //                              from
+         // // //    );
+         // // //    out.delay_sec = refund_delay_sec;
+         // // //    eosio::cancel_deferred( from.value ); // TODO: Remove this line when replacing deferred trxs is fixed
+         // // //    out.send( from.value, from, true );
+         // // // } else {
+         // // //    eosio::cancel_deferred( from.value );
+         // // // }
 
          auto transfer_amount = net_balance + cpu_balance;
          if ( 0 < transfer_amount.amount ) {

--- a/contracts/eosio.system/src/delegate_bandwidth.cpp
+++ b/contracts/eosio.system/src/delegate_bandwidth.cpp
@@ -263,8 +263,6 @@ namespace eosiosystem {
          //create/update/delete refund
          auto net_balance = stake_net_delta;
          auto cpu_balance = stake_cpu_delta;
-         // // // bool need_deferred_trx = false;
-
 
          // net and cpu are same sign by assertions in delegatebw and undelegatebw
          // redundant assertion also at start of changebw to protect against misuse of changebw

--- a/contracts/eosio.system/src/name_bidding.cpp
+++ b/contracts/eosio.system/src/name_bidding.cpp
@@ -49,15 +49,15 @@ namespace eosiosystem {
                });
          }
 
-         eosio::transaction t;
-         t.actions.emplace_back( permission_level{current->high_bidder, active_permission},
-                                 get_self(), "bidrefund"_n,
-                                 std::make_tuple( current->high_bidder, newname )
-         );
-         t.delay_sec = 0;
-         uint128_t deferred_id = (uint128_t(newname.value) << 64) | current->high_bidder.value;
-         eosio::cancel_deferred( deferred_id );
-         t.send( deferred_id, bidder );
+         // eosio::transaction t;
+         // t.actions.emplace_back( permission_level{current->high_bidder, active_permission},
+         //                         get_self(), "bidrefund"_n,
+         //                         std::make_tuple( current->high_bidder, newname )
+         // );
+         // t.delay_sec = 0;
+         // uint128_t deferred_id = (uint128_t(newname.value) << 64) | current->high_bidder.value;
+         // eosio::cancel_deferred( deferred_id );
+         // t.send( deferred_id, bidder );
 
          bids.modify( current, bidder, [&]( auto& b ) {
             b.high_bidder = bidder;

--- a/contracts/eosio.system/src/name_bidding.cpp
+++ b/contracts/eosio.system/src/name_bidding.cpp
@@ -49,16 +49,6 @@ namespace eosiosystem {
                });
          }
 
-         // eosio::transaction t;
-         // t.actions.emplace_back( permission_level{current->high_bidder, active_permission},
-         //                         get_self(), "bidrefund"_n,
-         //                         std::make_tuple( current->high_bidder, newname )
-         // );
-         // t.delay_sec = 0;
-         // uint128_t deferred_id = (uint128_t(newname.value) << 64) | current->high_bidder.value;
-         // eosio::cancel_deferred( deferred_id );
-         // t.send( deferred_id, bidder );
-
          bids.modify( current, bidder, [&]( auto& b ) {
             b.high_bidder = bidder;
             b.high_bid = bid.amount;

--- a/contracts/eosio.wrap/include/eosio.wrap/eosio.wrap.hpp
+++ b/contracts/eosio.wrap/include/eosio.wrap/eosio.wrap.hpp
@@ -33,7 +33,7 @@ namespace eosio {
           * @pre
           */
          [[eosio::action]]
-         void exec( ignore<name> executer, ignore<transaction> trx );
+         void exec( name executer, transaction trx );
 
          using exec_action = eosio::action_wrapper<"exec"_n, &wrap::exec>;
    };

--- a/contracts/eosio.wrap/src/eosio.wrap.cpp
+++ b/contracts/eosio.wrap/src/eosio.wrap.cpp
@@ -2,15 +2,14 @@
 
 namespace eosio {
 
-void wrap::exec( ignore<name>, ignore<transaction> ) {
+void wrap::exec( name executer, transaction trx) {
    require_auth( get_self() );
-
-   name executer;
-   _ds >> executer;
-
    require_auth( executer );
 
-   send_deferred( (uint128_t(executer.value) << 64) | (uint64_t)current_time_point().time_since_epoch().count(), executer, _ds.pos(), _ds.remaining() );
+   // Inline execution of the wrapped transaction.
+   for (const auto& act: trx.actions) {
+      act.send();
+   }
 }
 
 } /// namespace eosio

--- a/contracts/eosio.wrap/src/eosio.wrap.cpp
+++ b/contracts/eosio.wrap/src/eosio.wrap.cpp
@@ -6,6 +6,8 @@ void wrap::exec( name executer, transaction trx) {
    require_auth( get_self() );
    require_auth( executer );
 
+   check( trx.context_free_actions.empty(), "not allowed to `exec` a transaction with context-free actions" );
+
    // Inline execution of the wrapped transaction.
    for (const auto& act: trx.actions) {
       act.send();

--- a/pipeline.jsonc
+++ b/pipeline.jsonc
@@ -5,7 +5,7 @@
         "dependencies": // dependencies to pull for a build of contracts, by branch, tag, or commit hash
         {
             "eosio": "329071ae8ae7c8e467f42079ebdb09e675d7e702", // eventually update to release/2.0.x
-            "eosio.cdt": "aad0c4729b848c9cbe409aa1fdd917797a4d91e7" // eventually update to release/1.7.x
+            "eosio.cdt": "09d5953997ad4558ee41cdbd1604e89be88f068e" // eventually update to release/1.7.x
         }
     }
 }

--- a/pipeline.jsonc
+++ b/pipeline.jsonc
@@ -4,7 +4,7 @@
         "pipeline-branch": "master",
         "dependencies": // dependencies to pull for a build of contracts, by branch, tag, or commit hash
         {
-            "eosio": "329071ae8ae7c8e467f42079ebdb09e675d7e702", // eventually update to release/2.0.x
+            "eosio": "b9db0a220da55a7642bfb4b5b8b9dfc355f47524", // eventually update to release/2.0.x
             "eosio.cdt": "7523d444de9803a6f960543c993ca5321250d72f" // eventually update to release/1.7.x
         }
     }

--- a/pipeline.jsonc
+++ b/pipeline.jsonc
@@ -4,7 +4,7 @@
         "pipeline-branch": "master",
         "dependencies": // dependencies to pull for a build of contracts, by branch, tag, or commit hash
         {
-            "eosio": "b9db0a220da55a7642bfb4b5b8b9dfc355f47524", // eventually update to release/2.0.x
+            "eosio": "9dacbc26abfd91cf19f957be8af2252d64e7e3a9", // eventually update to release/2.0.x
             "eosio.cdt": "7523d444de9803a6f960543c993ca5321250d72f" // eventually update to release/1.7.x
         }
     }

--- a/pipeline.jsonc
+++ b/pipeline.jsonc
@@ -5,7 +5,7 @@
         "dependencies": // dependencies to pull for a build of contracts, by branch, tag, or commit hash
         {
             "eosio": "329071ae8ae7c8e467f42079ebdb09e675d7e702", // eventually update to release/2.0.x
-            "eosio.cdt": "09d5953997ad4558ee41cdbd1604e89be88f068e" // eventually update to release/1.7.x
+            "eosio.cdt": "f344026681da23bddbfc7902798068968fd9e7dc" // eventually update to release/1.7.x
         }
     }
 }

--- a/pipeline.jsonc
+++ b/pipeline.jsonc
@@ -5,7 +5,7 @@
         "dependencies": // dependencies to pull for a build of contracts, by branch, tag, or commit hash
         {
             "eosio": "329071ae8ae7c8e467f42079ebdb09e675d7e702", // eventually update to release/2.0.x
-            "eosio.cdt": "f344026681da23bddbfc7902798068968fd9e7dc" // eventually update to release/1.7.x
+            "eosio.cdt": "7523d444de9803a6f960543c993ca5321250d72f" // eventually update to release/1.7.x
         }
     }
 }

--- a/tests/eosio.msig_tests.cpp
+++ b/tests/eosio.msig_tests.cpp
@@ -245,7 +245,7 @@ BOOST_FIXTURE_TEST_CASE( check_earliest_exec_time_for_approve_and_unapprove, eos
    // `delay_sec` field of the `transaction_header` in the initial proposal), if
    // the specified authorizations are met (in this case they are).
    BOOST_REQUIRE_EQUAL( calculate_test_exec_time(delay_sec), get_earliest_exec_time(N(alice), N(first))->sec_since_epoch() );
-   
+
    transaction_trace_ptr trx_trace;
    trx_trace = push_action( N(alice), N(unapprove), mvo()
                              ("proposer",      "alice")
@@ -256,13 +256,13 @@ BOOST_FIXTURE_TEST_CASE( check_earliest_exec_time_for_approve_and_unapprove, eos
    // constructed state of a `std::optional` if the specified authorizations are
    // not met.
    BOOST_REQUIRE_EQUAL( fc::optional<time_point>{}.valid(), get_earliest_exec_time(N(alice), N(first)).valid() );
-   
+
    wdump((fc::json::to_pretty_string(trx_trace)));
-   
+
    BOOST_REQUIRE( bool(trx_trace) );
    BOOST_REQUIRE_EQUAL( transaction_receipt::executed, trx_trace->receipt->status );
    BOOST_REQUIRE_EQUAL( 1, trx_trace->action_traces.size() );
-   
+
    BOOST_REQUIRE_EQUAL( fc::unsigned_int{1}, trx_trace->action_traces[0].action_ordinal );
    BOOST_REQUIRE_EQUAL( fc::unsigned_int{0}, trx_trace->action_traces[0].creator_action_ordinal );
    BOOST_REQUIRE_EQUAL( fc::unsigned_int{0}, trx_trace->action_traces[0].closest_unnotified_ancestor_action_ordinal );

--- a/tests/eosio.msig_tests.cpp
+++ b/tests/eosio.msig_tests.cpp
@@ -445,13 +445,13 @@ BOOST_FIXTURE_TEST_CASE( propose_with_wrong_requested_auth, eosio_msig_tester ) 
 
 
 BOOST_FIXTURE_TEST_CASE( big_transaction, eosio_msig_tester ) try {
+   //change `default_max_inline_action_size` to 512 KB
    create_account(N(eosio.bios));
    set_code(N(eosio.bios), contracts::bios_wasm());
    set_abi(N(eosio.bios), contracts::bios_abi().data());
 
    produce_blocks();
 
-   // Change `default_max_inline_action_size` to 512 KB.
    eosio::chain::chain_config params = control->get_global_properties().configuration;
    params.max_inline_action_size = 512 * 1024;
    base_tester::push_action( config::system_account_name, N(setparams), config::system_account_name, mutable_variant_object()

--- a/tests/eosio.msig_tests.cpp
+++ b/tests/eosio.msig_tests.cpp
@@ -287,8 +287,8 @@ BOOST_FIXTURE_TEST_CASE( propose_approve_by_two, eosio_msig_tester ) try {
                              ("executer",      "alice")
    );
 
-   BOOST_REQUIRE( trx_trace->receipt.valid() );
    BOOST_REQUIRE( bool(trx_trace) );
+   BOOST_REQUIRE( trx_trace->receipt.valid() );
    BOOST_REQUIRE_EQUAL( transaction_receipt::executed, trx_trace->receipt->status );
    BOOST_REQUIRE_EQUAL( 2, trx_trace->action_traces.size() );
 
@@ -400,8 +400,8 @@ BOOST_FIXTURE_TEST_CASE( big_transaction, eosio_msig_tester ) try {
                              ("executer",      "alice")
    );
 
-   BOOST_REQUIRE( trx_trace->receipt.valid() );
    BOOST_REQUIRE( bool(trx_trace) );
+   BOOST_REQUIRE( trx_trace->receipt.valid() );
    BOOST_REQUIRE_EQUAL( transaction_receipt::executed, trx_trace->receipt->status );
    BOOST_REQUIRE_EQUAL( 2, trx_trace->action_traces.size() );
 
@@ -543,8 +543,8 @@ BOOST_FIXTURE_TEST_CASE( update_system_contract_all_approve, eosio_msig_tester )
                              ("executer",      "alice")
    );
 
-   BOOST_REQUIRE( trx_trace->receipt.valid() );
    BOOST_REQUIRE( bool(trx_trace) );
+   BOOST_REQUIRE( trx_trace->receipt.valid() );
    BOOST_REQUIRE_EQUAL( transaction_receipt::executed, trx_trace->receipt->status );
    BOOST_REQUIRE_EQUAL( 2, trx_trace->action_traces.size() );
 
@@ -693,8 +693,8 @@ BOOST_FIXTURE_TEST_CASE( update_system_contract_major_approve, eosio_msig_tester
                          ("executer",      "apple")
    );
 
-   BOOST_REQUIRE( trx_trace->receipt.valid() );
    BOOST_REQUIRE( bool(trx_trace) );
+   BOOST_REQUIRE( trx_trace->receipt.valid() );
    BOOST_REQUIRE_EQUAL( transaction_receipt::executed, trx_trace->receipt->status );
    BOOST_REQUIRE_EQUAL( 2, trx_trace->action_traces.size() );
 
@@ -806,8 +806,8 @@ BOOST_FIXTURE_TEST_CASE( propose_invalidate_approve, eosio_msig_tester ) try {
                              ("executer",      "bob")
    );
 
-   BOOST_REQUIRE( trx_trace->receipt.valid() );
    BOOST_REQUIRE( bool(trx_trace) );
+   BOOST_REQUIRE( trx_trace->receipt.valid() );
    BOOST_REQUIRE_EQUAL( transaction_receipt::executed, trx_trace->receipt->status );
    BOOST_REQUIRE_EQUAL( 2, trx_trace->action_traces.size() );
 
@@ -862,8 +862,8 @@ BOOST_FIXTURE_TEST_CASE( approve_execute_old, eosio_msig_tester ) try {
                              ("executer",      "alice")
    );
 
-   BOOST_REQUIRE( trx_trace->receipt.valid() );
    BOOST_REQUIRE( bool(trx_trace) );
+   BOOST_REQUIRE( trx_trace->receipt.valid() );
    BOOST_REQUIRE_EQUAL( transaction_receipt::executed, trx_trace->receipt->status );
    BOOST_REQUIRE_EQUAL( 2, trx_trace->action_traces.size() );
 
@@ -976,8 +976,8 @@ BOOST_FIXTURE_TEST_CASE( approve_by_two_old, eosio_msig_tester ) try {
                              ("executer",      "alice")
    );
 
-   BOOST_REQUIRE( trx_trace->receipt.valid() );
    BOOST_REQUIRE( bool(trx_trace) );
+   BOOST_REQUIRE( trx_trace->receipt.valid() );
    BOOST_REQUIRE_EQUAL( transaction_receipt::executed, trx_trace->receipt->status );
    BOOST_REQUIRE_EQUAL( 2, trx_trace->action_traces.size() );
 
@@ -1038,8 +1038,8 @@ BOOST_FIXTURE_TEST_CASE( approve_with_hash, eosio_msig_tester ) try {
                              ("executer",      "alice")
    );
 
-   BOOST_REQUIRE( trx_trace->receipt.valid() );
    BOOST_REQUIRE( bool(trx_trace) );
+   BOOST_REQUIRE( trx_trace->receipt.valid() );
    BOOST_REQUIRE_EQUAL( transaction_receipt::executed, trx_trace->receipt->status );
    BOOST_REQUIRE_EQUAL( 2, trx_trace->action_traces.size() );
 
@@ -1147,8 +1147,8 @@ BOOST_FIXTURE_TEST_CASE( check_earliest_exec_time_for_approve_and_unapprove, eos
    // not met.
    BOOST_REQUIRE_EQUAL( fc::optional<time_point>{}.valid(), get_earliest_exec_time(N(alice), N(first)).valid() );
 
-   BOOST_REQUIRE( trx_trace->receipt.valid() );
    BOOST_REQUIRE( bool(trx_trace) );
+   BOOST_REQUIRE( trx_trace->receipt.valid() );
    BOOST_REQUIRE_EQUAL( transaction_receipt::executed, trx_trace->receipt->status );
    BOOST_REQUIRE_EQUAL( 1, trx_trace->action_traces.size() );
 
@@ -1214,8 +1214,8 @@ BOOST_FIXTURE_TEST_CASE( check_earliest_exec_time_for_approve_and_unapprove_mult
    );
    BOOST_REQUIRE_EQUAL( fc::optional<time_point>{}.valid(), get_earliest_exec_time(N(alice), N(first)).valid() );
 
-   BOOST_REQUIRE( trx_trace->receipt.valid() );
    BOOST_REQUIRE( bool(trx_trace) );
+   BOOST_REQUIRE( trx_trace->receipt.valid() );
    BOOST_REQUIRE_EQUAL( transaction_receipt::executed, trx_trace->receipt->status );
    BOOST_REQUIRE_EQUAL( 1, trx_trace->action_traces.size() );
 
@@ -1319,8 +1319,8 @@ BOOST_FIXTURE_TEST_CASE( unnecessary_approve_logic, eosio_msig_tester ) try {
                              ("executer",      "alice")
    );
 
-   BOOST_REQUIRE( trx_trace->receipt.valid() );
    BOOST_REQUIRE( bool(trx_trace) );
+   BOOST_REQUIRE( trx_trace->receipt.valid() );
    BOOST_REQUIRE_EQUAL( transaction_receipt::executed, trx_trace->receipt->status );
    BOOST_REQUIRE_EQUAL( 2, trx_trace->action_traces.size() );
 

--- a/tests/eosio.msig_tests.cpp
+++ b/tests/eosio.msig_tests.cpp
@@ -109,7 +109,7 @@ public:
                                 ("memo", "")
                                 );
    }
-    
+
    asset get_balance( const account_name& act ) {
       //return get_currency_balance( config::system_account_name, symbol(CORE_SYMBOL), act );
       //temporary code. current get_currency_balancy uses table name N(accounts) from currency.h
@@ -134,7 +134,7 @@ public:
       const auto& db  = control->db();
       const auto* tbl = db.find<table_id_object, by_code_scope_table>(boost::make_tuple(N(eosio.msig), proposer, N(proposal)));
       time_point result;
-   
+
       if (tbl) {
          const auto *obj = db.find<key_value_object, by_scope_primary>(boost::make_tuple(tbl->id, proposal_name.to_uint64_t()));
          if (obj) {
@@ -215,7 +215,7 @@ BOOST_FIXTURE_TEST_CASE( check_earliest_exec_time_for_approve_and_unapprove, eos
    static const uint32_t delay_sec = 1000;
    static const uint32_t maximum_sec_since_epoch = time_point{microseconds::maximum()}.sec_since_epoch();
    static const uint32_t time_point_delay = time_point{microseconds::maximum()}.sec_since_epoch();
-   
+
    auto trx = reqauth( N(alice), {permission_level{N(alice), config::active_name}}, abi_serializer_max_time );
    trx.delay_sec = delay_sec;
 
@@ -226,14 +226,14 @@ BOOST_FIXTURE_TEST_CASE( check_earliest_exec_time_for_approve_and_unapprove, eos
                   ("requested",     vector<permission_level>{{ N(alice), config::active_name }})
    );
    BOOST_REQUIRE_EQUAL( maximum_sec_since_epoch, get_earliest_exec_time( N(alice), N(first) ) );
-   
+
    push_action( N(alice), N(approve), mvo()
                   ("proposer",      "alice")
                   ("proposal_name", "first")
                   ("level",         permission_level{ N(alice), config::active_name })
    );
    BOOST_REQUIRE_EQUAL( time_point{control->pending_block_time() + fc::seconds(delay_sec)}.sec_since_epoch(), get_earliest_exec_time( N(alice), N(first) ) );
-   
+
    push_action( N(alice), N(unapprove), mvo()
                   ("proposer",      "alice")
                   ("proposal_name", "first")
@@ -246,7 +246,7 @@ BOOST_FIXTURE_TEST_CASE( check_earliest_exec_time_for_approve_and_unapprove_mult
    static const uint32_t delay_sec = 1000;
    static const uint32_t maximum_sec_since_epoch = time_point{microseconds::maximum()}.sec_since_epoch();
    static const uint32_t time_point_delay = time_point{microseconds::maximum()}.sec_since_epoch();
-   
+
    auto trx = reqauth( N(alice), {permission_level{N(alice), config::active_name},
                                   permission_level{N(bob), config::active_name},
                                   permission_level{N(carol), config::active_name}}, abi_serializer_max_time );
@@ -261,28 +261,28 @@ BOOST_FIXTURE_TEST_CASE( check_earliest_exec_time_for_approve_and_unapprove_mult
                                                              { N(carol), config::active_name }})
    );
    BOOST_REQUIRE_EQUAL( maximum_sec_since_epoch, get_earliest_exec_time( N(alice), N(first) ) );
-   
+
    push_action( N(alice), N(approve), mvo()
                   ("proposer",      "alice")
                   ("proposal_name", "first")
                   ("level",         permission_level{ N(alice), config::active_name })
    );
    BOOST_REQUIRE_EQUAL( maximum_sec_since_epoch, get_earliest_exec_time( N(alice), N(first) ) );
-   
+
    push_action( N(bob), N(approve), mvo()
                   ("proposer",      "alice")
                   ("proposal_name", "first")
                   ("level",         permission_level{ N(bob), config::active_name })
    );
    BOOST_REQUIRE_EQUAL( maximum_sec_since_epoch, get_earliest_exec_time( N(alice), N(first) ) );
-   
+
    push_action( N(carol), N(approve), mvo()
                   ("proposer",      "alice")
                   ("proposal_name", "first")
                   ("level",         permission_level{ N(carol), config::active_name })
    );
    BOOST_REQUIRE_EQUAL( time_point{control->pending_block_time() + fc::seconds(delay_sec)}.sec_since_epoch(), get_earliest_exec_time( N(alice), N(first) ) );
-   
+
    push_action( N(alice), N(unapprove), mvo()
                   ("proposer",      "alice")
                   ("proposal_name", "first")
@@ -894,20 +894,20 @@ BOOST_FIXTURE_TEST_CASE( approve_execute_old, eosio_msig_tester ) try {
                   ("proposal_name", "first")
                   ("level",         permission_level{ N(alice), config::active_name })
    );
-   
+
    transaction_trace_ptr trace;
    control->applied_transaction.connect(
    [&]( std::tuple<const transaction_trace_ptr&, const signed_transaction&> p ) {
       const auto& t = std::get<0>(p);
       if( t->scheduled ) { trace = t; }
    } );
-   
+
    push_action( N(alice), N(exec), mvo()
                   ("proposer",      "alice")
                   ("proposal_name", "first")
                   ("executer",      "alice")
    );
-   
+
    BOOST_REQUIRE( bool(trace) );
    BOOST_REQUIRE_EQUAL( 1, trace->action_traces.size() );
    BOOST_REQUIRE_EQUAL( transaction_receipt::executed, trace->receipt->status );

--- a/tests/eosio.msig_tests.cpp
+++ b/tests/eosio.msig_tests.cpp
@@ -870,34 +870,6 @@ BOOST_FIXTURE_TEST_CASE( propose_invalidate_approve, eosio_msig_tester ) try {
    BOOST_REQUIRE_EQUAL( transaction_receipt::executed, trace->receipt->status );
 } FC_LOG_AND_RETHROW()
 
-// BOOST_FIXTURE_TEST_CASE( approve_execute_old, eosio_msig_tester ) try {
-//    set_code( N(eosio.msig), contracts::util::msig_wasm_old() );
-//    set_abi( N(eosio.msig), contracts::util::msig_abi_old().data() );
-//    produce_blocks();
-// 
-//    //propose with old version of eosio.msig
-//    auto trx = reqauth( N(alice), {permission_level{N(alice), config::active_name}}, abi_serializer_max_time );
-//    push_action( N(alice), N(propose), mvo()
-//                   ("proposer",      "alice")
-//                   ("proposal_name", "first")
-//                   ("trx",           trx)
-//                   ("requested", vector<permission_level>{{ N(alice), config::active_name }})
-//    );
-//    
-//    set_code( N(eosio.msig), contracts::msig_wasm() );
-//    set_abi( N(eosio.msig), contracts::msig_abi().data() );
-//    produce_blocks();
-// 
-//    // assert due to the old table being incompatable with the new table
-//    BOOST_REQUIRE_EXCEPTION( push_action( N(alice), N(approve), mvo()
-//                                          ("proposer",      "alice")
-//                                          ("proposal_name", "first")
-//                                          ("level",         permission_level{ N(alice), config::active_name })
-//                             ), eosio_assert_message_exception,
-//                                eosio_assert_message_is("`earliest_exec_time` does not exist")
-//    );
-// } FC_LOG_AND_RETHROW()
-
 BOOST_FIXTURE_TEST_CASE( approve_execute_old, eosio_msig_tester ) try {
    set_code( N(eosio.msig), contracts::util::msig_wasm_old() );
    set_abi( N(eosio.msig), contracts::util::msig_abi_old().data() );
@@ -941,41 +913,6 @@ BOOST_FIXTURE_TEST_CASE( approve_execute_old, eosio_msig_tester ) try {
    BOOST_REQUIRE_EQUAL( transaction_receipt::executed, trace->receipt->status );
 } FC_LOG_AND_RETHROW()
 
-// BOOST_FIXTURE_TEST_CASE( approve_unapprove_old, eosio_msig_tester ) try {
-//    set_code( N(eosio.msig), contracts::util::msig_wasm_old() );
-//    set_abi( N(eosio.msig), contracts::util::msig_abi_old().data() );
-//    produce_blocks();
-// 
-//    //propose with old version of eosio.msig
-//    auto trx = reqauth( N(alice), {permission_level{N(alice), config::active_name}}, abi_serializer_max_time );
-//    push_action( N(alice), N(propose), mvo()
-//                   ("proposer",      "alice")
-//                   ("proposal_name", "first")
-//                   ("trx",           trx)
-//                   ("requested", vector<permission_level>{{ N(alice), config::active_name }})
-//    );
-// 
-//    //approve with old version
-//    push_action( N(alice), N(approve), mvo()
-//                   ("proposer",      "alice")
-//                   ("proposal_name", "first")
-//                   ("level",         permission_level{ N(alice), config::active_name })
-//    );
-//    
-//    set_code( N(eosio.msig), contracts::msig_wasm() );
-//    set_abi( N(eosio.msig), contracts::msig_abi().data() );
-//    produce_blocks();
-//    
-//    //assert due to the old table being incompatable with the new table
-//    BOOST_REQUIRE_EXCEPTION( push_action( N(alice), N(unapprove), mvo()
-//                                          ("proposer",      "alice")
-//                                          ("proposal_name", "first")
-//                                          ("level",         permission_level{ N(alice), config::active_name })
-//                             ), eosio_assert_message_exception,
-//                                eosio_assert_message_is("`earliest_exec_time` does not exist")
-//    );
-// } FC_LOG_AND_RETHROW()
-
 BOOST_FIXTURE_TEST_CASE( approve_unapprove_old, eosio_msig_tester ) try {
    set_code( N(eosio.msig), contracts::util::msig_wasm_old() );
    set_abi( N(eosio.msig), contracts::util::msig_abi_old().data() );
@@ -1018,51 +955,6 @@ BOOST_FIXTURE_TEST_CASE( approve_unapprove_old, eosio_msig_tester ) try {
    );
 
 } FC_LOG_AND_RETHROW()
-
-// BOOST_FIXTURE_TEST_CASE( approve_by_two_old, eosio_msig_tester ) try {
-//    set_code( N(eosio.msig), contracts::util::msig_wasm_old() );
-//    set_abi( N(eosio.msig), contracts::util::msig_abi_old().data() );
-//    produce_blocks();
-// 
-//    auto trx = reqauth( N(alice), vector<permission_level>{ { N(alice), config::active_name }, { N(bob), config::active_name } }, abi_serializer_max_time );
-//    push_action( N(alice), N(propose), mvo()
-//                   ("proposer",      "alice")
-//                   ("proposal_name", "first")
-//                   ("trx",           trx)
-//                   ("requested", vector<permission_level>{ { N(alice), config::active_name }, { N(bob), config::active_name } })
-//    );
-// 
-//    //approve by alice
-//    push_action( N(alice), N(approve), mvo()
-//                   ("proposer",      "alice")
-//                   ("proposal_name", "first")
-//                   ("level",         permission_level{ N(alice), config::active_name })
-//    );
-// 
-//    set_code( N(eosio.msig), contracts::msig_wasm() );
-//    set_abi( N(eosio.msig), contracts::msig_abi().data() );
-//    produce_blocks();
-//    
-//    //fail because approval by bob is missing
-//    BOOST_REQUIRE_EXCEPTION( push_action( N(alice), N(exec), mvo()
-//                                           ("proposer",      "alice")
-//                                           ("proposal_name", "first")
-//                                           ("executer",      "alice")
-//                             ),
-//                             eosio_assert_message_exception,
-//                             eosio_assert_message_is("transaction authorization failed")
-//    );
-//    
-//    //assert due to the old table being incompatable with the new table
-//    BOOST_REQUIRE_EXCEPTION( push_action( N(bob), N(approve), mvo()
-//                                          ("proposer",      "alice")
-//                                          ("proposal_name", "first")
-//                                          ("level",         permission_level{ N(bob), config::active_name })
-//                             ), eosio_assert_message_exception,
-//                                eosio_assert_message_is("`earliest_exec_time` does not exist")
-//    );
-// 
-// } FC_LOG_AND_RETHROW()
 
 BOOST_FIXTURE_TEST_CASE( approve_by_two_old, eosio_msig_tester ) try {
    set_code( N(eosio.msig), contracts::util::msig_wasm_old() );

--- a/tests/eosio.msig_tests.cpp
+++ b/tests/eosio.msig_tests.cpp
@@ -287,31 +287,30 @@ BOOST_FIXTURE_TEST_CASE( propose_approve_by_two, eosio_msig_tester ) try {
                              ("executer",      "alice")
    );
 
-   wdump((fc::json::to_pretty_string(trx_trace)));
-
+   BOOST_REQUIRE( trx_trace->receipt.valid() );
    BOOST_REQUIRE( bool(trx_trace) );
    BOOST_REQUIRE_EQUAL( transaction_receipt::executed, trx_trace->receipt->status );
    BOOST_REQUIRE_EQUAL( 2, trx_trace->action_traces.size() );
 
-   BOOST_REQUIRE_EQUAL( fc::unsigned_int{1}, trx_trace->action_traces[0].action_ordinal );
-   BOOST_REQUIRE_EQUAL( fc::unsigned_int{0}, trx_trace->action_traces[0].creator_action_ordinal );
-   BOOST_REQUIRE_EQUAL( fc::unsigned_int{0}, trx_trace->action_traces[0].closest_unnotified_ancestor_action_ordinal );
-   BOOST_REQUIRE_EQUAL( N(eosio.msig), action_name{trx_trace->action_traces[0].receiver} );
-   BOOST_REQUIRE_EQUAL( N(eosio.msig), name{trx_trace->action_traces[0].act.account} );
-   BOOST_REQUIRE_EQUAL( N(exec), name{trx_trace->action_traces[0].act.name} );
-   BOOST_REQUIRE_EQUAL( N(alice), name{trx_trace->action_traces[0].act.authorization[0].actor} );
-   BOOST_REQUIRE_EQUAL( N(active), name{trx_trace->action_traces[0].act.authorization[0].permission} );
+   BOOST_REQUIRE_EQUAL( fc::unsigned_int{1}, trx_trace->action_traces.at(0).action_ordinal );
+   BOOST_REQUIRE_EQUAL( fc::unsigned_int{0}, trx_trace->action_traces.at(0).creator_action_ordinal );
+   BOOST_REQUIRE_EQUAL( fc::unsigned_int{0}, trx_trace->action_traces.at(0).closest_unnotified_ancestor_action_ordinal );
+   BOOST_REQUIRE_EQUAL( N(eosio.msig), action_name{trx_trace->action_traces.at(0).receiver} );
+   BOOST_REQUIRE_EQUAL( N(eosio.msig), name{trx_trace->action_traces.at(0).act.account} );
+   BOOST_REQUIRE_EQUAL( N(exec), name{trx_trace->action_traces.at(0).act.name} );
+   BOOST_REQUIRE_EQUAL( N(alice), name{trx_trace->action_traces.at(0).act.authorization[0].actor} );
+   BOOST_REQUIRE_EQUAL( N(active), name{trx_trace->action_traces.at(0).act.authorization[0].permission} );
 
-   BOOST_REQUIRE_EQUAL( fc::unsigned_int{2}, trx_trace->action_traces[1].action_ordinal );
-   BOOST_REQUIRE_EQUAL( fc::unsigned_int{1}, trx_trace->action_traces[1].creator_action_ordinal );
-   BOOST_REQUIRE_EQUAL( fc::unsigned_int{1}, trx_trace->action_traces[1].closest_unnotified_ancestor_action_ordinal );
-   BOOST_REQUIRE_EQUAL( N(eosio), action_name{trx_trace->action_traces[1].receiver} );
-   BOOST_REQUIRE_EQUAL( N(eosio), name{trx_trace->action_traces[1].act.account} );
-   BOOST_REQUIRE_EQUAL( N(reqauth), name{trx_trace->action_traces[1].act.name} );
-   BOOST_REQUIRE_EQUAL( N(alice), name{trx_trace->action_traces[1].act.authorization[0].actor} );
-   BOOST_REQUIRE_EQUAL( N(active), name{trx_trace->action_traces[1].act.authorization[0].permission} );
-   BOOST_REQUIRE_EQUAL( N(bob), name{trx_trace->action_traces[1].act.authorization[1].actor} );
-   BOOST_REQUIRE_EQUAL( N(active), name{trx_trace->action_traces[1].act.authorization[1].permission} );
+   BOOST_REQUIRE_EQUAL( fc::unsigned_int{2}, trx_trace->action_traces.at(1).action_ordinal );
+   BOOST_REQUIRE_EQUAL( fc::unsigned_int{1}, trx_trace->action_traces.at(1).creator_action_ordinal );
+   BOOST_REQUIRE_EQUAL( fc::unsigned_int{1}, trx_trace->action_traces.at(1).closest_unnotified_ancestor_action_ordinal );
+   BOOST_REQUIRE_EQUAL( N(eosio), action_name{trx_trace->action_traces.at(1).receiver} );
+   BOOST_REQUIRE_EQUAL( N(eosio), name{trx_trace->action_traces.at(1).act.account} );
+   BOOST_REQUIRE_EQUAL( N(reqauth), name{trx_trace->action_traces.at(1).act.name} );
+   BOOST_REQUIRE_EQUAL( N(alice), name{trx_trace->action_traces.at(1).act.authorization[0].actor} );
+   BOOST_REQUIRE_EQUAL( N(active), name{trx_trace->action_traces.at(1).act.authorization[0].permission} );
+   BOOST_REQUIRE_EQUAL( N(bob), name{trx_trace->action_traces.at(1).act.authorization[1].actor} );
+   BOOST_REQUIRE_EQUAL( N(active), name{trx_trace->action_traces.at(1).act.authorization[1].permission} );
 } FC_LOG_AND_RETHROW()
 
 
@@ -401,31 +400,30 @@ BOOST_FIXTURE_TEST_CASE( big_transaction, eosio_msig_tester ) try {
                              ("executer",      "alice")
    );
 
-   wdump((fc::json::to_pretty_string(trx_trace)));
-
+   BOOST_REQUIRE( trx_trace->receipt.valid() );
    BOOST_REQUIRE( bool(trx_trace) );
    BOOST_REQUIRE_EQUAL( transaction_receipt::executed, trx_trace->receipt->status );
    BOOST_REQUIRE_EQUAL( 2, trx_trace->action_traces.size() );
 
-   BOOST_REQUIRE_EQUAL( fc::unsigned_int{1}, trx_trace->action_traces[0].action_ordinal );
-   BOOST_REQUIRE_EQUAL( fc::unsigned_int{0}, trx_trace->action_traces[0].creator_action_ordinal );
-   BOOST_REQUIRE_EQUAL( fc::unsigned_int{0}, trx_trace->action_traces[0].closest_unnotified_ancestor_action_ordinal );
-   BOOST_REQUIRE_EQUAL( N(eosio.msig), action_name{trx_trace->action_traces[0].receiver} );
-   BOOST_REQUIRE_EQUAL( N(eosio.msig), name{trx_trace->action_traces[0].act.account} );
-   BOOST_REQUIRE_EQUAL( N(exec), name{trx_trace->action_traces[0].act.name} );
-   BOOST_REQUIRE_EQUAL( N(alice), name{trx_trace->action_traces[0].act.authorization[0].actor} );
-   BOOST_REQUIRE_EQUAL( N(active), name{trx_trace->action_traces[0].act.authorization[0].permission} );
+   BOOST_REQUIRE_EQUAL( fc::unsigned_int{1}, trx_trace->action_traces.at(0).action_ordinal );
+   BOOST_REQUIRE_EQUAL( fc::unsigned_int{0}, trx_trace->action_traces.at(0).creator_action_ordinal );
+   BOOST_REQUIRE_EQUAL( fc::unsigned_int{0}, trx_trace->action_traces.at(0).closest_unnotified_ancestor_action_ordinal );
+   BOOST_REQUIRE_EQUAL( N(eosio.msig), action_name{trx_trace->action_traces.at(0).receiver} );
+   BOOST_REQUIRE_EQUAL( N(eosio.msig), name{trx_trace->action_traces.at(0).act.account} );
+   BOOST_REQUIRE_EQUAL( N(exec), name{trx_trace->action_traces.at(0).act.name} );
+   BOOST_REQUIRE_EQUAL( N(alice), name{trx_trace->action_traces.at(0).act.authorization[0].actor} );
+   BOOST_REQUIRE_EQUAL( N(active), name{trx_trace->action_traces.at(0).act.authorization[0].permission} );
 
-   BOOST_REQUIRE_EQUAL( fc::unsigned_int{2}, trx_trace->action_traces[1].action_ordinal );
-   BOOST_REQUIRE_EQUAL( fc::unsigned_int{1}, trx_trace->action_traces[1].creator_action_ordinal );
-   BOOST_REQUIRE_EQUAL( fc::unsigned_int{1}, trx_trace->action_traces[1].closest_unnotified_ancestor_action_ordinal );
-   BOOST_REQUIRE_EQUAL( N(eosio), action_name{trx_trace->action_traces[1].receiver} );
-   BOOST_REQUIRE_EQUAL( N(eosio), name{trx_trace->action_traces[1].act.account} );
-   BOOST_REQUIRE_EQUAL( N(setcode), name{trx_trace->action_traces[1].act.name} );
-   BOOST_REQUIRE_EQUAL( N(alice), name{trx_trace->action_traces[1].act.authorization[0].actor} );
-   BOOST_REQUIRE_EQUAL( N(active), name{trx_trace->action_traces[1].act.authorization[0].permission} );
-   BOOST_REQUIRE_EQUAL( N(bob), name{trx_trace->action_traces[1].act.authorization[1].actor} );
-   BOOST_REQUIRE_EQUAL( N(active), name{trx_trace->action_traces[1].act.authorization[1].permission} );
+   BOOST_REQUIRE_EQUAL( fc::unsigned_int{2}, trx_trace->action_traces.at(1).action_ordinal );
+   BOOST_REQUIRE_EQUAL( fc::unsigned_int{1}, trx_trace->action_traces.at(1).creator_action_ordinal );
+   BOOST_REQUIRE_EQUAL( fc::unsigned_int{1}, trx_trace->action_traces.at(1).closest_unnotified_ancestor_action_ordinal );
+   BOOST_REQUIRE_EQUAL( N(eosio), action_name{trx_trace->action_traces.at(1).receiver} );
+   BOOST_REQUIRE_EQUAL( N(eosio), name{trx_trace->action_traces.at(1).act.account} );
+   BOOST_REQUIRE_EQUAL( N(setcode), name{trx_trace->action_traces.at(1).act.name} );
+   BOOST_REQUIRE_EQUAL( N(alice), name{trx_trace->action_traces.at(1).act.authorization[0].actor} );
+   BOOST_REQUIRE_EQUAL( N(active), name{trx_trace->action_traces.at(1).act.authorization[0].permission} );
+   BOOST_REQUIRE_EQUAL( N(bob), name{trx_trace->action_traces.at(1).act.authorization[1].actor} );
+   BOOST_REQUIRE_EQUAL( N(active), name{trx_trace->action_traces.at(1).act.authorization[1].permission} );
 } FC_LOG_AND_RETHROW()
 
 
@@ -545,29 +543,28 @@ BOOST_FIXTURE_TEST_CASE( update_system_contract_all_approve, eosio_msig_tester )
                              ("executer",      "alice")
    );
 
-   wdump((fc::json::to_pretty_string(trx_trace)));
-
+   BOOST_REQUIRE( trx_trace->receipt.valid() );
    BOOST_REQUIRE( bool(trx_trace) );
    BOOST_REQUIRE_EQUAL( transaction_receipt::executed, trx_trace->receipt->status );
    BOOST_REQUIRE_EQUAL( 2, trx_trace->action_traces.size() );
 
-   BOOST_REQUIRE_EQUAL( fc::unsigned_int{1}, trx_trace->action_traces[0].action_ordinal );
-   BOOST_REQUIRE_EQUAL( fc::unsigned_int{0}, trx_trace->action_traces[0].creator_action_ordinal );
-   BOOST_REQUIRE_EQUAL( fc::unsigned_int{0}, trx_trace->action_traces[0].closest_unnotified_ancestor_action_ordinal );
-   BOOST_REQUIRE_EQUAL( N(eosio.msig), action_name{trx_trace->action_traces[0].receiver} );
-   BOOST_REQUIRE_EQUAL( N(eosio.msig), name{trx_trace->action_traces[0].act.account} );
-   BOOST_REQUIRE_EQUAL( N(exec), name{trx_trace->action_traces[0].act.name} );
-   BOOST_REQUIRE_EQUAL( N(alice), name{trx_trace->action_traces[0].act.authorization[0].actor} );
-   BOOST_REQUIRE_EQUAL( N(active), name{trx_trace->action_traces[0].act.authorization[0].permission} );
+   BOOST_REQUIRE_EQUAL( fc::unsigned_int{1}, trx_trace->action_traces.at(0).action_ordinal );
+   BOOST_REQUIRE_EQUAL( fc::unsigned_int{0}, trx_trace->action_traces.at(0).creator_action_ordinal );
+   BOOST_REQUIRE_EQUAL( fc::unsigned_int{0}, trx_trace->action_traces.at(0).closest_unnotified_ancestor_action_ordinal );
+   BOOST_REQUIRE_EQUAL( N(eosio.msig), action_name{trx_trace->action_traces.at(0).receiver} );
+   BOOST_REQUIRE_EQUAL( N(eosio.msig), name{trx_trace->action_traces.at(0).act.account} );
+   BOOST_REQUIRE_EQUAL( N(exec), name{trx_trace->action_traces.at(0).act.name} );
+   BOOST_REQUIRE_EQUAL( N(alice), name{trx_trace->action_traces.at(0).act.authorization[0].actor} );
+   BOOST_REQUIRE_EQUAL( N(active), name{trx_trace->action_traces.at(0).act.authorization[0].permission} );
 
-   BOOST_REQUIRE_EQUAL( fc::unsigned_int{2}, trx_trace->action_traces[1].action_ordinal );
-   BOOST_REQUIRE_EQUAL( fc::unsigned_int{1}, trx_trace->action_traces[1].creator_action_ordinal );
-   BOOST_REQUIRE_EQUAL( fc::unsigned_int{1}, trx_trace->action_traces[1].closest_unnotified_ancestor_action_ordinal );
-   BOOST_REQUIRE_EQUAL( N(eosio), action_name{trx_trace->action_traces[1].receiver} );
-   BOOST_REQUIRE_EQUAL( N(eosio), name{trx_trace->action_traces[1].act.account} );
-   BOOST_REQUIRE_EQUAL( N(setcode), name{trx_trace->action_traces[1].act.name} );
-   BOOST_REQUIRE_EQUAL( N(eosio), name{trx_trace->action_traces[1].act.authorization[0].actor} );
-   BOOST_REQUIRE_EQUAL( N(active), name{trx_trace->action_traces[1].act.authorization[0].permission} );
+   BOOST_REQUIRE_EQUAL( fc::unsigned_int{2}, trx_trace->action_traces.at(1).action_ordinal );
+   BOOST_REQUIRE_EQUAL( fc::unsigned_int{1}, trx_trace->action_traces.at(1).creator_action_ordinal );
+   BOOST_REQUIRE_EQUAL( fc::unsigned_int{1}, trx_trace->action_traces.at(1).closest_unnotified_ancestor_action_ordinal );
+   BOOST_REQUIRE_EQUAL( N(eosio), action_name{trx_trace->action_traces.at(1).receiver} );
+   BOOST_REQUIRE_EQUAL( N(eosio), name{trx_trace->action_traces.at(1).act.account} );
+   BOOST_REQUIRE_EQUAL( N(setcode), name{trx_trace->action_traces.at(1).act.name} );
+   BOOST_REQUIRE_EQUAL( N(eosio), name{trx_trace->action_traces.at(1).act.authorization[0].actor} );
+   BOOST_REQUIRE_EQUAL( N(active), name{trx_trace->action_traces.at(1).act.authorization[0].permission} );
 
    // can't create account because system contract was replaced by the reject_all contract
    BOOST_REQUIRE_EXCEPTION( create_account_with_resources( N(alice1111112), N(eosio), core_sym::from_string("1.0000"), false ),
@@ -696,29 +693,28 @@ BOOST_FIXTURE_TEST_CASE( update_system_contract_major_approve, eosio_msig_tester
                          ("executer",      "apple")
    );
 
-   wdump((fc::json::to_pretty_string(trx_trace)));
-
+   BOOST_REQUIRE( trx_trace->receipt.valid() );
    BOOST_REQUIRE( bool(trx_trace) );
    BOOST_REQUIRE_EQUAL( transaction_receipt::executed, trx_trace->receipt->status );
    BOOST_REQUIRE_EQUAL( 2, trx_trace->action_traces.size() );
 
-   BOOST_REQUIRE_EQUAL( fc::unsigned_int{1}, trx_trace->action_traces[0].action_ordinal );
-   BOOST_REQUIRE_EQUAL( fc::unsigned_int{0}, trx_trace->action_traces[0].creator_action_ordinal );
-   BOOST_REQUIRE_EQUAL( fc::unsigned_int{0}, trx_trace->action_traces[0].closest_unnotified_ancestor_action_ordinal );
-   BOOST_REQUIRE_EQUAL( N(eosio.msig), action_name{trx_trace->action_traces[0].receiver} );
-   BOOST_REQUIRE_EQUAL( N(eosio.msig), name{trx_trace->action_traces[0].act.account} );
-   BOOST_REQUIRE_EQUAL( N(exec), name{trx_trace->action_traces[0].act.name} );
-   BOOST_REQUIRE_EQUAL( N(apple), name{trx_trace->action_traces[0].act.authorization[0].actor} );
-   BOOST_REQUIRE_EQUAL( N(active), name{trx_trace->action_traces[0].act.authorization[0].permission} );
+   BOOST_REQUIRE_EQUAL( fc::unsigned_int{1}, trx_trace->action_traces.at(0).action_ordinal );
+   BOOST_REQUIRE_EQUAL( fc::unsigned_int{0}, trx_trace->action_traces.at(0).creator_action_ordinal );
+   BOOST_REQUIRE_EQUAL( fc::unsigned_int{0}, trx_trace->action_traces.at(0).closest_unnotified_ancestor_action_ordinal );
+   BOOST_REQUIRE_EQUAL( N(eosio.msig), action_name{trx_trace->action_traces.at(0).receiver} );
+   BOOST_REQUIRE_EQUAL( N(eosio.msig), name{trx_trace->action_traces.at(0).act.account} );
+   BOOST_REQUIRE_EQUAL( N(exec), name{trx_trace->action_traces.at(0).act.name} );
+   BOOST_REQUIRE_EQUAL( N(apple), name{trx_trace->action_traces.at(0).act.authorization[0].actor} );
+   BOOST_REQUIRE_EQUAL( N(active), name{trx_trace->action_traces.at(0).act.authorization[0].permission} );
 
-   BOOST_REQUIRE_EQUAL( fc::unsigned_int{2}, trx_trace->action_traces[1].action_ordinal );
-   BOOST_REQUIRE_EQUAL( fc::unsigned_int{1}, trx_trace->action_traces[1].creator_action_ordinal );
-   BOOST_REQUIRE_EQUAL( fc::unsigned_int{1}, trx_trace->action_traces[1].closest_unnotified_ancestor_action_ordinal );
-   BOOST_REQUIRE_EQUAL( N(eosio), action_name{trx_trace->action_traces[1].receiver} );
-   BOOST_REQUIRE_EQUAL( N(eosio), name{trx_trace->action_traces[1].act.account} );
-   BOOST_REQUIRE_EQUAL( N(setcode), name{trx_trace->action_traces[1].act.name} );
-   BOOST_REQUIRE_EQUAL( N(eosio), name{trx_trace->action_traces[1].act.authorization[0].actor} );
-   BOOST_REQUIRE_EQUAL( N(active), name{trx_trace->action_traces[1].act.authorization[0].permission} );
+   BOOST_REQUIRE_EQUAL( fc::unsigned_int{2}, trx_trace->action_traces.at(1).action_ordinal );
+   BOOST_REQUIRE_EQUAL( fc::unsigned_int{1}, trx_trace->action_traces.at(1).creator_action_ordinal );
+   BOOST_REQUIRE_EQUAL( fc::unsigned_int{1}, trx_trace->action_traces.at(1).closest_unnotified_ancestor_action_ordinal );
+   BOOST_REQUIRE_EQUAL( N(eosio), action_name{trx_trace->action_traces.at(1).receiver} );
+   BOOST_REQUIRE_EQUAL( N(eosio), name{trx_trace->action_traces.at(1).act.account} );
+   BOOST_REQUIRE_EQUAL( N(setcode), name{trx_trace->action_traces.at(1).act.name} );
+   BOOST_REQUIRE_EQUAL( N(eosio), name{trx_trace->action_traces.at(1).act.authorization[0].actor} );
+   BOOST_REQUIRE_EQUAL( N(active), name{trx_trace->action_traces.at(1).act.authorization[0].permission} );
 
    // can't create account because system contract was replaced by the reject_all contract
    BOOST_REQUIRE_EXCEPTION( create_account_with_resources( N(alice1111112), N(eosio), core_sym::from_string("1.0000"), false ),
@@ -810,29 +806,28 @@ BOOST_FIXTURE_TEST_CASE( propose_invalidate_approve, eosio_msig_tester ) try {
                              ("executer",      "bob")
    );
 
-   wdump((fc::json::to_pretty_string(trx_trace)));
-
+   BOOST_REQUIRE( trx_trace->receipt.valid() );
    BOOST_REQUIRE( bool(trx_trace) );
    BOOST_REQUIRE_EQUAL( transaction_receipt::executed, trx_trace->receipt->status );
    BOOST_REQUIRE_EQUAL( 2, trx_trace->action_traces.size() );
 
-   BOOST_REQUIRE_EQUAL( fc::unsigned_int{1}, trx_trace->action_traces[0].action_ordinal );
-   BOOST_REQUIRE_EQUAL( fc::unsigned_int{0}, trx_trace->action_traces[0].creator_action_ordinal );
-   BOOST_REQUIRE_EQUAL( fc::unsigned_int{0}, trx_trace->action_traces[0].closest_unnotified_ancestor_action_ordinal );
-   BOOST_REQUIRE_EQUAL( N(eosio.msig), action_name{trx_trace->action_traces[0].receiver} );
-   BOOST_REQUIRE_EQUAL( N(eosio.msig), name{trx_trace->action_traces[0].act.account} );
-   BOOST_REQUIRE_EQUAL( N(exec), name{trx_trace->action_traces[0].act.name} );
-   BOOST_REQUIRE_EQUAL( N(bob), name{trx_trace->action_traces[0].act.authorization[0].actor} );
-   BOOST_REQUIRE_EQUAL( N(active), name{trx_trace->action_traces[0].act.authorization[0].permission} );
+   BOOST_REQUIRE_EQUAL( fc::unsigned_int{1}, trx_trace->action_traces.at(0).action_ordinal );
+   BOOST_REQUIRE_EQUAL( fc::unsigned_int{0}, trx_trace->action_traces.at(0).creator_action_ordinal );
+   BOOST_REQUIRE_EQUAL( fc::unsigned_int{0}, trx_trace->action_traces.at(0).closest_unnotified_ancestor_action_ordinal );
+   BOOST_REQUIRE_EQUAL( N(eosio.msig), action_name{trx_trace->action_traces.at(0).receiver} );
+   BOOST_REQUIRE_EQUAL( N(eosio.msig), name{trx_trace->action_traces.at(0).act.account} );
+   BOOST_REQUIRE_EQUAL( N(exec), name{trx_trace->action_traces.at(0).act.name} );
+   BOOST_REQUIRE_EQUAL( N(bob), name{trx_trace->action_traces.at(0).act.authorization[0].actor} );
+   BOOST_REQUIRE_EQUAL( N(active), name{trx_trace->action_traces.at(0).act.authorization[0].permission} );
 
-   BOOST_REQUIRE_EQUAL( fc::unsigned_int{2}, trx_trace->action_traces[1].action_ordinal );
-   BOOST_REQUIRE_EQUAL( fc::unsigned_int{1}, trx_trace->action_traces[1].creator_action_ordinal );
-   BOOST_REQUIRE_EQUAL( fc::unsigned_int{1}, trx_trace->action_traces[1].closest_unnotified_ancestor_action_ordinal );
-   BOOST_REQUIRE_EQUAL( N(eosio), action_name{trx_trace->action_traces[1].receiver} );
-   BOOST_REQUIRE_EQUAL( N(eosio), name{trx_trace->action_traces[1].act.account} );
-   BOOST_REQUIRE_EQUAL( N(reqauth), name{trx_trace->action_traces[1].act.name} );
-   BOOST_REQUIRE_EQUAL( N(alice), name{trx_trace->action_traces[1].act.authorization[0].actor} );
-   BOOST_REQUIRE_EQUAL( N(active), name{trx_trace->action_traces[1].act.authorization[0].permission} );
+   BOOST_REQUIRE_EQUAL( fc::unsigned_int{2}, trx_trace->action_traces.at(1).action_ordinal );
+   BOOST_REQUIRE_EQUAL( fc::unsigned_int{1}, trx_trace->action_traces.at(1).creator_action_ordinal );
+   BOOST_REQUIRE_EQUAL( fc::unsigned_int{1}, trx_trace->action_traces.at(1).closest_unnotified_ancestor_action_ordinal );
+   BOOST_REQUIRE_EQUAL( N(eosio), action_name{trx_trace->action_traces.at(1).receiver} );
+   BOOST_REQUIRE_EQUAL( N(eosio), name{trx_trace->action_traces.at(1).act.account} );
+   BOOST_REQUIRE_EQUAL( N(reqauth), name{trx_trace->action_traces.at(1).act.name} );
+   BOOST_REQUIRE_EQUAL( N(alice), name{trx_trace->action_traces.at(1).act.authorization[0].actor} );
+   BOOST_REQUIRE_EQUAL( N(active), name{trx_trace->action_traces.at(1).act.authorization[0].permission} );
 } FC_LOG_AND_RETHROW()
 
 BOOST_FIXTURE_TEST_CASE( approve_execute_old, eosio_msig_tester ) try {
@@ -867,29 +862,28 @@ BOOST_FIXTURE_TEST_CASE( approve_execute_old, eosio_msig_tester ) try {
                              ("executer",      "alice")
    );
 
-   wdump((fc::json::to_pretty_string(trx_trace)));
-
+   BOOST_REQUIRE( trx_trace->receipt.valid() );
    BOOST_REQUIRE( bool(trx_trace) );
    BOOST_REQUIRE_EQUAL( transaction_receipt::executed, trx_trace->receipt->status );
    BOOST_REQUIRE_EQUAL( 2, trx_trace->action_traces.size() );
 
-   BOOST_REQUIRE_EQUAL( fc::unsigned_int{1}, trx_trace->action_traces[0].action_ordinal );
-   BOOST_REQUIRE_EQUAL( fc::unsigned_int{0}, trx_trace->action_traces[0].creator_action_ordinal );
-   BOOST_REQUIRE_EQUAL( fc::unsigned_int{0}, trx_trace->action_traces[0].closest_unnotified_ancestor_action_ordinal );
-   BOOST_REQUIRE_EQUAL( N(eosio.msig), action_name{trx_trace->action_traces[0].receiver} );
-   BOOST_REQUIRE_EQUAL( N(eosio.msig), name{trx_trace->action_traces[0].act.account} );
-   BOOST_REQUIRE_EQUAL( N(exec), name{trx_trace->action_traces[0].act.name} );
-   BOOST_REQUIRE_EQUAL( N(alice), name{trx_trace->action_traces[0].act.authorization[0].actor} );
-   BOOST_REQUIRE_EQUAL( N(active), name{trx_trace->action_traces[0].act.authorization[0].permission} );
+   BOOST_REQUIRE_EQUAL( fc::unsigned_int{1}, trx_trace->action_traces.at(0).action_ordinal );
+   BOOST_REQUIRE_EQUAL( fc::unsigned_int{0}, trx_trace->action_traces.at(0).creator_action_ordinal );
+   BOOST_REQUIRE_EQUAL( fc::unsigned_int{0}, trx_trace->action_traces.at(0).closest_unnotified_ancestor_action_ordinal );
+   BOOST_REQUIRE_EQUAL( N(eosio.msig), action_name{trx_trace->action_traces.at(0).receiver} );
+   BOOST_REQUIRE_EQUAL( N(eosio.msig), name{trx_trace->action_traces.at(0).act.account} );
+   BOOST_REQUIRE_EQUAL( N(exec), name{trx_trace->action_traces.at(0).act.name} );
+   BOOST_REQUIRE_EQUAL( N(alice), name{trx_trace->action_traces.at(0).act.authorization[0].actor} );
+   BOOST_REQUIRE_EQUAL( N(active), name{trx_trace->action_traces.at(0).act.authorization[0].permission} );
 
-   BOOST_REQUIRE_EQUAL( fc::unsigned_int{2}, trx_trace->action_traces[1].action_ordinal );
-   BOOST_REQUIRE_EQUAL( fc::unsigned_int{1}, trx_trace->action_traces[1].creator_action_ordinal );
-   BOOST_REQUIRE_EQUAL( fc::unsigned_int{1}, trx_trace->action_traces[1].closest_unnotified_ancestor_action_ordinal );
-   BOOST_REQUIRE_EQUAL( N(eosio), action_name{trx_trace->action_traces[1].receiver} );
-   BOOST_REQUIRE_EQUAL( N(eosio), name{trx_trace->action_traces[1].act.account} );
-   BOOST_REQUIRE_EQUAL( N(reqauth), name{trx_trace->action_traces[1].act.name} );
-   BOOST_REQUIRE_EQUAL( N(alice), name{trx_trace->action_traces[1].act.authorization[0].actor} );
-   BOOST_REQUIRE_EQUAL( N(active), name{trx_trace->action_traces[1].act.authorization[0].permission} );
+   BOOST_REQUIRE_EQUAL( fc::unsigned_int{2}, trx_trace->action_traces.at(1).action_ordinal );
+   BOOST_REQUIRE_EQUAL( fc::unsigned_int{1}, trx_trace->action_traces.at(1).creator_action_ordinal );
+   BOOST_REQUIRE_EQUAL( fc::unsigned_int{1}, trx_trace->action_traces.at(1).closest_unnotified_ancestor_action_ordinal );
+   BOOST_REQUIRE_EQUAL( N(eosio), action_name{trx_trace->action_traces.at(1).receiver} );
+   BOOST_REQUIRE_EQUAL( N(eosio), name{trx_trace->action_traces.at(1).act.account} );
+   BOOST_REQUIRE_EQUAL( N(reqauth), name{trx_trace->action_traces.at(1).act.name} );
+   BOOST_REQUIRE_EQUAL( N(alice), name{trx_trace->action_traces.at(1).act.authorization[0].actor} );
+   BOOST_REQUIRE_EQUAL( N(active), name{trx_trace->action_traces.at(1).act.authorization[0].permission} );
 } FC_LOG_AND_RETHROW()
 
 BOOST_FIXTURE_TEST_CASE( approve_unapprove_old, eosio_msig_tester ) try {
@@ -982,29 +976,28 @@ BOOST_FIXTURE_TEST_CASE( approve_by_two_old, eosio_msig_tester ) try {
                              ("executer",      "alice")
    );
 
-   wdump((fc::json::to_pretty_string(trx_trace)));
-
+   BOOST_REQUIRE( trx_trace->receipt.valid() );
    BOOST_REQUIRE( bool(trx_trace) );
    BOOST_REQUIRE_EQUAL( transaction_receipt::executed, trx_trace->receipt->status );
    BOOST_REQUIRE_EQUAL( 2, trx_trace->action_traces.size() );
 
-   BOOST_REQUIRE_EQUAL( fc::unsigned_int{1}, trx_trace->action_traces[0].action_ordinal );
-   BOOST_REQUIRE_EQUAL( fc::unsigned_int{0}, trx_trace->action_traces[0].creator_action_ordinal );
-   BOOST_REQUIRE_EQUAL( fc::unsigned_int{0}, trx_trace->action_traces[0].closest_unnotified_ancestor_action_ordinal );
-   BOOST_REQUIRE_EQUAL( N(eosio.msig), action_name{trx_trace->action_traces[0].receiver} );
-   BOOST_REQUIRE_EQUAL( N(eosio.msig), name{trx_trace->action_traces[0].act.account} );
-   BOOST_REQUIRE_EQUAL( N(exec), name{trx_trace->action_traces[0].act.name} );
-   BOOST_REQUIRE_EQUAL( N(alice), name{trx_trace->action_traces[0].act.authorization[0].actor} );
-   BOOST_REQUIRE_EQUAL( N(active), name{trx_trace->action_traces[0].act.authorization[0].permission} );
+   BOOST_REQUIRE_EQUAL( fc::unsigned_int{1}, trx_trace->action_traces.at(0).action_ordinal );
+   BOOST_REQUIRE_EQUAL( fc::unsigned_int{0}, trx_trace->action_traces.at(0).creator_action_ordinal );
+   BOOST_REQUIRE_EQUAL( fc::unsigned_int{0}, trx_trace->action_traces.at(0).closest_unnotified_ancestor_action_ordinal );
+   BOOST_REQUIRE_EQUAL( N(eosio.msig), action_name{trx_trace->action_traces.at(0).receiver} );
+   BOOST_REQUIRE_EQUAL( N(eosio.msig), name{trx_trace->action_traces.at(0).act.account} );
+   BOOST_REQUIRE_EQUAL( N(exec), name{trx_trace->action_traces.at(0).act.name} );
+   BOOST_REQUIRE_EQUAL( N(alice), name{trx_trace->action_traces.at(0).act.authorization[0].actor} );
+   BOOST_REQUIRE_EQUAL( N(active), name{trx_trace->action_traces.at(0).act.authorization[0].permission} );
 
-   BOOST_REQUIRE_EQUAL( fc::unsigned_int{2}, trx_trace->action_traces[1].action_ordinal );
-   BOOST_REQUIRE_EQUAL( fc::unsigned_int{1}, trx_trace->action_traces[1].creator_action_ordinal );
-   BOOST_REQUIRE_EQUAL( fc::unsigned_int{1}, trx_trace->action_traces[1].closest_unnotified_ancestor_action_ordinal );
-   BOOST_REQUIRE_EQUAL( N(eosio), action_name{trx_trace->action_traces[1].receiver} );
-   BOOST_REQUIRE_EQUAL( N(eosio), name{trx_trace->action_traces[1].act.account} );
-   BOOST_REQUIRE_EQUAL( N(reqauth), name{trx_trace->action_traces[1].act.name} );
-   BOOST_REQUIRE_EQUAL( N(alice), name{trx_trace->action_traces[1].act.authorization[0].actor} );
-   BOOST_REQUIRE_EQUAL( N(active), name{trx_trace->action_traces[1].act.authorization[0].permission} );
+   BOOST_REQUIRE_EQUAL( fc::unsigned_int{2}, trx_trace->action_traces.at(1).action_ordinal );
+   BOOST_REQUIRE_EQUAL( fc::unsigned_int{1}, trx_trace->action_traces.at(1).creator_action_ordinal );
+   BOOST_REQUIRE_EQUAL( fc::unsigned_int{1}, trx_trace->action_traces.at(1).closest_unnotified_ancestor_action_ordinal );
+   BOOST_REQUIRE_EQUAL( N(eosio), action_name{trx_trace->action_traces.at(1).receiver} );
+   BOOST_REQUIRE_EQUAL( N(eosio), name{trx_trace->action_traces.at(1).act.account} );
+   BOOST_REQUIRE_EQUAL( N(reqauth), name{trx_trace->action_traces.at(1).act.name} );
+   BOOST_REQUIRE_EQUAL( N(alice), name{trx_trace->action_traces.at(1).act.authorization[0].actor} );
+   BOOST_REQUIRE_EQUAL( N(active), name{trx_trace->action_traces.at(1).act.authorization[0].permission} );
 } FC_LOG_AND_RETHROW()
 
 BOOST_FIXTURE_TEST_CASE( approve_with_hash, eosio_msig_tester ) try {
@@ -1045,29 +1038,28 @@ BOOST_FIXTURE_TEST_CASE( approve_with_hash, eosio_msig_tester ) try {
                              ("executer",      "alice")
    );
 
-   wdump((fc::json::to_pretty_string(trx_trace)));
-
+   BOOST_REQUIRE( trx_trace->receipt.valid() );
    BOOST_REQUIRE( bool(trx_trace) );
    BOOST_REQUIRE_EQUAL( transaction_receipt::executed, trx_trace->receipt->status );
    BOOST_REQUIRE_EQUAL( 2, trx_trace->action_traces.size() );
 
-   BOOST_REQUIRE_EQUAL( fc::unsigned_int{1}, trx_trace->action_traces[0].action_ordinal );
-   BOOST_REQUIRE_EQUAL( fc::unsigned_int{0}, trx_trace->action_traces[0].creator_action_ordinal );
-   BOOST_REQUIRE_EQUAL( fc::unsigned_int{0}, trx_trace->action_traces[0].closest_unnotified_ancestor_action_ordinal );
-   BOOST_REQUIRE_EQUAL( N(eosio.msig), action_name{trx_trace->action_traces[0].receiver} );
-   BOOST_REQUIRE_EQUAL( N(eosio.msig), name{trx_trace->action_traces[0].act.account} );
-   BOOST_REQUIRE_EQUAL( N(exec), name{trx_trace->action_traces[0].act.name} );
-   BOOST_REQUIRE_EQUAL( N(alice), name{trx_trace->action_traces[0].act.authorization[0].actor} );
-   BOOST_REQUIRE_EQUAL( N(active), name{trx_trace->action_traces[0].act.authorization[0].permission} );
+   BOOST_REQUIRE_EQUAL( fc::unsigned_int{1}, trx_trace->action_traces.at(0).action_ordinal );
+   BOOST_REQUIRE_EQUAL( fc::unsigned_int{0}, trx_trace->action_traces.at(0).creator_action_ordinal );
+   BOOST_REQUIRE_EQUAL( fc::unsigned_int{0}, trx_trace->action_traces.at(0).closest_unnotified_ancestor_action_ordinal );
+   BOOST_REQUIRE_EQUAL( N(eosio.msig), action_name{trx_trace->action_traces.at(0).receiver} );
+   BOOST_REQUIRE_EQUAL( N(eosio.msig), name{trx_trace->action_traces.at(0).act.account} );
+   BOOST_REQUIRE_EQUAL( N(exec), name{trx_trace->action_traces.at(0).act.name} );
+   BOOST_REQUIRE_EQUAL( N(alice), name{trx_trace->action_traces.at(0).act.authorization[0].actor} );
+   BOOST_REQUIRE_EQUAL( N(active), name{trx_trace->action_traces.at(0).act.authorization[0].permission} );
 
-   BOOST_REQUIRE_EQUAL( fc::unsigned_int{2}, trx_trace->action_traces[1].action_ordinal );
-   BOOST_REQUIRE_EQUAL( fc::unsigned_int{1}, trx_trace->action_traces[1].creator_action_ordinal );
-   BOOST_REQUIRE_EQUAL( fc::unsigned_int{1}, trx_trace->action_traces[1].closest_unnotified_ancestor_action_ordinal );
-   BOOST_REQUIRE_EQUAL( N(eosio), action_name{trx_trace->action_traces[1].receiver} );
-   BOOST_REQUIRE_EQUAL( N(eosio), name{trx_trace->action_traces[1].act.account} );
-   BOOST_REQUIRE_EQUAL( N(reqauth), name{trx_trace->action_traces[1].act.name} );
-   BOOST_REQUIRE_EQUAL( N(alice), name{trx_trace->action_traces[1].act.authorization[0].actor} );
-   BOOST_REQUIRE_EQUAL( N(active), name{trx_trace->action_traces[1].act.authorization[0].permission} );
+   BOOST_REQUIRE_EQUAL( fc::unsigned_int{2}, trx_trace->action_traces.at(1).action_ordinal );
+   BOOST_REQUIRE_EQUAL( fc::unsigned_int{1}, trx_trace->action_traces.at(1).creator_action_ordinal );
+   BOOST_REQUIRE_EQUAL( fc::unsigned_int{1}, trx_trace->action_traces.at(1).closest_unnotified_ancestor_action_ordinal );
+   BOOST_REQUIRE_EQUAL( N(eosio), action_name{trx_trace->action_traces.at(1).receiver} );
+   BOOST_REQUIRE_EQUAL( N(eosio), name{trx_trace->action_traces.at(1).act.account} );
+   BOOST_REQUIRE_EQUAL( N(reqauth), name{trx_trace->action_traces.at(1).act.name} );
+   BOOST_REQUIRE_EQUAL( N(alice), name{trx_trace->action_traces.at(1).act.authorization[0].actor} );
+   BOOST_REQUIRE_EQUAL( N(active), name{trx_trace->action_traces.at(1).act.authorization[0].permission} );
 } FC_LOG_AND_RETHROW()
 
 BOOST_FIXTURE_TEST_CASE( switch_proposal_and_fail_approve_with_hash, eosio_msig_tester ) try {
@@ -1114,9 +1106,8 @@ BOOST_FIXTURE_TEST_CASE( switch_proposal_and_fail_approve_with_hash, eosio_msig_
 
 BOOST_FIXTURE_TEST_CASE( check_earliest_exec_time_for_approve_and_unapprove, eosio_msig_tester ) try {
    static constexpr uint32_t delay_sec = 1000;
-   // static constexpr uint32_t maximum_sec_since_epoch = time_point{microseconds::maximum()}.sec_since_epoch();
 
-   //helper function
+   // helper function.
    static auto calculate_test_exec_time = [&] (uint32_t delay_sec) -> uint32_t {
       return time_point{control->pending_block_time() + fc::seconds(delay_sec)}.sec_since_epoch();
    };
@@ -1156,26 +1147,25 @@ BOOST_FIXTURE_TEST_CASE( check_earliest_exec_time_for_approve_and_unapprove, eos
    // not met.
    BOOST_REQUIRE_EQUAL( fc::optional<time_point>{}.valid(), get_earliest_exec_time(N(alice), N(first)).valid() );
 
-   wdump((fc::json::to_pretty_string(trx_trace)));
-
+   BOOST_REQUIRE( trx_trace->receipt.valid() );
    BOOST_REQUIRE( bool(trx_trace) );
    BOOST_REQUIRE_EQUAL( transaction_receipt::executed, trx_trace->receipt->status );
    BOOST_REQUIRE_EQUAL( 1, trx_trace->action_traces.size() );
 
-   BOOST_REQUIRE_EQUAL( fc::unsigned_int{1}, trx_trace->action_traces[0].action_ordinal );
-   BOOST_REQUIRE_EQUAL( fc::unsigned_int{0}, trx_trace->action_traces[0].creator_action_ordinal );
-   BOOST_REQUIRE_EQUAL( fc::unsigned_int{0}, trx_trace->action_traces[0].closest_unnotified_ancestor_action_ordinal );
-   BOOST_REQUIRE_EQUAL( N(eosio.msig), action_name{trx_trace->action_traces[0].receiver} );
-   BOOST_REQUIRE_EQUAL( N(eosio.msig), name{trx_trace->action_traces[0].act.account} );
-   BOOST_REQUIRE_EQUAL( N(unapprove), name{trx_trace->action_traces[0].act.name} );
-   BOOST_REQUIRE_EQUAL( N(alice), name{trx_trace->action_traces[0].act.authorization[0].actor} );
-   BOOST_REQUIRE_EQUAL( N(active), name{trx_trace->action_traces[0].act.authorization[0].permission} );
+   BOOST_REQUIRE_EQUAL( fc::unsigned_int{1}, trx_trace->action_traces.at(0).action_ordinal );
+   BOOST_REQUIRE_EQUAL( fc::unsigned_int{0}, trx_trace->action_traces.at(0).creator_action_ordinal );
+   BOOST_REQUIRE_EQUAL( fc::unsigned_int{0}, trx_trace->action_traces.at(0).closest_unnotified_ancestor_action_ordinal );
+   BOOST_REQUIRE_EQUAL( N(eosio.msig), action_name{trx_trace->action_traces.at(0).receiver} );
+   BOOST_REQUIRE_EQUAL( N(eosio.msig), name{trx_trace->action_traces.at(0).act.account} );
+   BOOST_REQUIRE_EQUAL( N(unapprove), name{trx_trace->action_traces.at(0).act.name} );
+   BOOST_REQUIRE_EQUAL( N(alice), name{trx_trace->action_traces.at(0).act.authorization[0].actor} );
+   BOOST_REQUIRE_EQUAL( N(active), name{trx_trace->action_traces.at(0).act.authorization[0].permission} );
 } FC_LOG_AND_RETHROW()
 
 BOOST_FIXTURE_TEST_CASE( check_earliest_exec_time_for_approve_and_unapprove_multiple, eosio_msig_tester ) try {
    static constexpr uint32_t delay_sec = 1000;
 
-   //helper function
+   // helper function.
    static auto calculate_test_exec_time = [&] (uint32_t delay_sec) -> uint32_t {
       return time_point{control->pending_block_time() + fc::seconds(delay_sec)}.sec_since_epoch();
    };
@@ -1193,8 +1183,6 @@ BOOST_FIXTURE_TEST_CASE( check_earliest_exec_time_for_approve_and_unapprove_mult
                                                              { N(bob), config::active_name },
                                                              { N(carol), config::active_name }})
    );
-   // `propose` initially default-constructs `earliest_exec_time` to the default
-   // constructed state of a `std::optional`.
    BOOST_REQUIRE_EQUAL( fc::optional<time_point>{}.valid(), get_earliest_exec_time(N(alice), N(first)).valid() );
 
    push_action( N(alice), N(approve), mvo()
@@ -1216,10 +1204,6 @@ BOOST_FIXTURE_TEST_CASE( check_earliest_exec_time_for_approve_and_unapprove_mult
                   ("proposal_name", "first")
                   ("level",         permission_level{ N(carol), config::active_name })
    );
-   // `approve` then initializes `earliest_exec_time` to it's specified value
-   // (calculated by the current time point and what was specified in the
-   // `delay_sec` field of the `transaction_header` in the initial proposal), if
-   // the specified authorizations are met (in this case they are).
    BOOST_REQUIRE_EQUAL( calculate_test_exec_time(delay_sec), get_earliest_exec_time(N(alice), N(first))->sec_since_epoch() );
 
    transaction_trace_ptr trx_trace;
@@ -1228,32 +1212,28 @@ BOOST_FIXTURE_TEST_CASE( check_earliest_exec_time_for_approve_and_unapprove_mult
                              ("proposal_name", "first")
                              ("level",         permission_level{ N(alice), config::active_name })
    );
-   // `unapprove` will revert `earliest_exec_time` back to the default
-   // constructed state of a `std::optional` if the specified authorizations are
-   // not met.
    BOOST_REQUIRE_EQUAL( fc::optional<time_point>{}.valid(), get_earliest_exec_time(N(alice), N(first)).valid() );
 
-   wdump((fc::json::to_pretty_string(trx_trace)));
-
+   BOOST_REQUIRE( trx_trace->receipt.valid() );
    BOOST_REQUIRE( bool(trx_trace) );
    BOOST_REQUIRE_EQUAL( transaction_receipt::executed, trx_trace->receipt->status );
    BOOST_REQUIRE_EQUAL( 1, trx_trace->action_traces.size() );
 
-   BOOST_REQUIRE_EQUAL( fc::unsigned_int{1}, trx_trace->action_traces[0].action_ordinal );
-   BOOST_REQUIRE_EQUAL( fc::unsigned_int{0}, trx_trace->action_traces[0].creator_action_ordinal );
-   BOOST_REQUIRE_EQUAL( fc::unsigned_int{0}, trx_trace->action_traces[0].closest_unnotified_ancestor_action_ordinal );
-   BOOST_REQUIRE_EQUAL( N(eosio.msig), action_name{trx_trace->action_traces[0].receiver} );
-   BOOST_REQUIRE_EQUAL( N(eosio.msig), name{trx_trace->action_traces[0].act.account} );
-   BOOST_REQUIRE_EQUAL( N(unapprove), name{trx_trace->action_traces[0].act.name} );
-   BOOST_REQUIRE_EQUAL( N(alice), name{trx_trace->action_traces[0].act.authorization[0].actor} );
-   BOOST_REQUIRE_EQUAL( N(active), name{trx_trace->action_traces[0].act.authorization[0].permission} );
+   BOOST_REQUIRE_EQUAL( fc::unsigned_int{1}, trx_trace->action_traces.at(0).action_ordinal );
+   BOOST_REQUIRE_EQUAL( fc::unsigned_int{0}, trx_trace->action_traces.at(0).creator_action_ordinal );
+   BOOST_REQUIRE_EQUAL( fc::unsigned_int{0}, trx_trace->action_traces.at(0).closest_unnotified_ancestor_action_ordinal );
+   BOOST_REQUIRE_EQUAL( N(eosio.msig), action_name{trx_trace->action_traces.at(0).receiver} );
+   BOOST_REQUIRE_EQUAL( N(eosio.msig), name{trx_trace->action_traces.at(0).act.account} );
+   BOOST_REQUIRE_EQUAL( N(unapprove), name{trx_trace->action_traces.at(0).act.name} );
+   BOOST_REQUIRE_EQUAL( N(alice), name{trx_trace->action_traces.at(0).act.authorization[0].actor} );
+   BOOST_REQUIRE_EQUAL( N(active), name{trx_trace->action_traces.at(0).act.authorization[0].permission} );
 } FC_LOG_AND_RETHROW()
 
 BOOST_FIXTURE_TEST_CASE( assert_if_context_free_actions_in_propose, eosio_msig_tester ) try {
    transaction trx = reqauth( N(alice), {permission_level{N(alice), config::active_name}}, abi_serializer_max_time );
    trx.context_free_actions.push_back( {} );
 
-   //since the `context_free_actions` vector is not empty, the transaction shall fail.
+   // since the `context_free_actions` vector is not empty, the transaction shall fail.
    BOOST_REQUIRE_EXCEPTION( push_action( N(alice), N(propose), mvo()
                                           ("proposer",      "alice")
                                           ("proposal_name", "first")
@@ -1263,6 +1243,104 @@ BOOST_FIXTURE_TEST_CASE( assert_if_context_free_actions_in_propose, eosio_msig_t
                             eosio_assert_message_exception,
                             eosio_assert_message_is("not allowed to `propose` a transaction with context-free actions")
    );
+} FC_LOG_AND_RETHROW()
+
+BOOST_FIXTURE_TEST_CASE( unnecessary_approve_logic, eosio_msig_tester ) try {
+   static constexpr uint32_t delay_sec = 1;
+   
+   // helper function.
+   static auto calculate_test_exec_time = [&] (uint32_t delay_sec) -> uint32_t {
+      return time_point{control->pending_block_time() + fc::seconds(delay_sec)}.sec_since_epoch();
+   };
+   
+   static transaction trx = reqauth( N(alice), {permission_level{N(alice), config::active_name}}, abi_serializer_max_time );
+   trx.delay_sec = delay_sec;
+   
+   push_action( N(alice), N(propose), mvo()
+                  ("proposer",      "alice")
+                  ("proposal_name", "first")
+                  ("trx",           trx)
+                  ("requested",     vector<permission_level>{{ N(alice), config::active_name },
+                                                             { N(bob), config::active_name }})
+   );
+   BOOST_REQUIRE_EQUAL( false, get_earliest_exec_time(N(alice), N(first)).valid() );
+
+   // cache the correctly expected value of `earliest_exec_time` into `exec_time`.
+   static uint32_t exec_time = calculate_test_exec_time(delay_sec);
+   
+   push_action( N(alice), N(approve), mvo()
+                  ("proposer",      "alice")
+                  ("proposal_name", "first")
+                  ("level",         permission_level{ N(alice), config::active_name })
+   );
+   BOOST_REQUIRE_EQUAL( exec_time, get_earliest_exec_time(N(alice), N(first))->sec_since_epoch() );
+
+   // produce a block to ensure consistency between `earliest_exec_time` and `exec_time`.
+   produce_block();
+
+   push_action( N(bob), N(approve), mvo()
+                  ("proposer",      "alice")
+                  ("proposal_name", "first")
+                  ("level",         permission_level{ N(bob), config::active_name })
+   );
+   BOOST_REQUIRE_EQUAL( exec_time, get_earliest_exec_time(N(alice), N(first))->sec_since_epoch() );
+
+   push_action( N(alice), N(unapprove), mvo()
+                           ("proposer",      "alice")
+                           ("proposal_name", "first")
+                           ("level",         permission_level{ N(alice), config::active_name })
+   );
+   BOOST_REQUIRE_EQUAL( false, get_earliest_exec_time(N(alice), N(first)).valid() );
+
+   // re-cache the correctly expected value of `earliest_exec_time` into `exec_time`.
+   exec_time = calculate_test_exec_time(delay_sec);
+
+   push_action( N(alice), N(approve), mvo()
+                  ("proposer",      "alice")
+                  ("proposal_name", "first")
+                  ("level",         permission_level{ N(alice), config::active_name })
+   );
+   BOOST_REQUIRE_EQUAL( exec_time, get_earliest_exec_time(N(alice), N(first))->sec_since_epoch() );
+
+   // produce a block to ensure consistency between `earliest_exec_time` and `exec_time`.
+   produce_block();
+
+   push_action( N(bob), N(unapprove), mvo()
+                         ("proposer",      "alice")
+                         ("proposal_name", "first")
+                         ("level",         permission_level{ N(bob), config::active_name })
+   );
+   BOOST_REQUIRE_EQUAL( exec_time, get_earliest_exec_time(N(alice), N(first))->sec_since_epoch() );
+   
+   transaction_trace_ptr trx_trace;
+   trx_trace = push_action( N(alice), N(exec), mvo()
+                             ("proposer",      "alice")
+                             ("proposal_name", "first")
+                             ("executer",      "alice")
+   );
+
+   BOOST_REQUIRE( trx_trace->receipt.valid() );
+   BOOST_REQUIRE( bool(trx_trace) );
+   BOOST_REQUIRE_EQUAL( transaction_receipt::executed, trx_trace->receipt->status );
+   BOOST_REQUIRE_EQUAL( 2, trx_trace->action_traces.size() );
+
+   BOOST_REQUIRE_EQUAL( fc::unsigned_int{1}, trx_trace->action_traces.at(0).action_ordinal );
+   BOOST_REQUIRE_EQUAL( fc::unsigned_int{0}, trx_trace->action_traces.at(0).creator_action_ordinal );
+   BOOST_REQUIRE_EQUAL( fc::unsigned_int{0}, trx_trace->action_traces.at(0).closest_unnotified_ancestor_action_ordinal );
+   BOOST_REQUIRE_EQUAL( N(eosio.msig), action_name{trx_trace->action_traces.at(0).receiver} );
+   BOOST_REQUIRE_EQUAL( N(eosio.msig), name{trx_trace->action_traces.at(0).act.account} );
+   BOOST_REQUIRE_EQUAL( N(exec), name{trx_trace->action_traces.at(0).act.name} );
+   BOOST_REQUIRE_EQUAL( N(alice), name{trx_trace->action_traces.at(0).act.authorization[0].actor} );
+   BOOST_REQUIRE_EQUAL( N(active), name{trx_trace->action_traces.at(0).act.authorization[0].permission} );
+
+   BOOST_REQUIRE_EQUAL( fc::unsigned_int{2}, trx_trace->action_traces.at(1).action_ordinal );
+   BOOST_REQUIRE_EQUAL( fc::unsigned_int{1}, trx_trace->action_traces.at(1).creator_action_ordinal );
+   BOOST_REQUIRE_EQUAL( fc::unsigned_int{1}, trx_trace->action_traces.at(1).closest_unnotified_ancestor_action_ordinal );
+   BOOST_REQUIRE_EQUAL( N(eosio), action_name{trx_trace->action_traces.at(1).receiver} );
+   BOOST_REQUIRE_EQUAL( N(eosio), name{trx_trace->action_traces.at(1).act.account} );
+   BOOST_REQUIRE_EQUAL( N(reqauth), name{trx_trace->action_traces.at(1).act.name} );
+   BOOST_REQUIRE_EQUAL( N(alice), name{trx_trace->action_traces.at(1).act.authorization[0].actor} );
+   BOOST_REQUIRE_EQUAL( N(active), name{trx_trace->action_traces.at(1).act.authorization[0].permission} );
 } FC_LOG_AND_RETHROW()
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/tests/eosio.system_tests.cpp
+++ b/tests/eosio.system_tests.cpp
@@ -2775,6 +2775,7 @@ BOOST_FIXTURE_TEST_CASE(producers_upgrade_system_contract, eosio_system_tester) 
                                           ("executer",      "alice1111111") );
 
    BOOST_REQUIRE( bool(trx_trace) );
+   BOOST_REQUIRE( trx_trace->receipt.valid() );
    BOOST_REQUIRE_EQUAL( transaction_receipt::executed, trx_trace->receipt->status );
    BOOST_REQUIRE_EQUAL( 2, trx_trace->action_traces.size() );
 
@@ -3556,6 +3557,7 @@ BOOST_FIXTURE_TEST_CASE( setparams, eosio_system_tester ) try {
                                           ("executer",      "alice1111111") );
 
    BOOST_REQUIRE( bool(trx_trace) );
+   BOOST_REQUIRE( trx_trace->receipt.valid() );
    BOOST_REQUIRE_EQUAL( transaction_receipt::executed, trx_trace->receipt->status );
    BOOST_REQUIRE_EQUAL( 2, trx_trace->action_traces.size() );
 

--- a/tests/eosio.system_tests.cpp
+++ b/tests/eosio.system_tests.cpp
@@ -176,27 +176,27 @@ BOOST_FIXTURE_TEST_CASE( buysell, eosio_system_tester ) try {
 
 BOOST_FIXTURE_TEST_CASE( stake_unstake, eosio_system_tester ) try {
    cross_15_percent_threshold();
-   
+
    produce_blocks( 10 );
    produce_block( fc::hours(3*24) );
-   
+
    BOOST_REQUIRE_EQUAL( core_sym::from_string("0.0000"), get_balance( "alice1111111" ) );
    transfer( "eosio", "alice1111111", core_sym::from_string("1000.0000"), "eosio" );
-   
+
    BOOST_REQUIRE_EQUAL( core_sym::from_string("1000.0000"), get_balance( "alice1111111" ) );
    BOOST_REQUIRE_EQUAL( success(), stake( "eosio", "alice1111111", core_sym::from_string("200.0000"), core_sym::from_string("100.0000") ) );
-   
+
    auto total = get_total_stake("alice1111111");
    BOOST_REQUIRE_EQUAL( core_sym::from_string("210.0000"), total["net_weight"].as<asset>());
    BOOST_REQUIRE_EQUAL( core_sym::from_string("110.0000"), total["cpu_weight"].as<asset>());
-   
+
    const auto init_eosio_stake_balance = get_balance( N(eosio.stake) );
    BOOST_REQUIRE_EQUAL( success(), stake( "alice1111111", "alice1111111", core_sym::from_string("200.0000"), core_sym::from_string("100.0000") ) );
    BOOST_REQUIRE_EQUAL( core_sym::from_string("700.0000"), get_balance( "alice1111111" ) );
    BOOST_REQUIRE_EQUAL( init_eosio_stake_balance + core_sym::from_string("300.0000"), get_balance( N(eosio.stake) ) );
    BOOST_REQUIRE_EQUAL( success(), unstake( "alice1111111", "alice1111111", core_sym::from_string("200.0000"), core_sym::from_string("100.0000") ) );
    BOOST_REQUIRE_EQUAL( core_sym::from_string("700.0000"), get_balance( "alice1111111" ) );
-   
+
    produce_block( fc::hours(3*24-1) );
    BOOST_REQUIRE_EXCEPTION( base_tester::push_action( config::system_account_name, N(refund), N(alice1111111), mutable_variant_object()
                                                                                     ("owner", N(alice1111111)) ),
@@ -212,25 +212,25 @@ BOOST_FIXTURE_TEST_CASE( stake_unstake, eosio_system_tester ) try {
                                                            ("owner", N(alice1111111))
    );
    produce_blocks(1);
-   
+
    BOOST_REQUIRE_EQUAL( core_sym::from_string("1000.0000"), get_balance( "alice1111111" ) );
    BOOST_REQUIRE_EQUAL( init_eosio_stake_balance, get_balance( N(eosio.stake) ) );
-   
+
    BOOST_REQUIRE_EQUAL( success(), stake( "alice1111111", "bob111111111", core_sym::from_string("200.0000"), core_sym::from_string("100.0000") ) );
    BOOST_REQUIRE_EQUAL( core_sym::from_string("700.0000"), get_balance( "alice1111111" ) );
    total = get_total_stake("bob111111111");
    BOOST_REQUIRE_EQUAL( core_sym::from_string("210.0000"), total["net_weight"].as<asset>());
    BOOST_REQUIRE_EQUAL( core_sym::from_string("110.0000"), total["cpu_weight"].as<asset>());
-   
+
    total = get_total_stake( "alice1111111" );
    BOOST_REQUIRE_EQUAL( core_sym::from_string("210.0000").get_amount(), total["net_weight"].as<asset>().get_amount() );
    BOOST_REQUIRE_EQUAL( core_sym::from_string("110.0000").get_amount(), total["cpu_weight"].as<asset>().get_amount() );
-   
+
    REQUIRE_MATCHING_OBJECT( voter( "alice1111111", core_sym::from_string("300.0000")), get_voter_info( "alice1111111" ) );
-   
+
    auto bytes = total["ram_bytes"].as_uint64();
    BOOST_REQUIRE_EQUAL( true, 0 < bytes );
-   
+
    //unstake from bob111111111
    BOOST_REQUIRE_EQUAL( success(), unstake( "alice1111111", "bob111111111", core_sym::from_string("200.0000"), core_sym::from_string("100.0000") ) );
    total = get_total_stake("bob111111111");
@@ -2679,7 +2679,7 @@ BOOST_FIXTURE_TEST_CASE(producers_upgrade_system_contract, eosio_system_tester) 
                               ("params", params) );
 
    produce_blocks();
-   
+
    //install multisig contract
    abi_serializer msig_abi_ser = initialize_multisig();
    auto producer_names = active_and_vote_producers();
@@ -3285,11 +3285,11 @@ BOOST_FIXTURE_TEST_CASE( multiple_namebids, eosio_system_tester ) try {
       const asset initial_names_balance = get_balance(N(eosio.names));
       BOOST_REQUIRE_EQUAL( success(),
                            bidname( "alice", "prefb", core_sym::from_string("1.1001") ) );
-      
+
       base_tester::push_action( config::system_account_name, N(bidrefund), vector<account_name>{ N(bob) }, mvo()
                                                               ("bidder", "bob")
                                                               ("newname", "prefb") );
-      
+
       BOOST_REQUIRE_EQUAL( core_sym::from_string( "9997.9997" ), get_balance("bob") );
       BOOST_REQUIRE_EQUAL( core_sym::from_string( "9998.8999" ), get_balance("alice") );
       BOOST_REQUIRE_EQUAL( initial_names_balance + core_sym::from_string("0.1001"), get_balance(N(eosio.names)) );
@@ -3305,7 +3305,7 @@ BOOST_FIXTURE_TEST_CASE( multiple_namebids, eosio_system_tester ) try {
       base_tester::push_action( config::system_account_name, N(bidrefund), vector<account_name>{ N(carl) }, mvo()
                                                               ("bidder", "carl")
                                                               ("newname", "prefd") );
-      
+
       BOOST_REQUIRE_EQUAL( core_sym::from_string( "9999.0000" ), get_balance("carl") );
       BOOST_REQUIRE_EQUAL( core_sym::from_string( "9998.0100" ), get_balance("david") );
    }
@@ -4533,11 +4533,11 @@ BOOST_FIXTURE_TEST_CASE( ramfee_namebid_to_rex, eosio_system_tester ) try {
    BOOST_REQUIRE_EQUAL( success(),                        bidname( carol, N(rndmbid), core_sym::from_string("23.7000") ) );
    BOOST_REQUIRE_EQUAL( core_sym::from_string("23.7000"), get_balance( N(eosio.names) ) );
    BOOST_REQUIRE_EQUAL( success(),                        bidname( alice, N(rndmbid), core_sym::from_string("29.3500") ) );
-   
+
    base_tester::push_action( config::system_account_name, N(bidrefund), vector<account_name>{ N(carolaccount) }, mvo()
                                                            ("bidder", "carolaccount")
                                                            ("newname", "rndmbid") );
-   
+
    BOOST_REQUIRE_EQUAL( core_sym::from_string("29.3500"), get_balance( N(eosio.names) ));
 
    produce_block();
@@ -4549,11 +4549,11 @@ BOOST_FIXTURE_TEST_CASE( ramfee_namebid_to_rex, eosio_system_tester ) try {
    BOOST_REQUIRE_EQUAL( success(),                        buyrex( frank, core_sym::from_string("5.0000") ) );
    BOOST_REQUIRE_EQUAL( get_balance( N(eosio.rex) ),      cur_rex_balance + core_sym::from_string("34.3500") );
    BOOST_REQUIRE_EQUAL( 0,                                get_balance( N(eosio.names) ).get_amount() );
-   
+
    cur_rex_balance = get_balance( N(eosio.rex) );
    produce_block( fc::hours(30*24 + 13) );
    produce_blocks( 1 );
-   
+
    BOOST_REQUIRE_EQUAL( success(),                        rexexec( alice, 1 ) );
    BOOST_REQUIRE_EQUAL( cur_rex_balance,                  get_rex_pool()["total_lendable"].as<asset>() );
    BOOST_REQUIRE_EQUAL( get_rex_pool()["total_lendable"].as<asset>(),
@@ -5504,7 +5504,7 @@ BOOST_FIXTURE_TEST_CASE( rex_return, eosio_system_tester ) try {
       BOOST_REQUIRE_EQUAL( success(),        rexexec( bob, 1 ) );
       BOOST_REQUIRE_EQUAL( 0,                get_rex_return_buckets()["return_buckets"].get_array().size() );
    }
-   
+
 } FC_LOG_AND_RETHROW()
 
 

--- a/tests/eosio.system_tests.cpp
+++ b/tests/eosio.system_tests.cpp
@@ -3285,6 +3285,11 @@ BOOST_FIXTURE_TEST_CASE( multiple_namebids, eosio_system_tester ) try {
       const asset initial_names_balance = get_balance(N(eosio.names));
       BOOST_REQUIRE_EQUAL( success(),
                            bidname( "alice", "prefb", core_sym::from_string("1.1001") ) );
+      
+      base_tester::push_action( config::system_account_name, N(bidrefund), vector<account_name>{ N(bob) }, mvo()
+                                                              ("bidder", "bob")
+                                                              ("newname", "prefb") );
+      
       BOOST_REQUIRE_EQUAL( core_sym::from_string( "9997.9997" ), get_balance("bob") );
       BOOST_REQUIRE_EQUAL( core_sym::from_string( "9998.8999" ), get_balance("alice") );
       BOOST_REQUIRE_EQUAL( initial_names_balance + core_sym::from_string("0.1001"), get_balance(N(eosio.names)) );
@@ -3296,6 +3301,11 @@ BOOST_FIXTURE_TEST_CASE( multiple_namebids, eosio_system_tester ) try {
       BOOST_REQUIRE_EQUAL( core_sym::from_string( "10000.0000" ), get_balance("david") );
       BOOST_REQUIRE_EQUAL( success(),
                            bidname( "david", "prefd", core_sym::from_string("1.9900") ) );
+
+      base_tester::push_action( config::system_account_name, N(bidrefund), vector<account_name>{ N(carl) }, mvo()
+                                                              ("bidder", "carl")
+                                                              ("newname", "prefd") );
+      
       BOOST_REQUIRE_EQUAL( core_sym::from_string( "9999.0000" ), get_balance("carl") );
       BOOST_REQUIRE_EQUAL( core_sym::from_string( "9998.0100" ), get_balance("david") );
    }
@@ -4523,8 +4533,14 @@ BOOST_FIXTURE_TEST_CASE( ramfee_namebid_to_rex, eosio_system_tester ) try {
    BOOST_REQUIRE_EQUAL( success(),                        bidname( carol, N(rndmbid), core_sym::from_string("23.7000") ) );
    BOOST_REQUIRE_EQUAL( core_sym::from_string("23.7000"), get_balance( N(eosio.names) ) );
    BOOST_REQUIRE_EQUAL( success(),                        bidname( alice, N(rndmbid), core_sym::from_string("29.3500") ) );
+   
+   base_tester::push_action( config::system_account_name, N(bidrefund), vector<account_name>{ N(carolaccount) }, mvo()
+                                                           ("bidder", "carolaccount")
+                                                           ("newname", "rndmbid") );
+   
    BOOST_REQUIRE_EQUAL( core_sym::from_string("29.3500"), get_balance( N(eosio.names) ));
 
+   produce_block();
    produce_block( fc::hours(24) );
    produce_blocks( 2 );
 
@@ -4533,11 +4549,11 @@ BOOST_FIXTURE_TEST_CASE( ramfee_namebid_to_rex, eosio_system_tester ) try {
    BOOST_REQUIRE_EQUAL( success(),                        buyrex( frank, core_sym::from_string("5.0000") ) );
    BOOST_REQUIRE_EQUAL( get_balance( N(eosio.rex) ),      cur_rex_balance + core_sym::from_string("34.3500") );
    BOOST_REQUIRE_EQUAL( 0,                                get_balance( N(eosio.names) ).get_amount() );
-
+   
    cur_rex_balance = get_balance( N(eosio.rex) );
    produce_block( fc::hours(30*24 + 13) );
    produce_blocks( 1 );
-
+   
    BOOST_REQUIRE_EQUAL( success(),                        rexexec( alice, 1 ) );
    BOOST_REQUIRE_EQUAL( cur_rex_balance,                  get_rex_pool()["total_lendable"].as<asset>() );
    BOOST_REQUIRE_EQUAL( get_rex_pool()["total_lendable"].as<asset>(),

--- a/tests/eosio.system_tests.cpp
+++ b/tests/eosio.system_tests.cpp
@@ -2774,8 +2774,6 @@ BOOST_FIXTURE_TEST_CASE(producers_upgrade_system_contract, eosio_system_tester) 
                                           ("proposal_name", "upgrade1")
                                           ("executer",      "alice1111111") );
 
-   wdump((fc::json::to_pretty_string(trx_trace)));
-
    BOOST_REQUIRE( bool(trx_trace) );
    BOOST_REQUIRE_EQUAL( transaction_receipt::executed, trx_trace->receipt->status );
    BOOST_REQUIRE_EQUAL( 2, trx_trace->action_traces.size() );
@@ -3556,8 +3554,6 @@ BOOST_FIXTURE_TEST_CASE( setparams, eosio_system_tester ) try {
                                           ("proposer",      "alice1111111")
                                           ("proposal_name", "setparams1")
                                           ("executer",      "alice1111111") );
-
-   wdump((fc::json::to_pretty_string(trx_trace)));
 
    BOOST_REQUIRE( bool(trx_trace) );
    BOOST_REQUIRE_EQUAL( transaction_receipt::executed, trx_trace->receipt->status );

--- a/tests/eosio.wrap_tests.cpp
+++ b/tests/eosio.wrap_tests.cpp
@@ -176,8 +176,8 @@ BOOST_FIXTURE_TEST_CASE( wrap_exec_direct, eosio_wrap_tester ) try {
 
    produce_block();
 
-   BOOST_REQUIRE( trx_trace->receipt.valid() );
    BOOST_REQUIRE( bool(trx_trace) );
+   BOOST_REQUIRE( trx_trace->receipt.valid() );
    BOOST_REQUIRE_EQUAL( transaction_receipt::executed, trx_trace->receipt->status );
    BOOST_REQUIRE_EQUAL( 2, trx_trace->action_traces.size() );
 
@@ -227,8 +227,8 @@ BOOST_FIXTURE_TEST_CASE( wrap_with_msig, eosio_wrap_tester ) try {
                               ("executer",      "alice")
    );
 
-   BOOST_REQUIRE( trx_trace->receipt.valid() );
    BOOST_REQUIRE( bool(trx_trace) );
+   BOOST_REQUIRE( trx_trace->receipt.valid() );
    BOOST_REQUIRE_EQUAL( transaction_receipt::executed, trx_trace->receipt->status );
    BOOST_REQUIRE_EQUAL( 3, trx_trace->action_traces.size() );
 
@@ -264,7 +264,8 @@ BOOST_FIXTURE_TEST_CASE( wrap_with_msig, eosio_wrap_tester ) try {
 
 BOOST_FIXTURE_TEST_CASE( wrap_with_msig_unapprove, eosio_wrap_tester ) try {
    transaction trx = reqauth( N(bob), {permission_level{N(bob), config::active_name}} );
-   transaction wrap_trx = wrap_exec( N(alice), trx, 36000 );
+   // transaction wrap_trx = wrap_exec( N(alice), trx, 36000 );
+   transaction wrap_trx = wrap_exec( N(alice), trx, {} );
 
    propose( N(carol), N(first),
             { {N(alice), N(active)},
@@ -353,8 +354,8 @@ BOOST_FIXTURE_TEST_CASE( wrap_with_msig_producers_change, eosio_wrap_tester ) tr
                               ("executer",      "alice")
    );
 
-   BOOST_REQUIRE( trx_trace->receipt.valid() );
    BOOST_REQUIRE( bool(trx_trace) );
+   BOOST_REQUIRE( trx_trace->receipt.valid() );
    BOOST_REQUIRE_EQUAL( transaction_receipt::executed, trx_trace->receipt->status );
    BOOST_REQUIRE_EQUAL( 3, trx_trace->action_traces.size() );
 

--- a/tests/eosio.wrap_tests.cpp
+++ b/tests/eosio.wrap_tests.cpp
@@ -163,46 +163,46 @@ transaction eosio_wrap_tester::reqauth( account_name from, const vector<permissi
 BOOST_AUTO_TEST_SUITE(eosio_wrap_tests)
 
 BOOST_FIXTURE_TEST_CASE( wrap_exec_direct, eosio_wrap_tester ) try {
-   auto trx = reqauth( N(bob), {permission_level{N(bob), config::active_name}} );
+   transaction trx = reqauth( N(bob), {permission_level{N(bob), config::active_name}} );
+   signed_transaction wrap_trx( wrap_exec( N(alice), trx ), {}, {} );
 
-   transaction_trace_ptr trace;
-   control->applied_transaction.connect(
-   [&]( std::tuple<const transaction_trace_ptr&, const signed_transaction&> p ) {
-      const auto& t = std::get<0>(p);
-      if( t->scheduled ) { trace = t; }
-   } );
-
-   {
-      signed_transaction wrap_trx( wrap_exec( N(alice), trx ), {}, {} );
-      /*
-      set_transaction_headers( wrap_trx );
-      wrap_trx.actions.emplace_back( get_action( N(eosio.wrap), N(exec),
-                                                 {{N(alice), config::active_name}, {N(eosio.wrap), config::active_name}},
-                                                 mvo()
-                                                   ("executer", "alice")
-                                                   ("trx", trx)
-      ) );
-      */
-      wrap_trx.sign( get_private_key( N(alice), "active" ), control->get_chain_id() );
-      for( const auto& actor : {N(prod1), N(prod2), N(prod3), N(prod4)} ) {
-         wrap_trx.sign( get_private_key( actor, "active" ), control->get_chain_id() );
-      }
-      push_transaction( wrap_trx );
+   wrap_trx.sign( get_private_key( N(alice), "active" ), control->get_chain_id() );
+   for( const auto& actor : {N(prod1), N(prod2), N(prod3), N(prod4)} ) {
+      wrap_trx.sign( get_private_key( actor, "active" ), control->get_chain_id() );
    }
 
+   transaction_trace_ptr trx_trace;
+   trx_trace = push_transaction( wrap_trx );
+
    produce_block();
+   wdump((fc::json::to_pretty_string(trx_trace)));
 
-   BOOST_REQUIRE( bool(trace) );
-   BOOST_REQUIRE_EQUAL( 1, trace->action_traces.size() );
-   BOOST_REQUIRE_EQUAL( config::system_account_name, name{trace->action_traces[0].act.account} );
-   BOOST_REQUIRE_EQUAL( N(reqauth), name{trace->action_traces[0].act.name} );
-   BOOST_REQUIRE_EQUAL( transaction_receipt::executed, trace->receipt->status );
-
+   BOOST_REQUIRE( bool(trx_trace) );
+   BOOST_REQUIRE_EQUAL( transaction_receipt::executed, trx_trace->receipt->status );
+   BOOST_REQUIRE_EQUAL( 2, trx_trace->action_traces.size() );
+   BOOST_REQUIRE_EQUAL( fc::unsigned_int{1}, trx_trace->action_traces[0].action_ordinal );
+   BOOST_REQUIRE_EQUAL( fc::unsigned_int{0}, trx_trace->action_traces[0].creator_action_ordinal );
+   BOOST_REQUIRE_EQUAL( fc::unsigned_int{0}, trx_trace->action_traces[0].closest_unnotified_ancestor_action_ordinal );
+   BOOST_REQUIRE_EQUAL( N(eosio.wrap), action_name{trx_trace->action_traces[0].receiver} );
+   BOOST_REQUIRE_EQUAL( N(eosio.wrap), name{trx_trace->action_traces[0].act.account} );
+   BOOST_REQUIRE_EQUAL( N(exec), name{trx_trace->action_traces[0].act.name} );
+   BOOST_REQUIRE_EQUAL( N(alice), name{trx_trace->action_traces[0].act.authorization[0].actor} );
+   BOOST_REQUIRE_EQUAL( N(active), name{trx_trace->action_traces[0].act.authorization[0].permission} );
+   BOOST_REQUIRE_EQUAL( N(eosio.wrap), name{trx_trace->action_traces[0].act.authorization[1].actor} );
+   BOOST_REQUIRE_EQUAL( N(active), name{trx_trace->action_traces[0].act.authorization[1].permission} );
+   BOOST_REQUIRE_EQUAL( fc::unsigned_int{2}, trx_trace->action_traces[1].action_ordinal );
+   BOOST_REQUIRE_EQUAL( fc::unsigned_int{1}, trx_trace->action_traces[1].creator_action_ordinal );
+   BOOST_REQUIRE_EQUAL( fc::unsigned_int{1}, trx_trace->action_traces[1].closest_unnotified_ancestor_action_ordinal );
+   BOOST_REQUIRE_EQUAL( N(eosio), action_name{trx_trace->action_traces[1].receiver} );
+   BOOST_REQUIRE_EQUAL( N(eosio), name{trx_trace->action_traces[1].act.account} );
+   BOOST_REQUIRE_EQUAL( N(reqauth), name{trx_trace->action_traces[1].act.name} );
+   BOOST_REQUIRE_EQUAL( N(bob), name{trx_trace->action_traces[1].act.authorization[0].actor} );
+   BOOST_REQUIRE_EQUAL( N(active), name{trx_trace->action_traces[1].act.authorization[0].permission} );
 } FC_LOG_AND_RETHROW()
 
 BOOST_FIXTURE_TEST_CASE( wrap_with_msig, eosio_wrap_tester ) try {
-   auto trx = reqauth( N(bob), {permission_level{N(bob), config::active_name}} );
-   auto wrap_trx = wrap_exec( N(alice), trx );
+   transaction trx = reqauth( N(bob), {permission_level{N(bob), config::active_name}} );
+   signed_transaction wrap_trx( wrap_exec( N(alice), trx), {}, {} );
 
    propose( N(carol), N(first),
             { {N(alice), N(active)},
@@ -217,41 +217,64 @@ BOOST_FIXTURE_TEST_CASE( wrap_with_msig, eosio_wrap_tester ) try {
    approve( N(carol), N(first), N(prod3) );
    approve( N(carol), N(first), N(prod4) );
 
-   vector<transaction_trace_ptr> traces;
+   transaction_trace_ptr trx_trace;
+   transaction_trace_ptr deferred_trx_trace;
+
+   // Now the proposal should be ready to execute
+   trx_trace = push_action( N(eosio.msig), N(exec), N(alice), mvo()
+                              ("proposer",      "carol")
+                              ("proposal_name", "first")
+                              ("executer",      "alice")
+   );
+
    control->applied_transaction.connect(
    [&]( std::tuple<const transaction_trace_ptr&, const signed_transaction&> p ) {
       const auto& t = std::get<0>(p);
-      if( t->scheduled ) {
-         traces.push_back( t );
-      }
+      if( t->scheduled ) { deferred_trx_trace = t; }
    } );
 
-   // Now the proposal should be ready to execute
-   push_action( N(eosio.msig), N(exec), N(alice), mvo()
-                  ("proposer",      "carol")
-                  ("proposal_name", "first")
-                  ("executer",      "alice")
-   );
-
    produce_block();
+   wdump((fc::json::to_pretty_string(trx_trace)));
+   wdump((fc::json::to_pretty_string(deferred_trx_trace)));
 
-   BOOST_REQUIRE_EQUAL( 2, traces.size() );
+   BOOST_REQUIRE( bool(trx_trace) );
+   BOOST_REQUIRE_EQUAL( transaction_receipt::executed, trx_trace->receipt->status );
+   BOOST_REQUIRE_EQUAL( 1, trx_trace->action_traces.size() );
+   BOOST_REQUIRE_EQUAL( fc::unsigned_int{1}, trx_trace->action_traces[0].action_ordinal );
+   BOOST_REQUIRE_EQUAL( fc::unsigned_int{0}, trx_trace->action_traces[0].creator_action_ordinal );
+   BOOST_REQUIRE_EQUAL( fc::unsigned_int{0}, trx_trace->action_traces[0].closest_unnotified_ancestor_action_ordinal );
+   BOOST_REQUIRE_EQUAL( N(eosio.msig), action_name{trx_trace->action_traces[0].receiver} );
+   BOOST_REQUIRE_EQUAL( N(eosio.msig), name{trx_trace->action_traces[0].act.account} );
+   BOOST_REQUIRE_EQUAL( N(exec), name{trx_trace->action_traces[0].act.name} );
+   BOOST_REQUIRE_EQUAL( N(alice), name{trx_trace->action_traces[0].act.authorization[0].actor} );
+   BOOST_REQUIRE_EQUAL( N(active), name{trx_trace->action_traces[0].act.authorization[0].permission} );
 
-   BOOST_REQUIRE_EQUAL( 1, traces[0]->action_traces.size() );
-   BOOST_REQUIRE_EQUAL( N(eosio.wrap), name{traces[0]->action_traces[0].act.account} );
-   BOOST_REQUIRE_EQUAL( N(exec), name{traces[0]->action_traces[0].act.name} );
-   BOOST_REQUIRE_EQUAL( transaction_receipt::executed, traces[0]->receipt->status );
-
-   BOOST_REQUIRE_EQUAL( 1, traces[1]->action_traces.size() );
-   BOOST_REQUIRE_EQUAL( config::system_account_name, name{traces[1]->action_traces[0].act.account} );
-   BOOST_REQUIRE_EQUAL( N(reqauth), name{traces[1]->action_traces[0].act.name} );
-   BOOST_REQUIRE_EQUAL( transaction_receipt::executed, traces[1]->receipt->status );
-
+   BOOST_REQUIRE( bool(deferred_trx_trace) );
+   BOOST_REQUIRE_EQUAL( transaction_receipt::executed, deferred_trx_trace->receipt->status );
+   BOOST_REQUIRE_EQUAL( 2, deferred_trx_trace->action_traces.size() );
+   BOOST_REQUIRE_EQUAL( fc::unsigned_int{1}, deferred_trx_trace->action_traces[0].action_ordinal );
+   BOOST_REQUIRE_EQUAL( fc::unsigned_int{0}, deferred_trx_trace->action_traces[0].creator_action_ordinal );
+   BOOST_REQUIRE_EQUAL( fc::unsigned_int{0}, deferred_trx_trace->action_traces[0].closest_unnotified_ancestor_action_ordinal );
+   BOOST_REQUIRE_EQUAL( N(eosio.wrap), action_name{deferred_trx_trace->action_traces[0].receiver} );
+   BOOST_REQUIRE_EQUAL( N(eosio.wrap), name{deferred_trx_trace->action_traces[0].act.account} );
+   BOOST_REQUIRE_EQUAL( N(exec), name{deferred_trx_trace->action_traces[0].act.name} );
+   BOOST_REQUIRE_EQUAL( N(alice), name{deferred_trx_trace->action_traces[0].act.authorization[0].actor} );
+   BOOST_REQUIRE_EQUAL( N(active), name{deferred_trx_trace->action_traces[0].act.authorization[0].permission} );
+   BOOST_REQUIRE_EQUAL( N(eosio.wrap), name{deferred_trx_trace->action_traces[0].act.authorization[1].actor} );
+   BOOST_REQUIRE_EQUAL( N(active), name{deferred_trx_trace->action_traces[0].act.authorization[1].permission} );
+   BOOST_REQUIRE_EQUAL( fc::unsigned_int{2}, deferred_trx_trace->action_traces[1].action_ordinal );
+   BOOST_REQUIRE_EQUAL( fc::unsigned_int{1}, deferred_trx_trace->action_traces[1].creator_action_ordinal );
+   BOOST_REQUIRE_EQUAL( fc::unsigned_int{1}, deferred_trx_trace->action_traces[1].closest_unnotified_ancestor_action_ordinal );
+   BOOST_REQUIRE_EQUAL( N(eosio), action_name{deferred_trx_trace->action_traces[1].receiver} );
+   BOOST_REQUIRE_EQUAL( N(eosio), name{deferred_trx_trace->action_traces[1].act.account} );
+   BOOST_REQUIRE_EQUAL( N(reqauth), name{deferred_trx_trace->action_traces[1].act.name} );
+   BOOST_REQUIRE_EQUAL( N(bob), name{deferred_trx_trace->action_traces[1].act.authorization[0].actor} );
+   BOOST_REQUIRE_EQUAL( N(active), name{deferred_trx_trace->action_traces[1].act.authorization[0].permission} );
 } FC_LOG_AND_RETHROW()
 
 BOOST_FIXTURE_TEST_CASE( wrap_with_msig_unapprove, eosio_wrap_tester ) try {
-   auto trx = reqauth( N(bob), {permission_level{N(bob), config::active_name}} );
-   auto wrap_trx = wrap_exec( N(alice), trx );
+   transaction trx = reqauth( N(bob), {permission_level{N(bob), config::active_name}} );
+   signed_transaction wrap_trx( wrap_exec( N(alice), trx ), {}, {} );
 
    propose( N(carol), N(first),
             { {N(alice), N(active)},
@@ -281,14 +304,13 @@ BOOST_FIXTURE_TEST_CASE( wrap_with_msig_unapprove, eosio_wrap_tester ) try {
                                        ), eosio_assert_message_exception,
                                           eosio_assert_message_is("transaction authorization failed")
    );
-
 } FC_LOG_AND_RETHROW()
 
 BOOST_FIXTURE_TEST_CASE( wrap_with_msig_producers_change, eosio_wrap_tester ) try {
    create_accounts( { N(newprod1) } );
 
-   auto trx = reqauth( N(bob), {permission_level{N(bob), config::active_name}} );
-   auto wrap_trx = wrap_exec( N(alice), trx, 36000 );
+   transaction trx = reqauth( N(bob), {permission_level{N(bob), config::active_name}} );
+   signed_transaction wrap_trx( wrap_exec( N(alice), trx, 36000 ), {}, {} );
 
    propose( N(carol), N(first),
             { {N(alice), N(active)},
@@ -333,36 +355,59 @@ BOOST_FIXTURE_TEST_CASE( wrap_with_msig_producers_change, eosio_wrap_tester ) tr
    // But prod5 still can provide the fifth approval necessary to satisfy the 2/3+1 threshold of the new producer set
    approve( N(carol), N(first), N(prod5) );
 
-   vector<transaction_trace_ptr> traces;
+   transaction_trace_ptr trx_trace;
+   transaction_trace_ptr deferred_trx_trace;
+
+   // Now the proposal should be ready to execute
+   trx_trace = push_action( N(eosio.msig), N(exec), N(alice), mvo()
+                              ("proposer",      "carol")
+                              ("proposal_name", "first")
+                              ("executer",      "alice")
+   );
+
    control->applied_transaction.connect(
    [&]( std::tuple<const transaction_trace_ptr&, const signed_transaction&> p ) {
       const auto& t = std::get<0>(p);
-      if( t->scheduled ) {
-         traces.push_back( t );
-      }
+      if( t->scheduled ) { deferred_trx_trace = t; }
    } );
 
-   // Now the proposal should be ready to execute
-   push_action( N(eosio.msig), N(exec), N(alice), mvo()
-                  ("proposer",      "carol")
-                  ("proposal_name", "first")
-                  ("executer",      "alice")
-   );
-
    produce_block();
+   wdump((fc::json::to_pretty_string(trx_trace)));
+   wdump((fc::json::to_pretty_string(deferred_trx_trace)));
 
-   BOOST_REQUIRE_EQUAL( 2, traces.size() );
+   BOOST_REQUIRE( bool(trx_trace) );
+   BOOST_REQUIRE_EQUAL( transaction_receipt::executed, trx_trace->receipt->status );
+   BOOST_REQUIRE_EQUAL( 1, trx_trace->action_traces.size() );
+   BOOST_REQUIRE_EQUAL( fc::unsigned_int{1}, trx_trace->action_traces[0].action_ordinal );
+   BOOST_REQUIRE_EQUAL( fc::unsigned_int{0}, trx_trace->action_traces[0].creator_action_ordinal );
+   BOOST_REQUIRE_EQUAL( fc::unsigned_int{0}, trx_trace->action_traces[0].closest_unnotified_ancestor_action_ordinal );
+   BOOST_REQUIRE_EQUAL( N(eosio.msig), action_name{trx_trace->action_traces[0].receiver} );
+   BOOST_REQUIRE_EQUAL( N(eosio.msig), name{trx_trace->action_traces[0].act.account} );
+   BOOST_REQUIRE_EQUAL( N(exec), name{trx_trace->action_traces[0].act.name} );
+   BOOST_REQUIRE_EQUAL( N(alice), name{trx_trace->action_traces[0].act.authorization[0].actor} );
+   BOOST_REQUIRE_EQUAL( N(active), name{trx_trace->action_traces[0].act.authorization[0].permission} );
 
-   BOOST_REQUIRE_EQUAL( 1, traces[0]->action_traces.size() );
-   BOOST_REQUIRE_EQUAL( N(eosio.wrap), name{traces[0]->action_traces[0].act.account} );
-   BOOST_REQUIRE_EQUAL( N(exec), name{traces[0]->action_traces[0].act.name} );
-   BOOST_REQUIRE_EQUAL( transaction_receipt::executed, traces[0]->receipt->status );
-
-   BOOST_REQUIRE_EQUAL( 1, traces[1]->action_traces.size() );
-   BOOST_REQUIRE_EQUAL( config::system_account_name, name{traces[1]->action_traces[0].act.account} );
-   BOOST_REQUIRE_EQUAL( N(reqauth), name{traces[1]->action_traces[0].act.name} );
-   BOOST_REQUIRE_EQUAL( transaction_receipt::executed, traces[1]->receipt->status );
-
+   BOOST_REQUIRE( bool(deferred_trx_trace) );
+   BOOST_REQUIRE_EQUAL( transaction_receipt::executed, deferred_trx_trace->receipt->status );
+   BOOST_REQUIRE_EQUAL( 2, deferred_trx_trace->action_traces.size() );
+   BOOST_REQUIRE_EQUAL( fc::unsigned_int{1}, deferred_trx_trace->action_traces[0].action_ordinal );
+   BOOST_REQUIRE_EQUAL( fc::unsigned_int{0}, deferred_trx_trace->action_traces[0].creator_action_ordinal );
+   BOOST_REQUIRE_EQUAL( fc::unsigned_int{0}, deferred_trx_trace->action_traces[0].closest_unnotified_ancestor_action_ordinal );
+   BOOST_REQUIRE_EQUAL( N(eosio.wrap), action_name{deferred_trx_trace->action_traces[0].receiver} );
+   BOOST_REQUIRE_EQUAL( N(eosio.wrap), name{deferred_trx_trace->action_traces[0].act.account} );
+   BOOST_REQUIRE_EQUAL( N(exec), name{deferred_trx_trace->action_traces[0].act.name} );
+   BOOST_REQUIRE_EQUAL( N(alice), name{deferred_trx_trace->action_traces[0].act.authorization[0].actor} );
+   BOOST_REQUIRE_EQUAL( N(active), name{deferred_trx_trace->action_traces[0].act.authorization[0].permission} );
+   BOOST_REQUIRE_EQUAL( N(eosio.wrap), name{deferred_trx_trace->action_traces[0].act.authorization[1].actor} );
+   BOOST_REQUIRE_EQUAL( N(active), name{deferred_trx_trace->action_traces[0].act.authorization[1].permission} );
+   BOOST_REQUIRE_EQUAL( fc::unsigned_int{2}, deferred_trx_trace->action_traces[1].action_ordinal );
+   BOOST_REQUIRE_EQUAL( fc::unsigned_int{1}, deferred_trx_trace->action_traces[1].creator_action_ordinal );
+   BOOST_REQUIRE_EQUAL( fc::unsigned_int{1}, deferred_trx_trace->action_traces[1].closest_unnotified_ancestor_action_ordinal );
+   BOOST_REQUIRE_EQUAL( N(eosio), action_name{deferred_trx_trace->action_traces[1].receiver} );
+   BOOST_REQUIRE_EQUAL( N(eosio), name{deferred_trx_trace->action_traces[1].act.account} );
+   BOOST_REQUIRE_EQUAL( N(reqauth), name{deferred_trx_trace->action_traces[1].act.name} );
+   BOOST_REQUIRE_EQUAL( N(bob), name{deferred_trx_trace->action_traces[1].act.authorization[0].actor} );
+   BOOST_REQUIRE_EQUAL( N(active), name{deferred_trx_trace->action_traces[1].act.authorization[0].permission} );
 } FC_LOG_AND_RETHROW()
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/tests/eosio.wrap_tests.cpp
+++ b/tests/eosio.wrap_tests.cpp
@@ -180,7 +180,7 @@ BOOST_FIXTURE_TEST_CASE( wrap_exec_direct, eosio_wrap_tester ) try {
    BOOST_REQUIRE( bool(trx_trace) );
    BOOST_REQUIRE_EQUAL( transaction_receipt::executed, trx_trace->receipt->status );
    BOOST_REQUIRE_EQUAL( 2, trx_trace->action_traces.size() );
-   
+
    BOOST_REQUIRE_EQUAL( fc::unsigned_int{1}, trx_trace->action_traces[0].action_ordinal );
    BOOST_REQUIRE_EQUAL( fc::unsigned_int{0}, trx_trace->action_traces[0].creator_action_ordinal );
    BOOST_REQUIRE_EQUAL( fc::unsigned_int{0}, trx_trace->action_traces[0].closest_unnotified_ancestor_action_ordinal );
@@ -191,7 +191,7 @@ BOOST_FIXTURE_TEST_CASE( wrap_exec_direct, eosio_wrap_tester ) try {
    BOOST_REQUIRE_EQUAL( N(active), name{trx_trace->action_traces[0].act.authorization[0].permission} );
    BOOST_REQUIRE_EQUAL( N(eosio.wrap), name{trx_trace->action_traces[0].act.authorization[1].actor} );
    BOOST_REQUIRE_EQUAL( N(active), name{trx_trace->action_traces[0].act.authorization[1].permission} );
-   
+
    BOOST_REQUIRE_EQUAL( fc::unsigned_int{2}, trx_trace->action_traces[1].action_ordinal );
    BOOST_REQUIRE_EQUAL( fc::unsigned_int{1}, trx_trace->action_traces[1].creator_action_ordinal );
    BOOST_REQUIRE_EQUAL( fc::unsigned_int{1}, trx_trace->action_traces[1].closest_unnotified_ancestor_action_ordinal );
@@ -232,7 +232,7 @@ BOOST_FIXTURE_TEST_CASE( wrap_with_msig, eosio_wrap_tester ) try {
    BOOST_REQUIRE( bool(trx_trace) );
    BOOST_REQUIRE_EQUAL( transaction_receipt::executed, trx_trace->receipt->status );
    BOOST_REQUIRE_EQUAL( 3, trx_trace->action_traces.size() );
-   
+
    BOOST_REQUIRE_EQUAL( fc::unsigned_int{1}, trx_trace->action_traces[0].action_ordinal );
    BOOST_REQUIRE_EQUAL( fc::unsigned_int{0}, trx_trace->action_traces[0].creator_action_ordinal );
    BOOST_REQUIRE_EQUAL( fc::unsigned_int{0}, trx_trace->action_traces[0].closest_unnotified_ancestor_action_ordinal );
@@ -359,7 +359,7 @@ BOOST_FIXTURE_TEST_CASE( wrap_with_msig_producers_change, eosio_wrap_tester ) tr
    BOOST_REQUIRE( bool(trx_trace) );
    BOOST_REQUIRE_EQUAL( transaction_receipt::executed, trx_trace->receipt->status );
    BOOST_REQUIRE_EQUAL( 3, trx_trace->action_traces.size() );
-   
+
    BOOST_REQUIRE_EQUAL( fc::unsigned_int{1}, trx_trace->action_traces[0].action_ordinal );
    BOOST_REQUIRE_EQUAL( fc::unsigned_int{0}, trx_trace->action_traces[0].creator_action_ordinal );
    BOOST_REQUIRE_EQUAL( fc::unsigned_int{0}, trx_trace->action_traces[0].closest_unnotified_ancestor_action_ordinal );

--- a/tests/eosio.wrap_tests.cpp
+++ b/tests/eosio.wrap_tests.cpp
@@ -204,7 +204,7 @@ BOOST_FIXTURE_TEST_CASE( wrap_exec_direct, eosio_wrap_tester ) try {
 
 BOOST_FIXTURE_TEST_CASE( wrap_with_msig, eosio_wrap_tester ) try {
    transaction trx = reqauth( N(bob), {permission_level{N(bob), config::active_name}} );
-   transaction wrap_trx = wrap_exec( N(alice), trx, {} );
+   transaction wrap_trx = wrap_exec( N(alice), trx );
 
    propose( N(carol), N(first),
             { {N(alice), N(active)},
@@ -264,8 +264,7 @@ BOOST_FIXTURE_TEST_CASE( wrap_with_msig, eosio_wrap_tester ) try {
 
 BOOST_FIXTURE_TEST_CASE( wrap_with_msig_unapprove, eosio_wrap_tester ) try {
    transaction trx = reqauth( N(bob), {permission_level{N(bob), config::active_name}} );
-   // transaction wrap_trx = wrap_exec( N(alice), trx, 36000 );
-   transaction wrap_trx = wrap_exec( N(alice), trx, {} );
+   transaction wrap_trx = wrap_exec( N(alice), trx );
 
    propose( N(carol), N(first),
             { {N(alice), N(active)},

--- a/tests/eosio.wrap_tests.cpp
+++ b/tests/eosio.wrap_tests.cpp
@@ -175,36 +175,36 @@ BOOST_FIXTURE_TEST_CASE( wrap_exec_direct, eosio_wrap_tester ) try {
    trx_trace = push_transaction( wrap_trx );
 
    produce_block();
-   wdump((fc::json::to_pretty_string(trx_trace)));
 
+   BOOST_REQUIRE( trx_trace->receipt.valid() );
    BOOST_REQUIRE( bool(trx_trace) );
    BOOST_REQUIRE_EQUAL( transaction_receipt::executed, trx_trace->receipt->status );
    BOOST_REQUIRE_EQUAL( 2, trx_trace->action_traces.size() );
 
-   BOOST_REQUIRE_EQUAL( fc::unsigned_int{1}, trx_trace->action_traces[0].action_ordinal );
-   BOOST_REQUIRE_EQUAL( fc::unsigned_int{0}, trx_trace->action_traces[0].creator_action_ordinal );
-   BOOST_REQUIRE_EQUAL( fc::unsigned_int{0}, trx_trace->action_traces[0].closest_unnotified_ancestor_action_ordinal );
-   BOOST_REQUIRE_EQUAL( N(eosio.wrap), action_name{trx_trace->action_traces[0].receiver} );
-   BOOST_REQUIRE_EQUAL( N(eosio.wrap), name{trx_trace->action_traces[0].act.account} );
-   BOOST_REQUIRE_EQUAL( N(exec), name{trx_trace->action_traces[0].act.name} );
-   BOOST_REQUIRE_EQUAL( N(alice), name{trx_trace->action_traces[0].act.authorization[0].actor} );
-   BOOST_REQUIRE_EQUAL( N(active), name{trx_trace->action_traces[0].act.authorization[0].permission} );
-   BOOST_REQUIRE_EQUAL( N(eosio.wrap), name{trx_trace->action_traces[0].act.authorization[1].actor} );
-   BOOST_REQUIRE_EQUAL( N(active), name{trx_trace->action_traces[0].act.authorization[1].permission} );
+   BOOST_REQUIRE_EQUAL( fc::unsigned_int{1}, trx_trace->action_traces.at(0).action_ordinal );
+   BOOST_REQUIRE_EQUAL( fc::unsigned_int{0}, trx_trace->action_traces.at(0).creator_action_ordinal );
+   BOOST_REQUIRE_EQUAL( fc::unsigned_int{0}, trx_trace->action_traces.at(0).closest_unnotified_ancestor_action_ordinal );
+   BOOST_REQUIRE_EQUAL( N(eosio.wrap), action_name{trx_trace->action_traces.at(0).receiver} );
+   BOOST_REQUIRE_EQUAL( N(eosio.wrap), name{trx_trace->action_traces.at(0).act.account} );
+   BOOST_REQUIRE_EQUAL( N(exec), name{trx_trace->action_traces.at(0).act.name} );
+   BOOST_REQUIRE_EQUAL( N(alice), name{trx_trace->action_traces.at(0).act.authorization[0].actor} );
+   BOOST_REQUIRE_EQUAL( N(active), name{trx_trace->action_traces.at(0).act.authorization[0].permission} );
+   BOOST_REQUIRE_EQUAL( N(eosio.wrap), name{trx_trace->action_traces.at(0).act.authorization[1].actor} );
+   BOOST_REQUIRE_EQUAL( N(active), name{trx_trace->action_traces.at(0).act.authorization[1].permission} );
 
-   BOOST_REQUIRE_EQUAL( fc::unsigned_int{2}, trx_trace->action_traces[1].action_ordinal );
-   BOOST_REQUIRE_EQUAL( fc::unsigned_int{1}, trx_trace->action_traces[1].creator_action_ordinal );
-   BOOST_REQUIRE_EQUAL( fc::unsigned_int{1}, trx_trace->action_traces[1].closest_unnotified_ancestor_action_ordinal );
-   BOOST_REQUIRE_EQUAL( N(eosio), action_name{trx_trace->action_traces[1].receiver} );
-   BOOST_REQUIRE_EQUAL( N(eosio), name{trx_trace->action_traces[1].act.account} );
-   BOOST_REQUIRE_EQUAL( N(reqauth), name{trx_trace->action_traces[1].act.name} );
-   BOOST_REQUIRE_EQUAL( N(bob), name{trx_trace->action_traces[1].act.authorization[0].actor} );
-   BOOST_REQUIRE_EQUAL( N(active), name{trx_trace->action_traces[1].act.authorization[0].permission} );
+   BOOST_REQUIRE_EQUAL( fc::unsigned_int{2}, trx_trace->action_traces.at(1).action_ordinal );
+   BOOST_REQUIRE_EQUAL( fc::unsigned_int{1}, trx_trace->action_traces.at(1).creator_action_ordinal );
+   BOOST_REQUIRE_EQUAL( fc::unsigned_int{1}, trx_trace->action_traces.at(1).closest_unnotified_ancestor_action_ordinal );
+   BOOST_REQUIRE_EQUAL( N(eosio), action_name{trx_trace->action_traces.at(1).receiver} );
+   BOOST_REQUIRE_EQUAL( N(eosio), name{trx_trace->action_traces.at(1).act.account} );
+   BOOST_REQUIRE_EQUAL( N(reqauth), name{trx_trace->action_traces.at(1).act.name} );
+   BOOST_REQUIRE_EQUAL( N(bob), name{trx_trace->action_traces.at(1).act.authorization[0].actor} );
+   BOOST_REQUIRE_EQUAL( N(active), name{trx_trace->action_traces.at(1).act.authorization[0].permission} );
 } FC_LOG_AND_RETHROW()
 
 BOOST_FIXTURE_TEST_CASE( wrap_with_msig, eosio_wrap_tester ) try {
    transaction trx = reqauth( N(bob), {permission_level{N(bob), config::active_name}} );
-   signed_transaction wrap_trx( wrap_exec( N(alice), trx), {}, {} );
+   transaction wrap_trx = wrap_exec( N(alice), trx, {} );
 
    propose( N(carol), N(first),
             { {N(alice), N(active)},
@@ -227,45 +227,44 @@ BOOST_FIXTURE_TEST_CASE( wrap_with_msig, eosio_wrap_tester ) try {
                               ("executer",      "alice")
    );
 
-   wdump((fc::json::to_pretty_string(trx_trace)));
-
+   BOOST_REQUIRE( trx_trace->receipt.valid() );
    BOOST_REQUIRE( bool(trx_trace) );
    BOOST_REQUIRE_EQUAL( transaction_receipt::executed, trx_trace->receipt->status );
    BOOST_REQUIRE_EQUAL( 3, trx_trace->action_traces.size() );
 
-   BOOST_REQUIRE_EQUAL( fc::unsigned_int{1}, trx_trace->action_traces[0].action_ordinal );
-   BOOST_REQUIRE_EQUAL( fc::unsigned_int{0}, trx_trace->action_traces[0].creator_action_ordinal );
-   BOOST_REQUIRE_EQUAL( fc::unsigned_int{0}, trx_trace->action_traces[0].closest_unnotified_ancestor_action_ordinal );
-   BOOST_REQUIRE_EQUAL( N(eosio.msig), action_name{trx_trace->action_traces[0].receiver} );
-   BOOST_REQUIRE_EQUAL( N(eosio.msig), name{trx_trace->action_traces[0].act.account} );
-   BOOST_REQUIRE_EQUAL( N(exec), name{trx_trace->action_traces[0].act.name} );
-   BOOST_REQUIRE_EQUAL( N(alice), name{trx_trace->action_traces[0].act.authorization[0].actor} );
-   BOOST_REQUIRE_EQUAL( N(active), name{trx_trace->action_traces[0].act.authorization[0].permission} );
+   BOOST_REQUIRE_EQUAL( fc::unsigned_int{1}, trx_trace->action_traces.at(0).action_ordinal );
+   BOOST_REQUIRE_EQUAL( fc::unsigned_int{0}, trx_trace->action_traces.at(0).creator_action_ordinal );
+   BOOST_REQUIRE_EQUAL( fc::unsigned_int{0}, trx_trace->action_traces.at(0).closest_unnotified_ancestor_action_ordinal );
+   BOOST_REQUIRE_EQUAL( N(eosio.msig), action_name{trx_trace->action_traces.at(0).receiver} );
+   BOOST_REQUIRE_EQUAL( N(eosio.msig), name{trx_trace->action_traces.at(0).act.account} );
+   BOOST_REQUIRE_EQUAL( N(exec), name{trx_trace->action_traces.at(0).act.name} );
+   BOOST_REQUIRE_EQUAL( N(alice), name{trx_trace->action_traces.at(0).act.authorization[0].actor} );
+   BOOST_REQUIRE_EQUAL( N(active), name{trx_trace->action_traces.at(0).act.authorization[0].permission} );
 
-   BOOST_REQUIRE_EQUAL( fc::unsigned_int{2}, trx_trace->action_traces[1].action_ordinal );
-   BOOST_REQUIRE_EQUAL( fc::unsigned_int{1}, trx_trace->action_traces[1].creator_action_ordinal );
-   BOOST_REQUIRE_EQUAL( fc::unsigned_int{1}, trx_trace->action_traces[1].closest_unnotified_ancestor_action_ordinal );
-   BOOST_REQUIRE_EQUAL( N(eosio.wrap), action_name{trx_trace->action_traces[1].receiver} );
-   BOOST_REQUIRE_EQUAL( N(eosio.wrap), name{trx_trace->action_traces[1].act.account} );
-   BOOST_REQUIRE_EQUAL( N(exec), name{trx_trace->action_traces[1].act.name} );
-   BOOST_REQUIRE_EQUAL( N(alice), name{trx_trace->action_traces[1].act.authorization[0].actor} );
-   BOOST_REQUIRE_EQUAL( N(active), name{trx_trace->action_traces[1].act.authorization[0].permission} );
-   BOOST_REQUIRE_EQUAL( N(eosio.wrap), name{trx_trace->action_traces[1].act.authorization[1].actor} );
-   BOOST_REQUIRE_EQUAL( N(active), name{trx_trace->action_traces[1].act.authorization[1].permission} );
+   BOOST_REQUIRE_EQUAL( fc::unsigned_int{2}, trx_trace->action_traces.at(1).action_ordinal );
+   BOOST_REQUIRE_EQUAL( fc::unsigned_int{1}, trx_trace->action_traces.at(1).creator_action_ordinal );
+   BOOST_REQUIRE_EQUAL( fc::unsigned_int{1}, trx_trace->action_traces.at(1).closest_unnotified_ancestor_action_ordinal );
+   BOOST_REQUIRE_EQUAL( N(eosio.wrap), action_name{trx_trace->action_traces.at(1).receiver} );
+   BOOST_REQUIRE_EQUAL( N(eosio.wrap), name{trx_trace->action_traces.at(1).act.account} );
+   BOOST_REQUIRE_EQUAL( N(exec), name{trx_trace->action_traces.at(1).act.name} );
+   BOOST_REQUIRE_EQUAL( N(alice), name{trx_trace->action_traces.at(1).act.authorization[0].actor} );
+   BOOST_REQUIRE_EQUAL( N(active), name{trx_trace->action_traces.at(1).act.authorization[0].permission} );
+   BOOST_REQUIRE_EQUAL( N(eosio.wrap), name{trx_trace->action_traces.at(1).act.authorization[1].actor} );
+   BOOST_REQUIRE_EQUAL( N(active), name{trx_trace->action_traces.at(1).act.authorization[1].permission} );
 
-   BOOST_REQUIRE_EQUAL( fc::unsigned_int{3}, trx_trace->action_traces[2].action_ordinal );
-   BOOST_REQUIRE_EQUAL( fc::unsigned_int{2}, trx_trace->action_traces[2].creator_action_ordinal );
-   BOOST_REQUIRE_EQUAL( fc::unsigned_int{2}, trx_trace->action_traces[2].closest_unnotified_ancestor_action_ordinal );
-   BOOST_REQUIRE_EQUAL( N(eosio), action_name{trx_trace->action_traces[2].receiver} );
-   BOOST_REQUIRE_EQUAL( N(eosio), name{trx_trace->action_traces[2].act.account} );
-   BOOST_REQUIRE_EQUAL( N(reqauth), name{trx_trace->action_traces[2].act.name} );
-   BOOST_REQUIRE_EQUAL( N(bob), name{trx_trace->action_traces[2].act.authorization[0].actor} );
-   BOOST_REQUIRE_EQUAL( N(active), name{trx_trace->action_traces[2].act.authorization[0].permission} );
+   BOOST_REQUIRE_EQUAL( fc::unsigned_int{3}, trx_trace->action_traces.at(2).action_ordinal );
+   BOOST_REQUIRE_EQUAL( fc::unsigned_int{2}, trx_trace->action_traces.at(2).creator_action_ordinal );
+   BOOST_REQUIRE_EQUAL( fc::unsigned_int{2}, trx_trace->action_traces.at(2).closest_unnotified_ancestor_action_ordinal );
+   BOOST_REQUIRE_EQUAL( N(eosio), action_name{trx_trace->action_traces.at(2).receiver} );
+   BOOST_REQUIRE_EQUAL( N(eosio), name{trx_trace->action_traces.at(2).act.account} );
+   BOOST_REQUIRE_EQUAL( N(reqauth), name{trx_trace->action_traces.at(2).act.name} );
+   BOOST_REQUIRE_EQUAL( N(bob), name{trx_trace->action_traces.at(2).act.authorization[0].actor} );
+   BOOST_REQUIRE_EQUAL( N(active), name{trx_trace->action_traces.at(2).act.authorization[0].permission} );
 } FC_LOG_AND_RETHROW()
 
 BOOST_FIXTURE_TEST_CASE( wrap_with_msig_unapprove, eosio_wrap_tester ) try {
    transaction trx = reqauth( N(bob), {permission_level{N(bob), config::active_name}} );
-   signed_transaction wrap_trx( wrap_exec( N(alice), trx ), {}, {} );
+   transaction wrap_trx = wrap_exec( N(alice), trx, 36000 );
 
    propose( N(carol), N(first),
             { {N(alice), N(active)},
@@ -301,7 +300,7 @@ BOOST_FIXTURE_TEST_CASE( wrap_with_msig_producers_change, eosio_wrap_tester ) tr
    create_accounts( { N(newprod1) } );
 
    transaction trx = reqauth( N(bob), {permission_level{N(bob), config::active_name}} );
-   signed_transaction wrap_trx( wrap_exec( N(alice), trx, 36000 ), {}, {} );
+   transaction wrap_trx = wrap_exec( N(alice), trx, 36000 );
 
    propose( N(carol), N(first),
             { {N(alice), N(active)},
@@ -354,40 +353,39 @@ BOOST_FIXTURE_TEST_CASE( wrap_with_msig_producers_change, eosio_wrap_tester ) tr
                               ("executer",      "alice")
    );
 
-   wdump((fc::json::to_pretty_string(trx_trace)));
-
+   BOOST_REQUIRE( trx_trace->receipt.valid() );
    BOOST_REQUIRE( bool(trx_trace) );
    BOOST_REQUIRE_EQUAL( transaction_receipt::executed, trx_trace->receipt->status );
    BOOST_REQUIRE_EQUAL( 3, trx_trace->action_traces.size() );
 
-   BOOST_REQUIRE_EQUAL( fc::unsigned_int{1}, trx_trace->action_traces[0].action_ordinal );
-   BOOST_REQUIRE_EQUAL( fc::unsigned_int{0}, trx_trace->action_traces[0].creator_action_ordinal );
-   BOOST_REQUIRE_EQUAL( fc::unsigned_int{0}, trx_trace->action_traces[0].closest_unnotified_ancestor_action_ordinal );
-   BOOST_REQUIRE_EQUAL( N(eosio.msig), action_name{trx_trace->action_traces[0].receiver} );
-   BOOST_REQUIRE_EQUAL( N(eosio.msig), name{trx_trace->action_traces[0].act.account} );
-   BOOST_REQUIRE_EQUAL( N(exec), name{trx_trace->action_traces[0].act.name} );
-   BOOST_REQUIRE_EQUAL( N(alice), name{trx_trace->action_traces[0].act.authorization[0].actor} );
-   BOOST_REQUIRE_EQUAL( N(active), name{trx_trace->action_traces[0].act.authorization[0].permission} );
+   BOOST_REQUIRE_EQUAL( fc::unsigned_int{1}, trx_trace->action_traces.at(0).action_ordinal );
+   BOOST_REQUIRE_EQUAL( fc::unsigned_int{0}, trx_trace->action_traces.at(0).creator_action_ordinal );
+   BOOST_REQUIRE_EQUAL( fc::unsigned_int{0}, trx_trace->action_traces.at(0).closest_unnotified_ancestor_action_ordinal );
+   BOOST_REQUIRE_EQUAL( N(eosio.msig), action_name{trx_trace->action_traces.at(0).receiver} );
+   BOOST_REQUIRE_EQUAL( N(eosio.msig), name{trx_trace->action_traces.at(0).act.account} );
+   BOOST_REQUIRE_EQUAL( N(exec), name{trx_trace->action_traces.at(0).act.name} );
+   BOOST_REQUIRE_EQUAL( N(alice), name{trx_trace->action_traces.at(0).act.authorization[0].actor} );
+   BOOST_REQUIRE_EQUAL( N(active), name{trx_trace->action_traces.at(0).act.authorization[0].permission} );
 
-   BOOST_REQUIRE_EQUAL( fc::unsigned_int{2}, trx_trace->action_traces[1].action_ordinal );
-   BOOST_REQUIRE_EQUAL( fc::unsigned_int{1}, trx_trace->action_traces[1].creator_action_ordinal );
-   BOOST_REQUIRE_EQUAL( fc::unsigned_int{1}, trx_trace->action_traces[1].closest_unnotified_ancestor_action_ordinal );
-   BOOST_REQUIRE_EQUAL( N(eosio.wrap), action_name{trx_trace->action_traces[1].receiver} );
-   BOOST_REQUIRE_EQUAL( N(eosio.wrap), name{trx_trace->action_traces[1].act.account} );
-   BOOST_REQUIRE_EQUAL( N(exec), name{trx_trace->action_traces[1].act.name} );
-   BOOST_REQUIRE_EQUAL( N(alice), name{trx_trace->action_traces[1].act.authorization[0].actor} );
-   BOOST_REQUIRE_EQUAL( N(active), name{trx_trace->action_traces[1].act.authorization[0].permission} );
-   BOOST_REQUIRE_EQUAL( N(eosio.wrap), name{trx_trace->action_traces[1].act.authorization[1].actor} );
-   BOOST_REQUIRE_EQUAL( N(active), name{trx_trace->action_traces[1].act.authorization[1].permission} );
+   BOOST_REQUIRE_EQUAL( fc::unsigned_int{2}, trx_trace->action_traces.at(1).action_ordinal );
+   BOOST_REQUIRE_EQUAL( fc::unsigned_int{1}, trx_trace->action_traces.at(1).creator_action_ordinal );
+   BOOST_REQUIRE_EQUAL( fc::unsigned_int{1}, trx_trace->action_traces.at(1).closest_unnotified_ancestor_action_ordinal );
+   BOOST_REQUIRE_EQUAL( N(eosio.wrap), action_name{trx_trace->action_traces.at(1).receiver} );
+   BOOST_REQUIRE_EQUAL( N(eosio.wrap), name{trx_trace->action_traces.at(1).act.account} );
+   BOOST_REQUIRE_EQUAL( N(exec), name{trx_trace->action_traces.at(1).act.name} );
+   BOOST_REQUIRE_EQUAL( N(alice), name{trx_trace->action_traces.at(1).act.authorization[0].actor} );
+   BOOST_REQUIRE_EQUAL( N(active), name{trx_trace->action_traces.at(1).act.authorization[0].permission} );
+   BOOST_REQUIRE_EQUAL( N(eosio.wrap), name{trx_trace->action_traces.at(1).act.authorization[1].actor} );
+   BOOST_REQUIRE_EQUAL( N(active), name{trx_trace->action_traces.at(1).act.authorization[1].permission} );
 
-   BOOST_REQUIRE_EQUAL( fc::unsigned_int{3}, trx_trace->action_traces[2].action_ordinal );
-   BOOST_REQUIRE_EQUAL( fc::unsigned_int{2}, trx_trace->action_traces[2].creator_action_ordinal );
-   BOOST_REQUIRE_EQUAL( fc::unsigned_int{2}, trx_trace->action_traces[2].closest_unnotified_ancestor_action_ordinal );
-   BOOST_REQUIRE_EQUAL( N(eosio), action_name{trx_trace->action_traces[2].receiver} );
-   BOOST_REQUIRE_EQUAL( N(eosio), name{trx_trace->action_traces[2].act.account} );
-   BOOST_REQUIRE_EQUAL( N(reqauth), name{trx_trace->action_traces[2].act.name} );
-   BOOST_REQUIRE_EQUAL( N(bob), name{trx_trace->action_traces[2].act.authorization[0].actor} );
-   BOOST_REQUIRE_EQUAL( N(active), name{trx_trace->action_traces[2].act.authorization[0].permission} );
+   BOOST_REQUIRE_EQUAL( fc::unsigned_int{3}, trx_trace->action_traces.at(2).action_ordinal );
+   BOOST_REQUIRE_EQUAL( fc::unsigned_int{2}, trx_trace->action_traces.at(2).creator_action_ordinal );
+   BOOST_REQUIRE_EQUAL( fc::unsigned_int{2}, trx_trace->action_traces.at(2).closest_unnotified_ancestor_action_ordinal );
+   BOOST_REQUIRE_EQUAL( N(eosio), action_name{trx_trace->action_traces.at(2).receiver} );
+   BOOST_REQUIRE_EQUAL( N(eosio), name{trx_trace->action_traces.at(2).act.account} );
+   BOOST_REQUIRE_EQUAL( N(reqauth), name{trx_trace->action_traces.at(2).act.name} );
+   BOOST_REQUIRE_EQUAL( N(bob), name{trx_trace->action_traces.at(2).act.authorization[0].actor} );
+   BOOST_REQUIRE_EQUAL( N(active), name{trx_trace->action_traces.at(2).act.authorization[0].permission} );
 } FC_LOG_AND_RETHROW()
 
 BOOST_FIXTURE_TEST_CASE( assert_if_context_free_actions_in_wrap, eosio_wrap_tester ) try {

--- a/tests/eosio.wrap_tests.cpp
+++ b/tests/eosio.wrap_tests.cpp
@@ -394,7 +394,7 @@ BOOST_FIXTURE_TEST_CASE( assert_if_context_free_actions_in_wrap, eosio_wrap_test
    transaction trx = reqauth( N(bob), {permission_level{N(bob), config::active_name}} );
    trx.context_free_actions.push_back( {} );
    signed_transaction wrap_trx( wrap_exec( N(alice), trx ), {}, {} );
-   
+
    wrap_trx.sign( get_private_key( N(alice), "active" ), control->get_chain_id() );
    for( const auto& actor : {N(prod1), N(prod2), N(prod3), N(prod4)} ) {
       wrap_trx.sign( get_private_key( actor, "active" ), control->get_chain_id() );


### PR DESCRIPTION
<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->

## Change Description
<!-- Describe your changes, their justification, AND their impact. Reference issues or pull requests where possible (use '#XX' or 'GH-XX' where XX is the issue or pull request number). -->

Deferred transactions are being deprecated. This PR removes any dependency that relies upon deferred transactions in the `eosio.contracts` repository. For further reading, and the rationale behind this PR, please see [Deprecate Deferred Transactions](https://github.com/EOSIO/spec-repo/blob/master/esr_deprecate_deferred.md).

### eosio.multisig contract

##### Previous Behavior
When utilizing the `eosio.multisig` contract a user would perform the action
`propose` and specify (among the proposed transaction and other things) a number
of delay seconds in the transaction header. After proposing the transaction,
users would perform the action `approve` and after, the action `exec`; where if
the approvals of the proposal have been satisfied, the packed transaction (given
in the action `propose`) would get sent out as a deferred transaction that is
delayed by the specified number of delay seconds.

##### Current Behavior
The changes are two-fold:
1) The number of delay seconds is used to calculate the earliest possible
execution time of the action `exec` (of course, once the approvals of the
proposal have been satisfied). The earliest execution time is the point in time
at which the proposal has been satisfied plus the delayed seconds specified in
the transaction header of the packed transaction. Also note, that if a proposal
reverts its status of having the approvals satisified, then unsatisfied, and
then satisfied once again, the earliest execution time will always get
recalculated.
2) The given transaction (given in the action `propose`) is executed immediately
upon the user performing the action `exec` as a sequence of inline actions, but
only if the the proposal has been approved and the given number of delay seconds
has passed. Otherwise, the execution of the action `exec` shall fail.

### eosio.system contract

#### name bidding

##### Previous Behavior
One feature of the `eosio.system` contract is the ability to bid on highly
sought-after names. Once the user gets outbid on a certain name, that user will
recieve their refund via a deferred transaction.

##### Current Behavior
This behavior changes in that now the user will only recieve their refund upon
explicitly performing the action `bidrefund` to the `eosio.system` contract.

#### unstaking resources

##### Previous Behavior
Another feature of the `eosio.system` contract is that of the ability to stake
and unstake resources according to how much of a specific asset the user's
account owns. Upon the user performing the action `undelegatebw` to unstake
his/her own resources, that user will then recieve their refund via a deferred
transaction.

##### Current Behavior
This behavior changes in that now the user will only recieve their refund upon
explicitly performing the action `refund` to the `eosio.system` contract.

### eosio.wrap contract

##### Previous Behavior
The `eosio.wrap` contract provides the system with the ability to issue a
privileged-level transaction; of which is sent via a deferred transaction.

##### Current Behavior
This behavior changes in that now the privileged-level transaction is executed
immediately upon the user performing the action `exec` action as a sequence of
inline actions.

## Deployment Changes
- [ ] Deployment Changes
<!-- checked [x] = Deployment changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces a change to the contracts that causes deployment to change, please describe the impact. -->

## API Changes
- [ ] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions
- [X] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
[Deprecating Deferred Transactions From First Principles And Migration Guide](https://github.com/EOSIO/devdocs/wiki/Deprecating-Deferred-Transactions-From-First-Principles-And-Migration-Guide).