### PR TITLE
Fix REX maturity date bug

### DIFF
--- a/contracts/eosio.system/src/rex.cpp
+++ b/contracts/eosio.system/src/rex.cpp
@@ -1180,7 +1180,7 @@ namespace eosiosystem {
          if ( !rb.rex_maturities.empty() && rb.rex_maturities.back().first == end_of_days ) {
             rb.rex_maturities.back().second += rex;
          } else {
-            rb.rex_maturities.emplace_back( end_of_days, rex );
+            rb.rex_maturities.emplace_back( get_rex_maturity(), rex );
          }
       });
    }


### PR DESCRIPTION
Fixing bug in REX maturity calculation that writes `2106-02-07T06:28:15` as the maturity date of some deposits instead of the proper maturity date, therefore locking SYS tokens in REX for 84 years.

<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->

## Change Description
<!-- Describe your changes, their justification, AND their impact. Reference issues or pull requests where possible (use '#XX' or 'GH-XX' where XX is the issue or pull request number). -->


## Deployment Changes
- [ ] Deployment Changes
<!-- checked [x] = Deployment changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces a change to the contracts that causes deployment to change, please describe the impact. -->


## API Changes
- [ ] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions
- [ ] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
