### PR TITLE
build.sh: switch from CMAKE_FRAMEWORK_PATH to CMAKE_MODULE_PATH

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -60,17 +60,17 @@ fi
 # Prompt user for location of eosio.cdt.
 cdt-directory-prompt
 
-# Include CDT_INSTALL_DIR in CMAKE_FRAMEWORK_PATH
+# Include CDT_INSTALL_DIR in CMAKE_MODULE_PATH
 echo "Using EOSIO.CDT installation at: $CDT_INSTALL_DIR"
-export CMAKE_FRAMEWORK_PATH="${CDT_INSTALL_DIR}:${CMAKE_FRAMEWORK_PATH}"
+CMAKE_MODULE_PATH="${CDT_INSTALL_DIR}:${CMAKE_MODULE_PATH}"
 
 if [[ ${BUILD_TESTS} == true ]]; then
    # Ensure eosio version is appropriate.
    nodeos-version-check
 
-   # Include EOSIO_INSTALL_DIR in CMAKE_FRAMEWORK_PATH
+   # Include EOSIO_INSTALL_DIR in CMAKE_MODULE_PATH
    echo "Using EOSIO installation at: $EOSIO_INSTALL_DIR"
-   export CMAKE_FRAMEWORK_PATH="${EOSIO_INSTALL_DIR}:${CMAKE_FRAMEWORK_PATH}"
+   CMAKE_MODULE_PATH="${EOSIO_INSTALL_DIR}:${CMAKE_MODULE_PATH}"
 fi
 
 printf "\t=========== Building eosio.contracts ===========\n\n"
@@ -79,6 +79,6 @@ NC='\033[0m'
 CPU_CORES=$(getconf _NPROCESSORS_ONLN)
 mkdir -p build
 pushd build &> /dev/null
-cmake -DBUILD_TESTS=${BUILD_TESTS} ../
+cmake -DBUILD_TESTS=${BUILD_TESTS} -DCMAKE_MODULE_PATH=${CMAKE_MODULE_PATH} ../
 make -j $CPU_CORES
 popd &> /dev/null


### PR DESCRIPTION
<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->

## Change Description
<!-- Describe your changes, their justification, AND their impact. Reference issues or pull requests where possible (use '#XX' or 'GH-XX' where XX is the issue or pull request number). -->

CMAKE_FRAMEWORK_PATH is bad as it's read by cmake but it is not available in cmake scripts.
Also according to the documentation this variable should contain path to OS X frameworks.

CMAKE_MODULE_PATH is the right way to go.

By adding this code to CMakeLists.txt (line 78 in this case):
```
message(FATAL_ERROR "${CMAKE_FRAMEWORK_PATH}")
```

And run:

```sh
$ export CMAKE_FRAMEWORK_PATH=/usr/opt/eosio.cdt/1.7
$ cmake ..
```

You get the following output:

```
-- The C compiler identification is GNU 7.5.0
-- The CXX compiler identification is GNU 7.5.0
...
-- Building eosio.contracts v1.9.0-rc1
-- Using eosio.cdt version 1.7.0
CMake Error at CMakeLists.txt:78 (message):


-- Configuring incomplete, errors occurred!
```

## Deployment Changes
- [ ] Deployment Changes
<!-- checked [x] = Deployment changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces a change to the contracts that causes deployment to change, please describe the impact. -->


## API Changes
- [ ] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions
- [ ] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
