### PR TITLE
[1.8.x] CI improvements for Deps

### DIFF
--- a/.cicd/build.sh
+++ b/.cicd/build.sh
@@ -4,7 +4,7 @@ set -eo pipefail
 . ./.cicd/helpers/general.sh
 . ./.cicd/helpers/dependency-info.sh
 mkdir -p $BUILD_DIR
-DOCKER_IMAGE=${DOCKER_IMAGE:-eosio/ci-contracts-builder:base-ubuntu-18.04-$EOSIO_COMMIT}
+DOCKER_IMAGE=${DOCKER_IMAGE:-eosio/ci-contracts-builder:base-ubuntu-18.04-$SANITIZED_EOSIO_VERSION}
 if [[ "$BUILDKITE" == 'true' ]]; then
     buildkite-agent meta-data set cdt-url "$CDT_URL"
     buildkite-agent meta-data set cdt-version "$CDT_VERSION"
@@ -16,15 +16,15 @@ else
 fi
 ARGS=${ARGS:-"--rm -v $(pwd):$MOUNTED_DIR"}
 CDT_COMMANDS="dpkg -i $MOUNTED_DIR/eosio.cdt.deb && export PATH=/usr/opt/eosio.cdt/\\\$(ls /usr/opt/eosio.cdt/)/bin:\\\$PATH"
-PRE_COMMANDS="$CDT_COMMANDS && cd $MOUNTED_DIR/build"
+PRE_COMMANDS="$CDT_COMMANDS && cd /root/eosio/ && printf \\\"EOSIO commit: \\\$(git rev-parse --verify HEAD). Click \033]1339;url=https://github.com/EOSIO/eos/commit/\\\$(git rev-parse --verify HEAD);content=here\a for details.\n\\\" && cd $MOUNTED_DIR/build"
 BUILD_COMMANDS="cmake -DBUILD_TESTS=true .. && make -j $JOBS"
 COMMANDS="$PRE_COMMANDS && $BUILD_COMMANDS"
 # Test CDT binary download to prevent failures due to eosio.cdt pipeline.
 INDEX='1'
 echo "$ curl -sSf $CDT_URL --output eosio.cdt.deb"
 while ! $(curl -sSf $CDT_URL --output eosio.cdt.deb); do
-    echo "ERROR: Expected CDT binary for commit ${CDT_COMMIT:0:7} from $CDT_VERSION. It does not exist at $CDT_URL!"
-    printf "There must be a successful build against ${CDT_COMMIT:0:7} \033]1339;url=https://buildkite.com/EOSIO/eosio-dot-cdt/builds?commit=$CDT_COMMIT;content=here\a for this package to exist.\n"
+    echo "ERROR: Expected CDT binary for commit ${CDT_COMMIT} from $CDT_VERSION. It does not exist at $CDT_URL!"
+    printf "There must be a successful build against ${CDT_COMMIT} \033]1339;url=https://buildkite.com/EOSIO/eosio-dot-cdt/builds?commit=$CDT_COMMIT;content=here\a for this package to exist.\n"
     echo "Attempt $INDEX, retry in 60 seconds..."
     echo ''
     INDEX=$(( $INDEX + 1 ))
@@ -34,8 +34,8 @@ done
 INDEX='1'
 echo "$ docker pull $DOCKER_IMAGE"
 while [[ "$(docker pull $DOCKER_IMAGE 2>&1 | grep -ice "manifest for $DOCKER_IMAGE not found")" != '0' ]]; do
-    echo "ERROR: Docker image \"$DOCKER_IMAGE\" not found for eosio commit ${EOSIO_COMMIT:0:7} from \"$EOSIO_VERSION\""'!'
-    printf "There must be a successful build against ${EOSIO_COMMIT:0:7} \033]1339;url=https://buildkite.com/EOSIO/eosio/builds?commit=$EOSIO_COMMIT;content=here\a for this container to exist.\n"
+    echo "ERROR: Docker image \"$DOCKER_IMAGE\" not found for eosio \"$EOSIO_VERSION\""'!'
+    printf "There must be a successful build against ${EOSIO_VERSION} \033]1339;url=${EOSIO_BK_URL};content=here\a for this container to exist.\n"
     echo "Attempt $INDEX, retry in 60 seconds..."
     echo ''
     INDEX=$(( $INDEX + 1 ))

--- a/.cicd/helpers/dependency-info.sh
+++ b/.cicd/helpers/dependency-info.sh
@@ -9,6 +9,7 @@ if [[ -f "$RAW_PIPELINE_CONFIG" ]]; then
     cat "$RAW_PIPELINE_CONFIG" | grep -Po '^[^"/]*("((?<=\\).|[^"])*"[^"/]*)*' | jq -c .\"eosio-dot-contracts\" > "$PIPELINE_CONFIG"
     CDT_VERSION=$(cat "$PIPELINE_CONFIG" | jq -r '.dependencies."eosio.cdt"')
     EOSIO_VERSION=$(cat "$PIPELINE_CONFIG" | jq -r '.dependencies.eosio')
+    SANITIZED_EOSIO_VERSION=$(echo $EOSIO_VERSION | sed 's/\//\_/')
 else
     echo 'ERROR: No pipeline configuration file or dependencies file found!'
     exit 1
@@ -29,6 +30,11 @@ else
     EOSIO_COMMIT=$(git rev-parse --verify HEAD)
     cd ..
 fi
-echo "Using eosio ${EOSIO_COMMIT:0:7} from \"$EOSIO_VERSION\"..."
-echo "Using cdt ${CDT_COMMIT:0:7} from \"$CDT_VERSION\"..."
+if [[ "$EOSIO_COMMIT" == "$EOSIO_VERSION" ]]; then
+    EOSIO_BK_URL="https://buildkite.com/EOSIO/eosio/builds?commit=${EOSIO_COMMIT}"
+else
+    EOSIO_BK_URL="https://buildkite.com/EOSIO/eosio/builds?branch=${EOSIO_VERSION}"
+fi
+echo "Using eosio \"$EOSIO_VERSION\"..."
+echo "Using cdt ${CDT_COMMIT} from \"$CDT_VERSION\"..."
 export CDT_URL="https://eos-public-oss-binaries.s3-us-west-2.amazonaws.com/${CDT_COMMIT:0:7}-eosio.cdt-ubuntu-18.04_amd64.deb"

--- a/.cicd/test.sh
+++ b/.cicd/test.sh
@@ -9,7 +9,7 @@ if [[ "$BUILDKITE" == 'true' ]]; then
     DOCKER_IMAGE="$(buildkite-agent meta-data get docker-image)"
 else # Actions
     . ./.cicd/helpers/dependency-info.sh
-    DOCKER_IMAGE=${DOCKER_IMAGE:-eosio/ci-contracts-builder:base-ubuntu-18.04-$EOSIO_COMMIT}
+    DOCKER_IMAGE=${DOCKER_IMAGE:-eosio/ci-contracts-builder:base-ubuntu-18.04-$SANITIZED_EOSIO_VERSION}
 fi
 ARGS=${ARGS:-"--rm -v $(pwd):$MOUNTED_DIR"}
 CDT_COMMANDS="dpkg -i $MOUNTED_DIR/eosio.cdt.deb && export PATH=/usr/opt/eosio.cdt/$CDT_VERSION/bin:\\\$PATH"
@@ -18,6 +18,7 @@ TEST_COMMANDS="ctest -j $JOBS --output-on-failure -T Test"
 COMMANDS="$PRE_COMMANDS && $TEST_COMMANDS"
 curl -sSf $CDT_URL --output eosio.cdt.deb
 set +e
+echo "docker run $ARGS $(buildkite-intrinsics) $DOCKER_IMAGE bash -c \"$COMMANDS\""
 eval docker run $ARGS $(buildkite-intrinsics) $DOCKER_IMAGE bash -c \"$COMMANDS\"
 EXIT_STATUS=$?
 # buildkite


### PR DESCRIPTION
<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->

## Change Description
<!-- Describe your changes, their justification, AND their impact. Reference issues or pull requests where possible (use '#XX' or 'GH-XX' where XX is the issue or pull request number). -->
Modified behavior of Contracts builds regarding the specified EOSIO dependency in the `pipeline.jsonc` file:
- Contracts now builds explicitly with the EOSIO dependency listed in `pipeline.jsonc`.
  - Buildkite CI no longer uses converted branch/tag names (`$EOSIO_VERSION`) into commit hashes (`$EOSIO_COMMIT`) to pull Docker containers.
  - We instead pull Docker containers based on the sanitized (`$EOSIO_VERSION`) input.
  - This results in fewer occurrences of wait times for builds when the EOSIO dependency is specified by branch/tag name.
  - If the EOSIO dependency is specified by commit hash, CI will still wait if it doesn't already exist.
  - No changes made to CDT dependencies at this time.
- Improved environment logging.
  - Don't trim commit hashes in log output.
  - Log exact Docker command used in test steps.
  - Log installed EOSIO version in Docker container by commit hash.
  - Dynamically log URL pointing to expected EOSIO build location by branch or commit as needed.

See:
[Build 1076](https://buildkite.com/EOSIO/eosio-dot-contracts/builds/1076) | Build with pre-existing EOSIO and CDT artifact defined by commit hash. Container pulled as specified by commit hash.
[Build 1077](https://buildkite.com/EOSIO/eosio-dot-contracts/builds/1077) | Build with pre-existing EOSIO and CDT artifact defined by branch name. Container pulled as specified by branch.
[Build 1078](https://buildkite.com/EOSIO/eosio-dot-contracts/builds/1078) | Build with pre-existing EOSIO and CDT artifact defined by tag name. Container pulled as specified by tag.
[Build 1079](https://buildkite.com/EOSIO/eosio-dot-contracts/builds/1079) | Build with non-existing EOSIO artifact defined by commit. Contract build waits for artifact to appear.
[Build 1080](https://buildkite.com/EOSIO/eosio-dot-contracts/builds/1080) | Build with non-existing EOSIO artifact defined by branch. Contract build waits for artifact to appear.
[Build 1081](https://buildkite.com/EOSIO/eosio-dot-contracts/builds/1081) | Build with EOSIO artifact defined by branch that has a build in progress. Container pulled based on branch name, but [one commit](https://buildkite.com/EOSIO/eosio-dot-contracts/builds/1081#94666333-cb0a-4ae7-9299-91f42eab562c/51-67) behind as expected to [avoid waiting](https://buildkite.com/EOSIO/eosio/builds/20425#72538b4e-3ffc-4ff4-b82d-b35c24393323/228-237).
[Actions](https://github.com/EOSIO/eosio.contracts/actions/runs/35620350) | Actions build ensuring no CI regressions for forks.

## Deployment Changes
- [ ] Deployment Changes
<!-- checked [x] = Deployment changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces a change to the contracts that causes deployment to change, please describe the impact. -->


## API Changes
- [ ] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions
- [ ] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
