### PR TITLE
Add support for setting KV Parameters to eosio.system contract and eo…

### DIFF
--- a/contracts/eosio.bios/include/eosio.bios/eosio.bios.hpp
+++ b/contracts/eosio.bios/include/eosio.bios/eosio.bios.hpp
@@ -229,6 +229,14 @@ namespace eosiobios {
          void setparams( const eosio::blockchain_parameters& params );
 
          /**
+          * Set KV params action, sets the KV  parameters. By tuning these parameters, various degrees of customization can be achieved.
+          *
+          * @param params - New KV parameters to set
+          */
+         [[eosio::action]]
+         void setkvparams( const eosio::kv_parameters& params );
+
+         /**
           * Require authorization action, checks if the account name `from` passed in as param has authorization to access
           * current action, that is, if it is listed in the action’s allowed permissions vector.
           *
@@ -275,6 +283,7 @@ namespace eosiobios {
          using setalimits_action = action_wrapper<"setalimits"_n, &bios::setalimits>;
          using setprods_action = action_wrapper<"setprods"_n, &bios::setprods>;
          using setparams_action = action_wrapper<"setparams"_n, &bios::setparams>;
+         using setkvparams_action = action_wrapper<"setkvparams"_n, &bios::setkvparams>;
          using reqauth_action = action_wrapper<"reqauth"_n, &bios::reqauth>;
          using activate_action = action_wrapper<"activate"_n, &bios::activate>;
          using reqactivated_action = action_wrapper<"reqactivated"_n, &bios::reqactivated>;

--- a/contracts/eosio.bios/ricardian/eosio.bios.contracts.md.in
+++ b/contracts/eosio.bios/ricardian/eosio.bios.contracts.md.in
@@ -128,6 +128,18 @@ icon: @ICON_BASE_URL@/@ADMIN_ICON_URI@
 {{$action.account}} sets system parameters to:
 {{to_json params}}
 
+<h1 class="contract">setkvparams</h1>
+
+---
+spec_version: "0.3.0"
+title: Set KV Parameters
+summary: 'Set KV parameters'
+icon: @ICON_BASE_URL@/@ADMIN_ICON_URI@
+---
+
+{{$action.account}} sets KV parameters to:
+{{to_json params}}
+
 <h1 class="contract">setpriv</h1>
 
 ---

--- a/contracts/eosio.bios/src/eosio.bios.cpp
+++ b/contracts/eosio.bios/src/eosio.bios.cpp
@@ -41,6 +41,11 @@ void bios::setparams( const eosio::blockchain_parameters& params ) {
    set_blockchain_parameters( params );
 }
 
+void bios::setkvparams( const eosio::kv_parameters& params ) {
+   require_auth( get_self() );
+   set_kv_parameters( params );
+}
+
 void bios::reqauth( name from ) {
    require_auth( from );
 }

--- a/contracts/eosio.system/include/eosio.system/eosio.system.hpp
+++ b/contracts/eosio.system/include/eosio.system/eosio.system.hpp
@@ -1085,6 +1085,13 @@ namespace eosiosystem {
          void setparams( const eosio::blockchain_parameters& params );
 
          /**
+          * Set KV parameters.
+          * @param params - New KV parameters to set.
+          */
+         [[eosio::action]]
+         void setkvparams( const eosio::kv_parameters& params );
+
+         /**
           * Claim rewards action, claims block producing and vote rewards.
           * @param owner - producer account claiming per-block and per-vote rewards.
           */
@@ -1208,6 +1215,7 @@ namespace eosiosystem {
          using setpriv_action = eosio::action_wrapper<"setpriv"_n, &system_contract::setpriv>;
          using setalimits_action = eosio::action_wrapper<"setalimits"_n, &system_contract::setalimits>;
          using setparams_action = eosio::action_wrapper<"setparams"_n, &system_contract::setparams>;
+         using setkvparams_action = eosio::action_wrapper<"setkvparams"_n, &system_contract::setkvparams>;
          using setinflation_action = eosio::action_wrapper<"setinflation"_n, &system_contract::setinflation>;
 
       private:

--- a/contracts/eosio.system/ricardian/eosio.system.contracts.md.in
+++ b/contracts/eosio.system/ricardian/eosio.system.contracts.md.in
@@ -522,6 +522,18 @@ icon: @ICON_BASE_URL@/@ADMIN_ICON_URI@
 {{$action.account}} sets system parameters to:
 {{to_json params}}
 
+<h1 class="contract">setkvparams</h1>
+
+---
+spec_version: "0.3.0"
+title: Set KV Parameters
+summary: 'Set KV Parameters'
+icon: @ICON_BASE_URL@/@ADMIN_ICON_URI@
+---
+
+{{$action.account}} sets KV parameters to:
+{{to_json params}}
+
 <h1 class="contract">setpriv</h1>
 
 ---

--- a/contracts/eosio.system/src/eosio.system.cpp
+++ b/contracts/eosio.system/src/eosio.system.cpp
@@ -116,6 +116,11 @@ namespace eosiosystem {
       set_blockchain_parameters( params );
    }
 
+   void system_contract::setkvparams( const eosio::kv_parameters& params ) {
+      require_auth( get_self() );
+      set_kv_parameters( params );
+   }
+
    void system_contract::setpriv( const name& account, uint8_t ispriv ) {
       require_auth( get_self() );
       set_privileged( account, ispriv );

--- a/pipeline.jsonc
+++ b/pipeline.jsonc
@@ -5,7 +5,7 @@
         "dependencies": // dependencies to pull for a build of contracts, by branch, tag, or commit hash
         {
             "eosio": "develop", 
-            "eosio.cdt": "d02cd8ef007758257f232f4ba711e74c8eece149"
+            "eosio.cdt": "f7529f9d6c093e9ad0067cfd8d393d472009f50a"
         }
     }
 }


### PR DESCRIPTION
…sio.bios contract

	modified:   contracts/eosio.bios/include/eosio.bios/eosio.bios.hpp
	modified:   contracts/eosio.bios/ricardian/eosio.bios.contracts.md.in
	modified:   contracts/eosio.bios/src/eosio.bios.cpp
	modified:   contracts/eosio.system/include/eosio.system/eosio.system.hpp
	modified:   contracts/eosio.system/ricardian/eosio.system.contracts.md.in
	modified:   contracts/eosio.system/src/eosio.system.cpp
	modified:   tests/eosio.system_tests.cpp

<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->
At the present there is no way to set the KV parameters on a 3.0 chain outside of test system contracts.

This PR adds  `setkvparams` action to `eosio.system` contract and  `eosio.bios` contract that will directly take a packed set of parameters (`max_key_size`, `max_value_size`, `max_iterators`) and pass them to the `set_kv_parameters_packed` host function.


## Change Description
<!-- Describe your changes, their justification, AND their impact. Reference issues or pull requests where possible (use '#XX' or 'GH-XX' where XX is the issue or pull request number). -->


## Deployment Changes
- [ ] Deployment Changes
<!-- checked [x] = Deployment changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces a change to the contracts that causes deployment to change, please describe the impact. -->


## API Changes
- [ ] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions
- [ ] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
