### PR TITLE
Fix compilation with CDT develop

### DIFF
--- a/contracts/eosio.system/CMakeLists.txt
+++ b/contracts/eosio.system/CMakeLists.txt
@@ -2,6 +2,7 @@ add_contract(eosio.system eosio.system
    ${CMAKE_CURRENT_SOURCE_DIR}/src/eosio.system.cpp
    ${CMAKE_CURRENT_SOURCE_DIR}/src/delegate_bandwidth.cpp
    ${CMAKE_CURRENT_SOURCE_DIR}/src/exchange_state.cpp
+   ${CMAKE_CURRENT_SOURCE_DIR}/src/name_bidding.cpp
    ${CMAKE_CURRENT_SOURCE_DIR}/src/native.cpp
    ${CMAKE_CURRENT_SOURCE_DIR}/src/producer_pay.cpp
    ${CMAKE_CURRENT_SOURCE_DIR}/src/rex.cpp

--- a/contracts/eosio.system/src/delegate_bandwidth.cpp
+++ b/contracts/eosio.system/src/delegate_bandwidth.cpp
@@ -8,9 +8,6 @@
 #include <eosio.system/eosio.system.hpp>
 #include <eosio.token/eosio.token.hpp>
 
-#include "name_bidding.cpp"
-// Unfortunately, this is needed until CDT fixes the duplicate symbol error with eosio::send_deferred
-
 namespace eosiosystem {
 
    using eosio::asset;


### PR DESCRIPTION
<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->

## Change Description
<!-- Describe your changes, their justification, AND their impact. Reference issues or pull requests where possible (use '#XX' or 'GH-XX' where XX is the issue or pull request number). -->

Backport fix from develop. Without this, 1.9.x can't build with the develop version of CDT.

## Deployment Changes
- [ ] Deployment Changes
<!-- checked [x] = Deployment changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces a change to the contracts that causes deployment to change, please describe the impact. -->


## API Changes
- [ ] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions
- [ ] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
