### PR TITLE
Powerup rename

### DIFF
--- a/contracts/eosio.system/CMakeLists.txt
+++ b/contracts/eosio.system/CMakeLists.txt
@@ -5,7 +5,7 @@ add_contract(eosio.system eosio.system
    ${CMAKE_CURRENT_SOURCE_DIR}/src/name_bidding.cpp
    ${CMAKE_CURRENT_SOURCE_DIR}/src/native.cpp
    ${CMAKE_CURRENT_SOURCE_DIR}/src/producer_pay.cpp
-   ${CMAKE_CURRENT_SOURCE_DIR}/src/rentbw.cpp
+   ${CMAKE_CURRENT_SOURCE_DIR}/src/powerup.cpp
    ${CMAKE_CURRENT_SOURCE_DIR}/src/rex.cpp
    ${CMAKE_CURRENT_SOURCE_DIR}/src/voting.cpp
 )
@@ -20,14 +20,23 @@ set_target_properties(eosio.system
    RUNTIME_OUTPUT_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}")
 
 add_contract(rex.results rex.results ${CMAKE_CURRENT_SOURCE_DIR}/src/rex.results.cpp)
+add_contract(powup.results powup.results ${CMAKE_CURRENT_SOURCE_DIR}/src/powerup.results.cpp)
 
 target_include_directories(rex.results
+   PUBLIC
+   ${CMAKE_CURRENT_SOURCE_DIR}/include)
+
+target_include_directories(powup.results
    PUBLIC
    ${CMAKE_CURRENT_SOURCE_DIR}/include)
 
 set_target_properties(rex.results
    PROPERTIES
    RUNTIME_OUTPUT_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/.rex")
+
+set_target_properties(powup.results
+   PROPERTIES
+   RUNTIME_OUTPUT_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/.powerup")
 
 configure_file( ${CMAKE_CURRENT_SOURCE_DIR}/ricardian/eosio.system.contracts.md.in ${CMAKE_CURRENT_BINARY_DIR}/ricardian/eosio.system.contracts.md @ONLY )
 

--- a/contracts/eosio.system/include/eosio.system/eosio.system.hpp
+++ b/contracts/eosio.system/include/eosio.system/eosio.system.hpp
@@ -549,11 +549,11 @@ namespace eosiosystem {
                                                             //    utilization and instantaneous resource utilization to shrink
                                                             //    by 63%. Do not specify to preserve the existing setting or
                                                             //    use the default.
-      std::optional<asset>          min_price;              // Fee needed to rent the entire resource market weight at the
+      std::optional<asset>          min_price;              // Fee needed to reserve the entire resource market weight at the
                                                             //    minimum price. For example, this could be set to 0.005% of
                                                             //    total token supply. Do not specify to preserve the existing
                                                             //    setting or use the default.
-      std::optional<asset>          max_price;              // Fee needed to rent the entire resource market weight at the
+      std::optional<asset>          max_price;              // Fee needed to reserve the entire resource market weight at the
                                                             //    maximum price. For example, this could be set to 10% of total
                                                             //    token supply. Do not specify to preserve the existing
                                                             //    setting (no default exists).
@@ -563,22 +563,22 @@ namespace eosiosystem {
    };
 
    struct powerup_config {
-      powerup_config_resource  net;           // NET market configuration
-      powerup_config_resource  cpu;           // CPU market configuration
-      std::optional<uint32_t> powerup_days;     // `power` `days` argument must match this. Do not specify to preserve the
-                                             //    existing setting or use the default.
-      std::optional<asset>    min_powerup_fee;  // Rental fees below this amount are rejected. Do not specify to preserve the
-                                             //    existing setting (no default exists).
+      powerup_config_resource  net;             // NET market configuration
+      powerup_config_resource  cpu;             // CPU market configuration
+      std::optional<uint32_t> powerup_days;     // `powerup` `days` argument must match this. Do not specify to preserve the
+                                                //    existing setting or use the default.
+      std::optional<asset>    min_powerup_fee;  // Fees below this amount are rejected. Do not specify to preserve the
+                                                //    existing setting (no default exists).
 
       EOSLIB_SERIALIZE( powerup_config, (net)(cpu)(powerup_days)(min_powerup_fee) )
    };
 
    struct powerup_state_resource {
-      static constexpr double   default_exponent   = 2.0;                  // Exponent of 2.0 means that the price to rent a
+      static constexpr double   default_exponent   = 2.0;                  // Exponent of 2.0 means that the price to reserve a
                                                                            //    tiny amount of resources increases linearly
                                                                            //    with utilization.
       static constexpr uint32_t default_decay_secs = 1 * seconds_per_day;  // 1 day; if 100% of bandwidth resources are in a
-                                                                           //    single loan, then, assuming no further renting,
+                                                                           //    single loan, then, assuming no further powerup usage,
                                                                            //    1 day after it expires the adjusted utilization
                                                                            //    will be at approximately 37% and after 3 days
                                                                            //    the adjusted utilization will be less than 5%.
@@ -599,9 +599,9 @@ namespace eosiosystem {
       double         exponent                = default_exponent;   // Exponent of resource price curve.
       uint32_t       decay_secs              = default_decay_secs; // Number of seconds for the gap between adjusted resource
                                                                    //    utilization and instantaneous utilization to shrink by 63%.
-      asset          min_price               = {};                 // Fee needed to rent the entire resource market weight at
+      asset          min_price               = {};                 // Fee needed to reserve the entire resource market weight at
                                                                    //    the minimum price (defaults to 0).
-      asset          max_price               = {};                 // Fee needed to rent the entire resource market weight at
+      asset          max_price               = {};                 // Fee needed to reserve the entire resource market weight at
                                                                    //    the maximum price.
       int64_t        utilization             = 0;                  // Instantaneous resource utilization. This is the current
                                                                    //    amount sold. utilization <= weight.
@@ -1315,7 +1315,7 @@ namespace eosiosystem {
          void powerupexec( const name& user, uint16_t max );
 
          /**
-          * Rent NET and CPU by percentage
+          * Powerup NET and CPU resources by percentage
           *
           * @param payer - the resource buyer
           * @param receiver - the resource receiver
@@ -1480,7 +1480,7 @@ namespace eosiosystem {
 
          // defined in power.cpp
          void adjust_resources(name payer, name account, symbol core_symbol, int64_t net_delta, int64_t cpu_delta, bool must_not_be_managed = false);
-         void process_queue(
+         void process_powerup_queue(
             time_point_sec now, symbol core_symbol, powerup_state& state,
             powerup_order_table& orders, uint32_t max_items, int64_t& net_delta_available,
             int64_t& cpu_delta_available);

--- a/contracts/eosio.system/include/eosio.system/eosio.system.hpp
+++ b/contracts/eosio.system/include/eosio.system/eosio.system.hpp
@@ -40,7 +40,7 @@ namespace eosiosystem {
    using eosio::time_point_sec;
    using eosio::unsigned_int;
 
-   inline constexpr int64_t rentbw_frac = 1'000'000'000'000'000ll;  // 1.0 = 10^15
+   inline constexpr int64_t powerup_frac = 1'000'000'000'000'000ll;  // 1.0 = 10^15
 
    template<typename E, typename F>
    static inline auto has_field( F flags, E field )
@@ -525,7 +525,7 @@ namespace eosiosystem {
       asset stake_change;
    };
 
-   struct rentbw_config_resource {
+   struct powerup_config_resource {
       std::optional<int64_t>        current_weight_ratio;   // Immediately set weight_ratio to this amount. 1x = 10^15. 0.01x = 10^13.
                                                             //    Do not specify to preserve the existing setting or use the default;
                                                             //    this avoids sudden price jumps. For new chains which don't need
@@ -534,7 +534,7 @@ namespace eosiosystem {
       std::optional<int64_t>        target_weight_ratio;    // Linearly shrink weight_ratio to this amount. 1x = 10^15. 0.01x = 10^13.
                                                             //    Do not specify to preserve the existing setting or use the default.
       std::optional<int64_t>        assumed_stake_weight;   // Assumed stake weight for ratio calculations. Use the sum of total
-                                                            //    staked and total rented by REX at the time the rentbw market
+                                                            //    staked and total rented by REX at the time the power market
                                                             //    is first activated. Do not specify to preserve the existing
                                                             //    setting (no default exists); this avoids sudden price jumps.
                                                             //    For new chains which don't need to phase out staking and REX,
@@ -558,22 +558,22 @@ namespace eosiosystem {
                                                             //    token supply. Do not specify to preserve the existing
                                                             //    setting (no default exists).
 
-      EOSLIB_SERIALIZE( rentbw_config_resource, (current_weight_ratio)(target_weight_ratio)(assumed_stake_weight)
+      EOSLIB_SERIALIZE( powerup_config_resource, (current_weight_ratio)(target_weight_ratio)(assumed_stake_weight)
                                                 (target_timestamp)(exponent)(decay_secs)(min_price)(max_price)    )
    };
 
-   struct rentbw_config {
-      rentbw_config_resource  net;           // NET market configuration
-      rentbw_config_resource  cpu;           // CPU market configuration
-      std::optional<uint32_t> rent_days;     // `rentbw` `days` argument must match this. Do not specify to preserve the
+   struct powerup_config {
+      powerup_config_resource  net;           // NET market configuration
+      powerup_config_resource  cpu;           // CPU market configuration
+      std::optional<uint32_t> powerup_days;     // `power` `days` argument must match this. Do not specify to preserve the
                                              //    existing setting or use the default.
-      std::optional<asset>    min_rent_fee;  // Rental fees below this amount are rejected. Do not specify to preserve the
+      std::optional<asset>    min_powerup_fee;  // Rental fees below this amount are rejected. Do not specify to preserve the
                                              //    existing setting (no default exists).
 
-      EOSLIB_SERIALIZE( rentbw_config, (net)(cpu)(rent_days)(min_rent_fee) )
+      EOSLIB_SERIALIZE( powerup_config, (net)(cpu)(powerup_days)(min_powerup_fee) )
    };
 
-   struct rentbw_state_resource {
+   struct powerup_state_resource {
       static constexpr double   default_exponent   = 2.0;                  // Exponent of 2.0 means that the price to rent a
                                                                            //    tiny amount of resources increases linearly
                                                                            //    with utilization.
@@ -591,8 +591,8 @@ namespace eosiosystem {
                                                                    //    assumed_stake_weight / (assumed_stake_weight + weight).
                                                                    //    calculated; varies over time. 1x = 10^15. 0.01x = 10^13.
       int64_t        assumed_stake_weight    = 0;                  // Assumed stake weight for ratio calculations.
-      int64_t        initial_weight_ratio    = rentbw_frac;        // Initial weight_ratio used for linear shrinkage.
-      int64_t        target_weight_ratio     = rentbw_frac / 100;  // Linearly shrink the weight_ratio to this amount.
+      int64_t        initial_weight_ratio    = powerup_frac;        // Initial weight_ratio used for linear shrinkage.
+      int64_t        target_weight_ratio     = powerup_frac / 100;  // Linearly shrink the weight_ratio to this amount.
       time_point_sec initial_timestamp       = {};                 // When weight_ratio shrinkage started
       time_point_sec target_timestamp        = {};                 // Stop automatic weight_ratio shrinkage at this time. Once this
                                                                    //    time hits, weight_ratio will be target_weight_ratio.
@@ -610,21 +610,21 @@ namespace eosiosystem {
       time_point_sec utilization_timestamp   = {};                 // When adjusted_utilization was last updated
    };
 
-   struct [[eosio::table("rent.state"),eosio::contract("eosio.system")]] rentbw_state {
-      static constexpr uint32_t default_rent_days = 30; // 30 day resource rentals
+   struct [[eosio::table("powup.state"),eosio::contract("eosio.system")]] powerup_state {
+      static constexpr uint32_t default_powerup_days = 30; // 30 day resource powerups
 
-      uint8_t                 version      = 0;
-      rentbw_state_resource   net          = {};                 // NET market state
-      rentbw_state_resource   cpu          = {};                 // CPU market state
-      uint32_t                rent_days    = default_rent_days;  // `rentbw` `days` argument must match this.
-      asset                   min_rent_fee = {};                 // Rental fees below this amount are rejected
+      uint8_t                    version           = 0;
+      powerup_state_resource     net               = {};                     // NET market state
+      powerup_state_resource     cpu               = {};                     // CPU market state
+      uint32_t                   powerup_days      = default_powerup_days;   // `powerup` `days` argument must match this.
+      asset                      min_powerup_fee   = {};                     // fees below this amount are rejected
 
       uint64_t primary_key()const { return 0; }
    };
 
-   typedef eosio::singleton<"rent.state"_n, rentbw_state> rentbw_state_singleton;
+   typedef eosio::singleton<"powup.state"_n, powerup_state> powerup_state_singleton;
 
-   struct [[eosio::table("rentbw.order"),eosio::contract("eosio.system")]] rentbw_order {
+   struct [[eosio::table("powup.order"),eosio::contract("eosio.system")]] powerup_order {
       uint8_t              version = 0;
       uint64_t             id;
       name                 owner;
@@ -637,13 +637,16 @@ namespace eosiosystem {
       uint64_t by_expires()const  { return expires.utc_seconds; }
    };
 
-   typedef eosio::multi_index< "rentbw.order"_n, rentbw_order,
-                               indexed_by<"byowner"_n, const_mem_fun<rentbw_order, uint64_t, &rentbw_order::by_owner>>,
-                               indexed_by<"byexpires"_n, const_mem_fun<rentbw_order, uint64_t, &rentbw_order::by_expires>>
-                               > rentbw_order_table;
+   typedef eosio::multi_index< "powup.order"_n, powerup_order,
+                               indexed_by<"byowner"_n, const_mem_fun<powerup_order, uint64_t, &powerup_order::by_owner>>,
+                               indexed_by<"byexpires"_n, const_mem_fun<powerup_order, uint64_t, &powerup_order::by_expires>>
+                               > powerup_order_table;
 
    /**
-    * eosio.system contract defines the structures and actions needed for blockchain's core functionality.
+    * The `eosio.system` smart contract is provided by `block.one` as a sample system contract, and it defines the structures and actions needed for blockchain's core functionality.
+    *
+    * Just like in the `eosio.bios` sample contract implementation, there are a few actions which are not implemented at the contract level (`newaccount`, `updateauth`, `deleteauth`, `linkauth`, `unlinkauth`, `canceldelay`, `onerror`, `setabi`, `setcode`), they are just declared in the contract so they will show in the contract's ABI and users will be able to push those actions to the chain via the account holding the `eosio.system` contract, but the implementation is at the EOSIO core level. They are referred to as EOSIO native actions.
+    *
     * - Users can stake tokens for CPU and Network bandwidth, and then vote for producers or
     *    delegate their vote to a proxy.
     * - Producers register in order to be voted for, and can claim per-block and per-vote rewards.
@@ -651,7 +654,7 @@ namespace eosiosystem {
     * - Users can bid on premium names.
     * - A resource exchange system (REX) allows token holders to lend their tokens,
     *    and users to rent CPU and Network resources in return for a market-determined fee.
-    * - A resource market separate from REX: `rentbw`.
+    * - A resource market separate from REX: `power`.
     */
    class [[eosio::contract("eosio.system")]] system_contract : public native {
 
@@ -1296,23 +1299,23 @@ namespace eosiosystem {
          void setinflation( int64_t annual_rate, int64_t inflation_pay_factor, int64_t votepay_factor );
 
          /**
-          * Configure the `rentbw` market. The market becomes available the first time this
+          * Configure the `power` market. The market becomes available the first time this
           * action is invoked.
           */
          [[eosio::action]]
-         void configrentbw( rentbw_config& args );
+         void cfgpowerup( powerup_config& args );
 
          /**
-          * Process rentbw queue and update state. Action does not execute anything related to a specific user.
+          * Process power queue and update state. Action does not execute anything related to a specific user.
           *
           * @param user - any account can execute this action
           * @param max - number of queue items to process
           */
          [[eosio::action]]
-         void rentbwexec( const name& user, uint16_t max );
+         void powerupexec( const name& user, uint16_t max );
 
          /**
-          * Rent NET and CPU
+          * Rent NET and CPU by percentage
           *
           * @param payer - the resource buyer
           * @param receiver - the resource receiver
@@ -1323,7 +1326,7 @@ namespace eosiosystem {
           *    `payer`'s token balance.
           */
          [[eosio::action]]
-         void rentbw( const name& payer, const name& receiver, uint32_t days, int64_t net_frac, int64_t cpu_frac, const asset& max_payment );
+         void powerup( const name& payer, const name& receiver, uint32_t days, int64_t net_frac, int64_t cpu_frac, const asset& max_payment );
 
          using init_action = eosio::action_wrapper<"init"_n, &system_contract::init>;
          using setacctram_action = eosio::action_wrapper<"setacctram"_n, &system_contract::setacctram>;
@@ -1371,9 +1374,9 @@ namespace eosiosystem {
          using setalimits_action = eosio::action_wrapper<"setalimits"_n, &system_contract::setalimits>;
          using setparams_action = eosio::action_wrapper<"setparams"_n, &system_contract::setparams>;
          using setinflation_action = eosio::action_wrapper<"setinflation"_n, &system_contract::setinflation>;
-         using configrentbw_action = eosio::action_wrapper<"configrentbw"_n, &system_contract::configrentbw>;
-         using rentbwexec_action = eosio::action_wrapper<"rentbwexec"_n, &system_contract::rentbwexec>;
-         using rentbw_action = eosio::action_wrapper<"rentbw"_n, &system_contract::rentbw>;
+         using cfgpowerup_action = eosio::action_wrapper<"cfgpowerup"_n, &system_contract::cfgpowerup>;
+         using powerupexec_action = eosio::action_wrapper<"powerupexec"_n, &system_contract::powerupexec>;
+         using powerup_action = eosio::action_wrapper<"powerup"_n, &system_contract::powerup>;
 
       private:
          // Implementation details:
@@ -1475,11 +1478,11 @@ namespace eosiosystem {
 
          registration<&system_contract::update_rex_stake> vote_stake_updater{ this };
 
-         // defined in rentbw.cpp
+         // defined in power.cpp
          void adjust_resources(name payer, name account, symbol core_symbol, int64_t net_delta, int64_t cpu_delta, bool must_not_be_managed = false);
-         void process_rentbw_queue(
-            time_point_sec now, symbol core_symbol, rentbw_state& state,
-            rentbw_order_table& orders, uint32_t max_items, int64_t& net_delta_available,
+         void process_queue(
+            time_point_sec now, symbol core_symbol, powerup_state& state,
+            powerup_order_table& orders, uint32_t max_items, int64_t& net_delta_available,
             int64_t& cpu_delta_available);
    };
 

--- a/contracts/eosio.system/include/eosio.system/powerup.results.hpp
+++ b/contracts/eosio.system/include/eosio.system/powerup.results.hpp
@@ -1,0 +1,33 @@
+#pragma once
+
+#include <eosio/asset.hpp>
+#include <eosio/eosio.hpp>
+#include <eosio/name.hpp>
+
+using eosio::action_wrapper;
+using eosio::asset;
+using eosio::name;
+
+/**
+ * The action `powerresult` of `power.results` is a no-op.
+ * It is added as an inline convenience action to `power` rental.
+ * This inline convenience action does not have any effect, however,
+ * its data includes the result of the parent action and appears in its trace.
+ */
+class [[eosio::contract("powup.results")]] powup_results : eosio::contract {
+   public:
+
+      using eosio::contract::contract;
+
+      /**
+       * powupresult action.
+       *
+       * @param fee        - rental fee amount
+       * @param powup_net - amount of powup NET tokens
+       * @param powup_cpu - amount of powup CPU tokens
+       */
+      [[eosio::action]]
+      void powupresult( const asset& fee, const asset& powup_net, const asset& powup_cpu );
+
+      using powupresult_action  = action_wrapper<"powupresult"_n,  &powup_results::powupresult>;
+};

--- a/contracts/eosio.system/include/eosio.system/powerup.results.hpp
+++ b/contracts/eosio.system/include/eosio.system/powerup.results.hpp
@@ -10,7 +10,7 @@ using eosio::name;
 
 /**
  * The action `powerresult` of `power.results` is a no-op.
- * It is added as an inline convenience action to `power` rental.
+ * It is added as an inline convenience action to `powerup` reservation.
  * This inline convenience action does not have any effect, however,
  * its data includes the result of the parent action and appears in its trace.
  */
@@ -22,7 +22,7 @@ class [[eosio::contract("powup.results")]] powup_results : eosio::contract {
       /**
        * powupresult action.
        *
-       * @param fee        - rental fee amount
+       * @param fee       - powerup fee amount
        * @param powup_net - amount of powup NET tokens
        * @param powup_cpu - amount of powup CPU tokens
        */

--- a/contracts/eosio.system/include/eosio.system/powerup.results.hpp
+++ b/contracts/eosio.system/include/eosio.system/powerup.results.hpp
@@ -27,7 +27,7 @@ class [[eosio::contract("powup.results")]] powup_results : eosio::contract {
        * @param powup_cpu - amount of powup CPU tokens
        */
       [[eosio::action]]
-      void powupresult( const asset& fee, const asset& powup_net, const asset& powup_cpu );
+      void powupresult( const asset& fee, const int64_t powup_net, const int64_t powup_cpu );
 
       using powupresult_action  = action_wrapper<"powupresult"_n,  &powup_results::powupresult>;
 };

--- a/contracts/eosio.system/src/powerup.cpp
+++ b/contracts/eosio.system/src/powerup.cpp
@@ -1,11 +1,12 @@
 #include <eosio.system/eosio.system.hpp>
 #include <eosio/action.hpp>
+#include <eosio.system/powerup.results.hpp>
 #include <algorithm>
 #include <cmath>
 
 namespace eosiosystem {
 
-void update_weight(time_point_sec now, rentbw_state_resource& res, int64_t& delta_available);
+void update_weight(time_point_sec now, powerup_state_resource& res, int64_t& delta_available);
 
 /**
  *  @pre  now >= res.utilization_timestamp
@@ -13,7 +14,7 @@ void update_weight(time_point_sec now, rentbw_state_resource& res, int64_t& delt
  *  @post if res.utilization < old res.adjusted_utilization, then new res.adjusted_utilization <= old res.adjusted_utilization
  *  @post if res.utilization >= old res.adjusted_utilization, then new res.adjusted_utilization == res.utilization
  */
-void update_utilization(time_point_sec now, rentbw_state_resource& res);
+void update_utilization(time_point_sec now, powerup_state_resource& res);
 
 void system_contract::adjust_resources(name payer, name account, symbol core_symbol, int64_t net_delta,
                                        int64_t cpu_delta, bool must_not_be_managed) {
@@ -66,8 +67,8 @@ void system_contract::adjust_resources(name payer, name account, symbol core_sym
    }
 } // system_contract::adjust_resources
 
-void system_contract::process_rentbw_queue(time_point_sec now, symbol core_symbol, rentbw_state& state,
-                                           rentbw_order_table& orders, uint32_t max_items, int64_t& net_delta_available,
+void system_contract::process_queue(time_point_sec now, symbol core_symbol, powerup_state& state,
+                                           powerup_order_table& orders, uint32_t max_items, int64_t& net_delta_available,
                                            int64_t& cpu_delta_available) {
    update_utilization(now, state.net);
    update_utilization(now, state.cpu);
@@ -87,7 +88,7 @@ void system_contract::process_rentbw_queue(time_point_sec now, symbol core_symbo
    update_weight(now, state.cpu, cpu_delta_available);
 }
 
-void update_weight(time_point_sec now, rentbw_state_resource& res, int64_t& delta_available) {
+void update_weight(time_point_sec now, powerup_state_resource& res, int64_t& delta_available) {
    if (now >= res.target_timestamp) {
       res.weight_ratio = res.target_weight_ratio;
    } else {
@@ -96,12 +97,12 @@ void update_weight(time_point_sec now, rentbw_state_resource& res, int64_t& delt
                                (now.utc_seconds - res.initial_timestamp.utc_seconds) /
                                (res.target_timestamp.utc_seconds - res.initial_timestamp.utc_seconds);
    }
-   int64_t new_weight    = res.assumed_stake_weight * int128_t(rentbw_frac) / res.weight_ratio - res.assumed_stake_weight;
+   int64_t new_weight    = res.assumed_stake_weight * int128_t(powerup_frac) / res.weight_ratio - res.assumed_stake_weight;
    delta_available += new_weight - res.weight;
    res.weight = new_weight;
 }
 
-void update_utilization(time_point_sec now, rentbw_state_resource& res) {
+void update_utilization(time_point_sec now, powerup_state_resource& res) {
    if (now <= res.utilization_timestamp) return;
 
    if (res.utilization >= res.adjusted_utilization) {
@@ -115,11 +116,11 @@ void update_utilization(time_point_sec now, rentbw_state_resource& res) {
    res.utilization_timestamp = now;
 }
 
-void system_contract::configrentbw(rentbw_config& args) {
+void system_contract::cfgpowerup(powerup_config& args) {
    require_auth(get_self());
    time_point_sec         now         = eosio::current_time_point();
    auto                   core_symbol = get_core_symbol();
-   rentbw_state_singleton state_sing{ get_self(), 0 };
+   powerup_state_singleton state_sing{ get_self(), 0 };
    auto                   state = state_sing.get_or_default();
 
    eosio::check(eosio::is_account(reserv_account), "eosio.reserv account must first be created");
@@ -191,12 +192,12 @@ void system_contract::configrentbw(rentbw_config& args) {
       }
 
       eosio::check(*args.current_weight_ratio > 0, "current_weight_ratio is too small");
-      eosio::check(*args.current_weight_ratio <= rentbw_frac, "current_weight_ratio is too large");
+      eosio::check(*args.current_weight_ratio <= powerup_frac, "current_weight_ratio is too large");
       eosio::check(*args.target_weight_ratio > 0, "target_weight_ratio is too small");
       eosio::check(*args.target_weight_ratio <= *args.current_weight_ratio, "weight can't grow over time");
       eosio::check(*args.assumed_stake_weight >= 1,
                    "assumed_stake_weight must be at least 1; a much larger value is recommended");
-      eosio::check(*args.assumed_stake_weight * int128_t(rentbw_frac) / *args.target_weight_ratio <=
+      eosio::check(*args.assumed_stake_weight * int128_t(powerup_frac) / *args.target_weight_ratio <=
                          std::numeric_limits<int64_t>::max(),
                    "assumed_stake_weight/target_weight_ratio is too large");
       eosio::check(*args.exponent >= 1.0, "exponent must be >= 1");
@@ -221,21 +222,21 @@ void system_contract::configrentbw(rentbw_config& args) {
       state.max_price            = *args.max_price;
    };
 
-   if (!args.rent_days) {
-      *args.rent_days = state.rent_days;
+   if (!args.powerup_days) {
+      *args.powerup_days = state.powerup_days;
    }
 
-   if (!args.min_rent_fee) {
-      eosio::check(!is_default_asset(state.min_rent_fee), "min_rent_fee does not have a default value");
-      *args.min_rent_fee = state.min_rent_fee;
+   if (!args.min_powerup_fee) {
+      eosio::check(!is_default_asset(state.min_powerup_fee), "min_powerup_fee does not have a default value");
+      *args.min_powerup_fee = state.min_powerup_fee;
    }
 
-   eosio::check(*args.rent_days > 0, "rent_days must be > 0");
-   eosio::check(args.min_rent_fee->symbol == core_symbol, "min_rent_fee doesn't match core symbol");
-   eosio::check(args.min_rent_fee->amount > 0, "min_rent_fee must be positive");
+   eosio::check(*args.powerup_days > 0, "powerup_days must be > 0");
+   eosio::check(args.min_powerup_fee->symbol == core_symbol, "min_powerup_fee doesn't match core symbol");
+   eosio::check(args.min_powerup_fee->amount > 0, "min_powerup_fee must be positive");
 
-   state.rent_days    = *args.rent_days;
-   state.min_rent_fee = *args.min_rent_fee;
+   state.powerup_days    = *args.powerup_days;
+   state.min_powerup_fee = *args.min_powerup_fee;
 
    update(state.net, args.net);
    update(state.cpu, args.cpu);
@@ -249,7 +250,7 @@ void system_contract::configrentbw(rentbw_config& args) {
 
    adjust_resources(get_self(), reserv_account, core_symbol, net_delta_available, cpu_delta_available, true);
    state_sing.set(state, get_self());
-} // system_contract::configrentbw
+} // system_contract::configpower
 
 /**
  *  @pre 0 <= state.min_price.amount <= state.max_price.amount
@@ -258,7 +259,7 @@ void system_contract::configrentbw(rentbw_config& args) {
  *  @pre 0 <= state.utilization <= state.adjusted_utilization <= state.weight
  *  @pre 0 <= utilization_increase <= (state.weight - state.utilization)
  */
-int64_t calc_rentbw_fee(const rentbw_state_resource& state, int64_t utilization_increase) {
+int64_t calc_powerup_fee(const powerup_state_resource& state, int64_t utilization_increase) {
    if( utilization_increase <= 0 ) return 0;
 
    // Let p(u) = price as a function of the utilization fraction u which is defined for u in [0.0, 1.0].
@@ -278,8 +279,6 @@ int64_t calc_rentbw_fee(const rentbw_state_resource& state, int64_t utilization_
                coefficient * std::pow(end_u, state.exponent) - coefficient * std::pow(start_u, state.exponent);
    };
 
-   // Returns p(double(utilization)/state.weight).
-   // @pre 0 <= utilization <= state.weight
    auto price_function = [&state](int64_t utilization) -> double {
       double price = state.min_price.amount;
       // state.exponent >= 1.0, therefore the exponent passed into std::pow is >= 0.0.
@@ -313,51 +312,51 @@ int64_t calc_rentbw_fee(const rentbw_state_resource& state, int64_t utilization_
    return std::ceil(fee);
 }
 
-void system_contract::rentbwexec(const name& user, uint16_t max) {
+void system_contract::powerupexec(const name& user, uint16_t max) {
    require_auth(user);
-   rentbw_state_singleton state_sing{ get_self(), 0 };
-   rentbw_order_table     orders{ get_self(), 0 };
-   eosio::check(state_sing.exists(), "rentbw hasn't been initialized");
+   powerup_state_singleton state_sing{ get_self(), 0 };
+   powerup_order_table     orders{ get_self(), 0 };
+   eosio::check(state_sing.exists(), "powerup hasn't been initialized");
    auto           state       = state_sing.get();
    time_point_sec now         = eosio::current_time_point();
    auto           core_symbol = get_core_symbol();
 
    int64_t net_delta_available = 0;
    int64_t cpu_delta_available = 0;
-   process_rentbw_queue(now, core_symbol, state, orders, max, net_delta_available, cpu_delta_available);
+   process_queue(now, core_symbol, state, orders, max, net_delta_available, cpu_delta_available);
 
    adjust_resources(get_self(), reserv_account, core_symbol, net_delta_available, cpu_delta_available, true);
    state_sing.set(state, get_self());
 }
 
-void system_contract::rentbw(const name& payer, const name& receiver, uint32_t days, int64_t net_frac, int64_t cpu_frac,
+void system_contract::powerup(const name& payer, const name& receiver, uint32_t days, int64_t net_frac, int64_t cpu_frac,
                              const asset& max_payment) {
    require_auth(payer);
-   rentbw_state_singleton state_sing{ get_self(), 0 };
-   rentbw_order_table     orders{ get_self(), 0 };
-   eosio::check(state_sing.exists(), "rentbw hasn't been initialized");
+   powerup_state_singleton state_sing{ get_self(), 0 };
+   powerup_order_table     orders{ get_self(), 0 };
+   eosio::check(state_sing.exists(), "powerup hasn't been initialized");
    auto           state       = state_sing.get();
    time_point_sec now         = eosio::current_time_point();
    auto           core_symbol = get_core_symbol();
    eosio::check(max_payment.symbol == core_symbol, "max_payment doesn't match core symbol");
-   eosio::check(days == state.rent_days, "days doesn't match configuration");
+   eosio::check(days == state.powerup_days, "days doesn't match configuration");
    eosio::check(net_frac >= 0, "net_frac can't be negative");
    eosio::check(cpu_frac >= 0, "cpu_frac can't be negative");
-   eosio::check(net_frac <= rentbw_frac, "net can't be more than 100%");
-   eosio::check(cpu_frac <= rentbw_frac, "cpu can't be more than 100%");
+   eosio::check(net_frac <= powerup_frac, "net can't be more than 100%");
+   eosio::check(cpu_frac <= powerup_frac, "cpu can't be more than 100%");
 
    int64_t net_delta_available = 0;
    int64_t cpu_delta_available = 0;
-   process_rentbw_queue(now, core_symbol, state, orders, 2, net_delta_available, cpu_delta_available);
+   process_queue(now, core_symbol, state, orders, 2, net_delta_available, cpu_delta_available);
 
    eosio::asset fee{ 0, core_symbol };
-   auto         process = [&](int64_t frac, int64_t& amount, rentbw_state_resource& state) {
+   auto         process = [&](int64_t frac, int64_t& amount, powerup_state_resource& state) {
       if (!frac)
          return;
-      amount = int128_t(frac) * state.weight / rentbw_frac;
+      amount = int128_t(frac) * state.weight / powerup_frac;
       eosio::check(state.weight, "market doesn't have resources available");
       eosio::check(state.utilization + amount <= state.weight, "market doesn't have enough resources available");
-      int64_t f = calc_rentbw_fee(state, amount);
+      int64_t f = calc_powerup_fee(state, amount);
       eosio::check(f > 0, "calculated fee is below minimum; try renting more");
       fee.amount += f;
       state.utilization += amount;
@@ -372,7 +371,7 @@ void system_contract::rentbw(const name& payer, const name& receiver, uint32_t d
       error_msg += fee.to_string();
       eosio::check(false, error_msg);
    }
-   eosio::check(fee >= state.min_rent_fee, "calculated fee is below minimum; try renting more");
+   eosio::check(fee >= state.min_powerup_fee, "calculated fee is below minimum; try renting more");
 
    orders.emplace(payer, [&](auto& order) {
       order.id         = orders.available_primary_key();
@@ -388,6 +387,10 @@ void system_contract::rentbw(const name& payer, const name& receiver, uint32_t d
    adjust_resources(get_self(), reserv_account, core_symbol, net_delta_available, cpu_delta_available, true);
    channel_to_rex(payer, fee, true);
    state_sing.set(state, get_self());
+
+   // inline noop action
+   powup_results::powupresult_action powupresult_act{ reserv_account, std::vector<eosio::permission_level>{ } };
+   powupresult_act.send( fee, asset{ net_amount, core_symbol }, asset{ cpu_amount, core_symbol } );
 }
 
 } // namespace eosiosystem

--- a/contracts/eosio.system/src/powerup.cpp
+++ b/contracts/eosio.system/src/powerup.cpp
@@ -392,7 +392,7 @@ void system_contract::powerup(const name& payer, const name& receiver, uint32_t 
 
    // inline noop action
    powup_results::powupresult_action powupresult_act{ reserv_account, std::vector<eosio::permission_level>{ } };
-   powupresult_act.send( fee, asset{ net_amount, core_symbol }, asset{ cpu_amount, core_symbol } );
+   powupresult_act.send( fee, net_amount, cpu_amount );
 }
 
 } // namespace eosiosystem

--- a/contracts/eosio.system/src/powerup.cpp
+++ b/contracts/eosio.system/src/powerup.cpp
@@ -279,6 +279,8 @@ int64_t calc_powerup_fee(const powerup_state_resource& state, int64_t utilizatio
                coefficient * std::pow(end_u, state.exponent) - coefficient * std::pow(start_u, state.exponent);
    };
 
+   // Returns p(double(utilization)/state.weight).
+   // @pre 0 <= utilization <= state.weight
    auto price_function = [&state](int64_t utilization) -> double {
       double price = state.min_price.amount;
       // state.exponent >= 1.0, therefore the exponent passed into std::pow is >= 0.0.

--- a/contracts/eosio.system/src/powerup.results.cpp
+++ b/contracts/eosio.system/src/powerup.results.cpp
@@ -1,5 +1,5 @@
 #include <eosio.system/powerup.results.hpp>
 
-void powup_results::powupresult( const asset& fee, const asset& powup_net, const asset& powup_cpu ) { }
+void powup_results::powupresult( const asset& fee, const int64_t powup_net_weight, const int64_t powup_cpu_weight ) { }
 
 extern "C" void apply( uint64_t, uint64_t, uint64_t ) { }

--- a/contracts/eosio.system/src/powerup.results.cpp
+++ b/contracts/eosio.system/src/powerup.results.cpp
@@ -1,0 +1,5 @@
+#include <eosio.system/powerup.results.hpp>
+
+void powup_results::powupresult( const asset& fee, const asset& powup_net, const asset& powup_cpu ) { }
+
+extern "C" void apply( uint64_t, uint64_t, uint64_t ) { }

--- a/docs/04_guides/08_configure-use-powerup-resource-model.md
+++ b/docs/04_guides/08_configure-use-powerup-resource-model.md
@@ -1,0 +1,248 @@
+# Configure and Use the `PowerUp` Resource Model
+
+## Configuration
+
+### Definitions
+
+#### Configuration
+```
+// configure the `powerup` market. The market becomes available the first time this action is invoked
+void cfgpowerup( powerup_config& args );
+
+struct powerup_config_resource {
+    std::optional<int64_t>        current_weight_ratio;   // Immediately set weight_ratio to this amount. 1x = 10^15. 0.01x = 10^13.                                                //    Do not specify to preserve the existing setting or use the default;
+                                                          //    this avoids sudden price jumps. For new chains which don't need
+                                                          //    to gradually phase out staking and REX, 0.01x (10^13) is a good
+                                                          //    value for both current_weight_ratio and target_weight_ratio.
+    std::optional<int64_t>        target_weight_ratio;    // Linearly shrink weight_ratio to this amount. 1x = 10^15. 0.01x = 10^13.
+                                                          //    Do not specify to preserve the existing setting or use the default.
+    std::optional<int64_t>        assumed_stake_weight;   // Assumed stake weight for ratio calculations. Use the sum of total
+                                                          //    staked and total rented by REX at the time the power market
+                                                          //    is first activated. Do not specify to preserve the existing
+                                                          //    setting (no default exists); this avoids sudden price jumps.
+                                                          //    For new chains which don't need to phase out staking and REX,
+                                                          //    10^12 is probably a good value.
+    std::optional<time_point_sec> target_timestamp;       // Stop automatic weight_ratio shrinkage at this time. Once this
+                                                          //    time hits, weight_ratio will be target_weight_ratio. Ignored
+                                                          //    if current_weight_ratio == target_weight_ratio. Do not specify
+                                                          //    this to preserve the existing setting (no default exists).
+    std::optional<double>         exponent;               // Exponent of resource price curve. Must be >= 1. Do not specify
+                                                          //    to preserve the existing setting or use the default.
+    std::optional<uint32_t>       decay_secs;             // Number of seconds for the gap between adjusted resource
+                                                          //    utilization and instantaneous resource utilization to shrink
+                                                          //    by 63%. Do not specify to preserve the existing setting or
+                                                          //    use the default.
+    std::optional<asset>          min_price;              // Fee needed to rent the entire resource market weight at the
+                                                          //    minimum price. For example, this could be set to 0.005% of
+                                                          //    total token supply. Do not specify to preserve the existing
+                                                          //    setting or use the default.
+    std::optional<asset>          max_price;              // Fee needed to rent the entire resource market weight at the
+                                                          //    maximum price. For example, this could be set to 10% of total
+                                                          //    token supply. Do not specify to preserve the existing
+                                                          //    setting (no default exists).
+
+   };
+
+struct powerup_config {
+    powerup_config_resource  net;             // NET market configuration
+    powerup_config_resource  cpu;             // CPU market configuration
+    std::optional<uint32_t> powerup_days;     // `power` `days` argument must match this. Do not specify to preserve the
+                                              //    existing setting or use the default.
+    std::optional<asset>    min_powerup_fee;  // Rental fees below this amount are rejected. Do not specify to preserve the
+                                              //    existing setting (no default exists).
+};
+```
+#### State
+
+Definitions useful to help understand the configuration, including defaults:
+```
+inline constexpr int64_t powerup_frac = 1'000'000'000'000'000ll;  // 1.0 = 10^15
+
+struct powerup_state_resource {
+    static constexpr double   default_exponent   = 2.0;                  // Exponent of 2.0 means that the price to rent a
+                                                                         //    tiny amount of resources increases linearly
+                                                                         //    with utilization.
+    static constexpr uint32_t default_decay_secs = 1 * seconds_per_day;  // 1 day; if 100% of bandwidth resources are in a
+                                                                         //    single loan, then, assuming no further renting,
+                                                                         //    1 day after it expires the adjusted utilization
+                                                                         //    will be at approximately 37% and after 3 days
+                                                                         //    the adjusted utilization will be less than 5%.
+
+    uint8_t        version                 = 0;
+    int64_t        weight                  = 0;                  // resource market weight. calculated; varies over time.
+                                                                 //    1 represents the same amount of resources as 1
+                                                                 //    satoshi of SYS staked.
+    int64_t        weight_ratio            = 0;                  // resource market weight ratio:
+                                                                 //    assumed_stake_weight / (assumed_stake_weight + weight).
+                                                                 //    calculated; varies over time. 1x = 10^15. 0.01x = 10^13.
+    int64_t        assumed_stake_weight    = 0;                  // Assumed stake weight for ratio calculations.
+    int64_t        initial_weight_ratio    = powerup_frac;       // Initial weight_ratio used for linear shrinkage.
+    int64_t        target_weight_ratio     = powerup_frac / 100; // Linearly shrink the weight_ratio to this amount.
+    time_point_sec initial_timestamp       = {};                 // When weight_ratio shrinkage started
+    time_point_sec target_timestamp        = {};                 // Stop automatic weight_ratio shrinkage at this time. Once this
+                                                                 //    time hits, weight_ratio will be target_weight_ratio.
+    double         exponent                = default_exponent;   // Exponent of resource price curve.
+    uint32_t       decay_secs              = default_decay_secs; // Number of seconds for the gap between adjusted resource
+                                                                 //    utilization and instantaneous utilization to shrink by 63%.
+    asset          min_price               = {};                 // Fee needed to rent the entire resource market weight at
+                                                                 //    the minimum price (defaults to 0).
+    asset          max_price               = {};                 // Fee needed to rent the entire resource market weight at
+                                                                 //    the maximum price.
+    int64_t        utilization             = 0;                  // Instantaneous resource utilization. This is the current
+                                                                 //    amount sold. utilization <= weight.
+    int64_t        adjusted_utilization    = 0;                  // Adjusted resource utilization. This is >= utilization and
+                                                                 //    <= weight. It grows instantly but decays exponentially.
+    time_point_sec utilization_timestamp   = {};                 // When adjusted_utilization was last updated
+};
+
+struct powerup_state {
+    static constexpr uint32_t default_powerup_days = 30; // 30 day resource powerups
+
+    uint8_t                    version           = 0;
+    powerup_state_resource     net               = {};                     // NET market state
+    powerup_state_resource     cpu               = {};                     // CPU market state
+    uint32_t                   powerup_days      = default_powerup_days;   // `powerup` `days` argument must match this.
+    asset                      min_powerup_fee   = {};                     // fees below this amount are rejected
+
+    uint64_t primary_key()const { return 0; }
+};
+```
+
+### Preparation for Upgrade
+1. Build [eosio.contracts](https://github.com/EOSIO/eosio.contracts) with `powerup` code. Version **1.9.2** or greater .
+2. Deploy eosio.system contract to `eosio`.
+3. Create account `eosio.reserv` and ensure the account has enough at least 4 KiB of RAM.
+4. Deploy `powup.results.abi` to `eosio.reserv` account using `setabi`. The ABI can be found in the `build/contracts/eosio.system/.powerup/` directory.
+5. Enable the REX system (if not enabled).
+
+### Configuring `PowerUp`
+
+#### Config file
+```
+# config.json
+{
+    "net": {
+        "assumed_stake_weight": 944076307,
+        "current_weight_ratio": 1000000000000000,
+        "decay_secs": 86400,
+        "exponent": 2,
+        "max_price": "10000000.0000 TST",
+        "min_price": "0.0000 TST",
+        "target_timestamp": "2022-01-01T00:00:00.000",
+        "target_weight_ratio": 10000000000000
+    },
+    "cpu": {
+        "assumed_stake_weight": 3776305228,
+        "current_weight_ratio": 1000000000000000,
+        "decay_secs": 86400,
+        "exponent": 2,
+        "max_price": "10000000.0000 TST",
+        "min_price": "0.0000 TST",
+        "target_timestamp": "2022-01-01T00:00:00.000",
+        "target_weight_ratio": 10000000000000
+    },
+    "min_powerup_fee": "0.0001 TST",
+    "powerup_days": 1
+}
+```
+
+#### `cfgpowerup` Action Call
+```
+# call to `cfgpowerup`
+cleos push action eosio cfgpowerup "[`cat ./config.json`]" -p eosio
+```
+
+#### Check state
+```
+cleos get table eosio 0 powup.state
+{
+  "rows": [{
+      "version": 0,
+      "net": {
+        "version": 0,
+        "weight": 0,
+        "weight_ratio": "1000000000000000",
+        "assumed_stake_weight": 944076307,
+        "initial_weight_ratio": "1000000000000000",
+        "target_weight_ratio": "10000000000000",
+        "initial_timestamp": "2020-11-16T19:52:50",
+        "target_timestamp": "2022-01-01T00:00:00",
+        "exponent": "2.00000000000000000",
+        "decay_secs": 3600,
+        "min_price": "0.0000 EOS",
+        "max_price": "10000000.0000 EOS",
+        "utilization": 0,
+        "adjusted_utilization": 0,
+        "utilization_timestamp": "2020-11-16T19:52:50"
+      },
+      "cpu": {
+        "version": 0,
+        "weight": 0,
+        "weight_ratio": "1000000000000000",
+        "assumed_stake_weight": 3776305228,
+        "initial_weight_ratio": "1000000000000000",
+        "target_weight_ratio": "10000000000000",
+        "initial_timestamp": "2020-11-16T19:52:50",
+        "target_timestamp": "2022-01-01T00:00:00",
+        "exponent": "2.00000000000000000",
+        "decay_secs": 3600,
+        "min_price": "0.0000 EOS",
+        "max_price": "10000000.0000 EOS",
+        "utilization": 0,
+        "adjusted_utilization": 0,
+        "utilization_timestamp": "2020-11-16T19:52:50"
+      },
+      "powerup_days": 1,
+      "min_powerup_fee": "0.0001 EOS"
+    }
+  ],
+  "more": false,
+  "next_key": ""
+}
+```
+
+### Using `PowerUp`
+
+#### Executing an order
+The action to powerup an account is `powerup`. It takes a `payer` and a `receiver` of the resources. The `days` should always match `state.powerup_days`. `net_frac` and `cpu_frac` are the percentage of the resources that you need. The easiest way to caclulate the percentage is to multiple 10^15 (100%) by the desired percentage. For example: 10^15 * 1% = 10^13.
+```
+cleos push action eosio powerup '[user, user, 1, 10000000000000, 10000000000000, "1000.0000 EOS"]' -p user
+executed transaction: 82b7124601612b371b812e3bf65cf63bb44616802d3cd33a2c0422b58399f54f  144 bytes  521 us
+#         eosio <= eosio::powerup               {"payer":"user","receiver":"user","days":1,"net_frac":"10000000000000","cpu_frac":"10000000000000","...
+#   eosio.token <= eosio.token::transfer        {"from":"user","to":"eosio.rex","quantity":"999.9901 EOS","memo":"transfer from user to eosio.rex"}
+#  eosio.reserv <= eosio.reserv::powupresult    {"fee":"999.9901 EOS","powup_net":"1.6354 EOS","powup_cpu":"6.5416 EOS"}
+#          user <= eosio.token::transfer        {"from":"user","to":"eosio.rex","quantity":"999.9901 EOS","memo":"transfer from user to eosio.rex"}
+#     eosio.rex <= eosio.token::transfer        {"from":"user","to":"eosio.rex","quantity":"999.9901 EOS","memo":"transfer from user to eosio.rex"}
+```
+You can see how many tokens were received for `NET` and `CPU` as well as the fee by looking at the `eosio.reserv::powupresult` informational action. 
+
+*It is worth mentioning that the network being used for the example has not fully transitioned so the available resources are minimal therefore 1% of the resources are quite expensive. As the system continues the transition more resources are available to the `PowerUp` resource model and will become more affordable.*
+
+#### Clearing the orders queue
+
+The orders table `powup.order` can be viewed by calling:
+```
+cleos get table eosio 0 powup.order
+{
+  "rows": [{
+      "version": 0,
+      "id": 0,
+      "owner": "user",
+      "net_weight": 16354,
+      "cpu_weight": 65416,
+      "expires": "2020-11-18T13:04:33"
+    }
+  ],
+  "more": false,
+  "next_key": ""
+}
+```
+
+The action `powerupexec` that takes a `name` of a user and the `max` number of orders that will be cleared if expired. It is worth noting that the call to `powerup` will also clear up to two expired orders per call.
+
+```
+cleos push action eosio powerupexec '[user, 2]' -p user
+executed transaction: 93ab4ac900a7902e4e59e5e925e8b54622715328965150db10774aa09855dc98  104 bytes  363 us
+#         eosio <= eosio::powerupexec           {"user":"user","max":2}
+warning: transaction executed locally, but may not be confirmed by the network yet         ]
+```

--- a/docs/04_guides/08_configure-use-powerup-resource-model.md
+++ b/docs/04_guides/08_configure-use-powerup-resource-model.md
@@ -32,11 +32,11 @@ struct powerup_config_resource {
                                                           //    utilization and instantaneous resource utilization to shrink
                                                           //    by 63%. Do not specify to preserve the existing setting or
                                                           //    use the default.
-    std::optional<asset>          min_price;              // Fee needed to rent the entire resource market weight at the
+    std::optional<asset>          min_price;              // Fee needed to reserve the entire resource market weight at the
                                                           //    minimum price. For example, this could be set to 0.005% of
                                                           //    total token supply. Do not specify to preserve the existing
                                                           //    setting or use the default.
-    std::optional<asset>          max_price;              // Fee needed to rent the entire resource market weight at the
+    std::optional<asset>          max_price;              // Fee needed to reserve the entire resource market weight at the
                                                           //    maximum price. For example, this could be set to 10% of total
                                                           //    token supply. Do not specify to preserve the existing
                                                           //    setting (no default exists).
@@ -46,9 +46,9 @@ struct powerup_config_resource {
 struct powerup_config {
     powerup_config_resource  net;             // NET market configuration
     powerup_config_resource  cpu;             // CPU market configuration
-    std::optional<uint32_t> powerup_days;     // `power` `days` argument must match this. Do not specify to preserve the
+    std::optional<uint32_t> powerup_days;     // `powerup` `days` argument must match this. Do not specify to preserve the
                                               //    existing setting or use the default.
-    std::optional<asset>    min_powerup_fee;  // Rental fees below this amount are rejected. Do not specify to preserve the
+    std::optional<asset>    min_powerup_fee;  // Powerup fees below this amount are rejected. Do not specify to preserve the
                                               //    existing setting (no default exists).
 };
 ```
@@ -59,11 +59,11 @@ Definitions useful to help understand the configuration, including defaults:
 inline constexpr int64_t powerup_frac = 1'000'000'000'000'000ll;  // 1.0 = 10^15
 
 struct powerup_state_resource {
-    static constexpr double   default_exponent   = 2.0;                  // Exponent of 2.0 means that the price to rent a
+    static constexpr double   default_exponent   = 2.0;                  // Exponent of 2.0 means that the price to reserve a
                                                                          //    tiny amount of resources increases linearly
                                                                          //    with utilization.
     static constexpr uint32_t default_decay_secs = 1 * seconds_per_day;  // 1 day; if 100% of bandwidth resources are in a
-                                                                         //    single loan, then, assuming no further renting,
+                                                                         //    single loan, then, assuming no further powerup usage,
                                                                          //    1 day after it expires the adjusted utilization
                                                                          //    will be at approximately 37% and after 3 days
                                                                          //    the adjusted utilization will be less than 5%.
@@ -84,9 +84,9 @@ struct powerup_state_resource {
     double         exponent                = default_exponent;   // Exponent of resource price curve.
     uint32_t       decay_secs              = default_decay_secs; // Number of seconds for the gap between adjusted resource
                                                                  //    utilization and instantaneous utilization to shrink by 63%.
-    asset          min_price               = {};                 // Fee needed to rent the entire resource market weight at
+    asset          min_price               = {};                 // Fee needed to reserve the entire resource market weight at
                                                                  //    the minimum price (defaults to 0).
-    asset          max_price               = {};                 // Fee needed to rent the entire resource market weight at
+    asset          max_price               = {};                 // Fee needed to reserve the entire resource market weight at
                                                                  //    the maximum price.
     int64_t        utilization             = 0;                  // Instantaneous resource utilization. This is the current
                                                                  //    amount sold. utilization <= weight.

--- a/docs/04_guides/08_configure-use-powerup-resource-model.md
+++ b/docs/04_guides/08_configure-use-powerup-resource-model.md
@@ -1,7 +1,7 @@
 # Configure and Use the `PowerUp` Resource Model
 
 ## Overview
-This new system will create a new optional NET and CPU rental market which displaces (over time)
+This new system will create a new optional NET and CPU marketplace which displaces (over time)
 the existing staking system and REX market. Under the old model, system token holders
 own NET and CPU and may choose to use it themselves, delegate it to others, or make
 it available for others to rent using the REX market. Under this new model, the chain
@@ -228,7 +228,7 @@ You can see how much NET and CPU weight was received as well as the fee by looki
 *It is worth mentioning that the network being used for the example has not fully transitioned so the available resources are minimal therefore 1% of the resources are quite expensive. As the system continues the transition more resources are available to the `PowerUp` resource model and will become more affordable.*
 
 #### Processing Expired Orders
-The resources in loans that expire do not automatically get reclaimed by the system. The expired loans sit in a queue that must be processed. Anyone calling the `powerup` action will help with processing this queue (limited to processing at most two expired loans at a time) so that normally the expired loans will be automatically processed in a timely manner. However, in some cases it may be necessary to manual process expired loans in the queue to make resources available to the system again and thus make rental prices cheaper. In such a scenario, any account may process up to an arbitrary number of expired loans by calling the `powerupexec` action.
+The resources in loans that expire do not automatically get reclaimed by the system. The expired loans sit in a queue that must be processed. Anyone calling the `powerup` action will help with processing this queue (limited to processing at most two expired loans at a time) so that normally the expired loans will be automatically processed in a timely manner. However, in some cases it may be necessary to manual process expired loans in the queue to make resources available to the system again and thus make prices cheaper. In such a scenario, any account may process up to an arbitrary number of expired loans by calling the `powerupexec` action.
 
 The orders table `powup.order` can be viewed by calling:
 ```

--- a/tests/eosio.powerup_tests.cpp
+++ b/tests/eosio.powerup_tests.cpp
@@ -12,10 +12,10 @@
 
 #include "eosio.system_tester.hpp"
 
-inline constexpr int64_t rentbw_frac  = 1'000'000'000'000'000ll; // 1.0 = 10^15
+inline constexpr int64_t powerup_frac  = 1'000'000'000'000'000ll; // 1.0 = 10^15
 inline constexpr int64_t stake_weight = 100'000'000'0000ll; // 10^12
 
-struct rentbw_config_resource {
+struct powerup_config_resource {
    fc::optional<int64_t>        current_weight_ratio = {};
    fc::optional<int64_t>        target_weight_ratio  = {};
    fc::optional<int64_t>        assumed_stake_weight = {};
@@ -25,19 +25,19 @@ struct rentbw_config_resource {
    fc::optional<asset>          min_price            = {};
    fc::optional<asset>          max_price            = {};
 };
-FC_REFLECT(rentbw_config_resource,                                                             //
+FC_REFLECT(powerup_config_resource,                                                             //
            (current_weight_ratio)(target_weight_ratio)(assumed_stake_weight)(target_timestamp) //
            (exponent)(decay_secs)(min_price)(max_price))
 
-struct rentbw_config {
-   rentbw_config_resource net          = {};
-   rentbw_config_resource cpu          = {};
-   fc::optional<uint32_t> rent_days    = {};
-   fc::optional<asset>    min_rent_fee = {};
+struct powerup_config {
+   powerup_config_resource net          = {};
+   powerup_config_resource cpu          = {};
+   fc::optional<uint32_t> powerup_days    = {};
+   fc::optional<asset>    min_powerup_fee = {};
 };
-FC_REFLECT(rentbw_config, (net)(cpu)(rent_days)(min_rent_fee))
+FC_REFLECT(powerup_config, (net)(cpu)(powerup_days)(min_powerup_fee))
 
-struct rentbw_state_resource {
+struct powerup_state_resource {
    uint8_t        version;
    int64_t        weight;
    int64_t        weight_ratio;
@@ -54,25 +54,25 @@ struct rentbw_state_resource {
    int64_t        adjusted_utilization;
    time_point_sec utilization_timestamp;
 };
-FC_REFLECT(rentbw_state_resource,                                                                           //
+FC_REFLECT(powerup_state_resource,                                                                           //
            (version)(weight)(weight_ratio)(assumed_stake_weight)(initial_weight_ratio)(target_weight_ratio) //
            (initial_timestamp)(target_timestamp)(exponent)(decay_secs)(min_price)(max_price)(utilization)   //
            (adjusted_utilization)(utilization_timestamp))
 
-struct rentbw_state {
+struct powerup_state {
    uint8_t               version;
-   rentbw_state_resource net;
-   rentbw_state_resource cpu;
-   uint32_t              rent_days;
-   asset                 min_rent_fee;
+   powerup_state_resource net;
+   powerup_state_resource cpu;
+   uint32_t              powerup_days;
+   asset                 min_powerup_fee;
 };
-FC_REFLECT(rentbw_state, (version)(net)(cpu)(rent_days)(min_rent_fee))
+FC_REFLECT(powerup_state, (version)(net)(cpu)(powerup_days)(min_powerup_fee))
 
 using namespace eosio_system;
 
-struct rentbw_tester : eosio_system_tester {
+struct powerup_tester : eosio_system_tester {
 
-   rentbw_tester() { create_accounts_with_resources({ N(eosio.reserv) }); }
+   powerup_tester() { create_accounts_with_resources({ N(eosio.reserv) }); }
 
    void start_rex() {
       create_account_with_resources(N(rexholder111), config::system_account_name, core_sym::from_string("1.0000"),
@@ -92,11 +92,11 @@ struct rentbw_tester : eosio_system_tester {
    }
 
    template <typename F>
-   rentbw_config make_config(F f) {
-      rentbw_config config;
+   powerup_config make_config(F f) {
+      powerup_config config;
 
-      config.net.current_weight_ratio = rentbw_frac;
-      config.net.target_weight_ratio  = rentbw_frac / 100;
+      config.net.current_weight_ratio = powerup_frac;
+      config.net.target_weight_ratio  = powerup_frac / 100;
       config.net.assumed_stake_weight = stake_weight;
       config.net.target_timestamp     = control->head_block_time() + fc::days(100);
       config.net.exponent             = 2;
@@ -104,8 +104,8 @@ struct rentbw_tester : eosio_system_tester {
       config.net.min_price            = asset::from_string("0.0000 TST");
       config.net.max_price            = asset::from_string("1000000.0000 TST");
 
-      config.cpu.current_weight_ratio = rentbw_frac;
-      config.cpu.target_weight_ratio  = rentbw_frac / 100;
+      config.cpu.current_weight_ratio = powerup_frac;
+      config.cpu.target_weight_ratio  = powerup_frac / 100;
       config.cpu.assumed_stake_weight = stake_weight;
       config.cpu.target_timestamp     = control->head_block_time() + fc::days(100);
       config.cpu.exponent             = 2;
@@ -113,25 +113,25 @@ struct rentbw_tester : eosio_system_tester {
       config.cpu.min_price            = asset::from_string("0.0000 TST");
       config.cpu.max_price            = asset::from_string("1000000.0000 TST");
 
-      config.rent_days    = 30;
-      config.min_rent_fee = asset::from_string("1.0000 TST");
+      config.powerup_days    = 30;
+      config.min_powerup_fee = asset::from_string("1.0000 TST");
 
       f(config);
       return config;
    }
 
-   rentbw_config make_config() {
+   powerup_config make_config() {
       return make_config([](auto&) {});
    }
 
    template <typename F>
-   rentbw_config make_default_config(F f) {
-      rentbw_config config;
+   powerup_config make_default_config(F f) {
+      powerup_config config;
       f(config);
       return config;
    }
 
-   action_result configbw(const rentbw_config& config) {
+   action_result configbw(const powerup_config& config) {
       // Verbose solution needed to work around bug in abi_serializer that fails if optional values aren't explicitly
       // specified with a null value.
 
@@ -139,7 +139,7 @@ struct rentbw_tester : eosio_system_tester {
          return (!v ? fc::variant() : fc::variant(*v));
       };
 
-      auto resource_conf_vo = [&optional_to_variant](const rentbw_config_resource& c ) {
+      auto resource_conf_vo = [&optional_to_variant](const powerup_config_resource& c ) {
          return   mvo("current_weight_ratio", optional_to_variant(c.current_weight_ratio))
                      ("target_weight_ratio",  optional_to_variant(c.target_weight_ratio))
                      ("assumed_stake_weight", optional_to_variant(c.assumed_stake_weight))
@@ -153,31 +153,31 @@ struct rentbw_tester : eosio_system_tester {
 
       auto conf = mvo("net",          resource_conf_vo(config.net))
                      ("cpu",          resource_conf_vo(config.cpu))
-                     ("rent_days",    optional_to_variant(config.rent_days))
-                     ("min_rent_fee", optional_to_variant(config.min_rent_fee))
+                     ("powerup_days",    optional_to_variant(config.powerup_days))
+                     ("min_powerup_fee", optional_to_variant(config.min_powerup_fee))
       ;
 
       //idump((fc::json::to_pretty_string(conf)));
-      return push_action(config::system_account_name, N(configrentbw), mvo()("args", std::move(conf)));
+      return push_action(config::system_account_name, N(cfgpowerup), mvo()("args", std::move(conf)));
 
       // If abi_serializer worked correctly, the following is all that would be needed:
-      //return push_action(config::system_account_name, N(configrentbw), mvo()("args", config));
+      //return push_action(config::system_account_name, N(cfgpowerup), mvo()("args", config));
    }
 
-   action_result rentbwexec(name user, uint16_t max) {
-      return push_action(user, N(rentbwexec), mvo()("user", user)("max", max));
+   action_result powerupexec(name user, uint16_t max) {
+      return push_action(user, N(powerupexec), mvo()("user", user)("max", max));
    }
 
-   action_result rentbw(const name& payer, const name& receiver, uint32_t days, int64_t net_frac, int64_t cpu_frac,
+   action_result powerup(const name& payer, const name& receiver, uint32_t days, int64_t net_frac, int64_t cpu_frac,
                         const asset& max_payment) {
-      return push_action(payer, N(rentbw),
+      return push_action(payer, N(powerup),
                          mvo()("payer", payer)("receiver", receiver)("days", days)("net_frac", net_frac)(
                                "cpu_frac", cpu_frac)("max_payment", max_payment));
    }
 
-   rentbw_state get_state() {
-      vector<char> data = get_row_by_account(config::system_account_name, {}, N(rent.state), N(rent.state));
-      return fc::raw::unpack<rentbw_state>(data);
+   powerup_state get_state() {
+      vector<char> data = get_row_by_account(config::system_account_name, {}, N(powup.state), N(powup.state));
+      return fc::raw::unpack<powerup_state>(data);
    }
 
    struct account_info {
@@ -194,13 +194,13 @@ struct rentbw_tester : eosio_system_tester {
       return info;
    };
 
-   void check_rentbw(const name& payer, const name& receiver, uint32_t days, int64_t net_frac, int64_t cpu_frac,
+   void check_powerup(const name& payer, const name& receiver, uint32_t days, int64_t net_frac, int64_t cpu_frac,
                      const asset& expected_fee, int64_t expected_net, int64_t expected_cpu) {
       auto before_payer    = get_account_info(payer);
       auto before_receiver = get_account_info(receiver);
       auto before_reserve  = get_account_info(N(eosio.reserv));
       auto before_state    = get_state();
-      BOOST_REQUIRE_EQUAL("", rentbw(payer, receiver, days, net_frac, cpu_frac, expected_fee));
+      BOOST_REQUIRE_EQUAL("", powerup(payer, receiver, days, net_frac, cpu_frac, expected_fee));
       auto after_payer    = get_account_info(payer);
       auto after_receiver = get_account_info(receiver);
       auto after_reserve  = get_account_info(N(eosio.reserv));
@@ -209,7 +209,7 @@ struct rentbw_tester : eosio_system_tester {
       if (false) {
          ilog("before_state.net.assumed_stake_weight:    ${x}", ("x", before_state.net.assumed_stake_weight));
          ilog("before_state.net.weight_ratio:            ${x}",
-              ("x", before_state.net.weight_ratio / double(rentbw_frac)));
+              ("x", before_state.net.weight_ratio / double(powerup_frac)));
          ilog("before_state.net.assumed_stake_weight:    ${x}", ("x", before_state.net.assumed_stake_weight));
          ilog("before_state.net.weight:                  ${x}", ("x", before_state.net.weight));
 
@@ -252,35 +252,35 @@ bool near(A a, B b, D delta) {
    return false;
 }
 
-BOOST_AUTO_TEST_SUITE(eosio_system_rentbw_tests)
+BOOST_AUTO_TEST_SUITE(eosio_system_powerup_tests)
 
-BOOST_FIXTURE_TEST_CASE(config_tests, rentbw_tester) try {
+BOOST_FIXTURE_TEST_CASE(config_tests, powerup_tester) try {
    BOOST_REQUIRE_EQUAL("missing authority of eosio",
-                       push_action(N(alice1111111), N(configrentbw), mvo()("args", make_config())));
-   BOOST_REQUIRE_EQUAL(wasm_assert_msg("rentbw hasn't been initialized"), rentbwexec(N(alice1111111), 10));
+                       push_action(N(alice1111111), N(cfgpowerup), mvo()("args", make_config())));
+   BOOST_REQUIRE_EQUAL(wasm_assert_msg("powerup hasn't been initialized"), powerupexec(N(alice1111111), 10));
 
-   BOOST_REQUIRE_EQUAL(wasm_assert_msg("rent_days must be > 0"),
-                       configbw(make_config([&](auto& c) { c.rent_days = 0; })));
-   BOOST_REQUIRE_EQUAL(wasm_assert_msg("min_rent_fee doesn't match core symbol"), configbw(make_config([&](auto& c) {
-                          c.min_rent_fee = asset::from_string("1000000.000 TST");
+   BOOST_REQUIRE_EQUAL(wasm_assert_msg("powerup_days must be > 0"),
+                       configbw(make_config([&](auto& c) { c.powerup_days = 0; })));
+   BOOST_REQUIRE_EQUAL(wasm_assert_msg("min_powerup_fee doesn't match core symbol"), configbw(make_config([&](auto& c) {
+                          c.min_powerup_fee = asset::from_string("1000000.000 TST");
                        })));
-   BOOST_REQUIRE_EQUAL(wasm_assert_msg("min_rent_fee does not have a default value"),
-                       configbw(make_config([&](auto& c) { c.min_rent_fee = {}; })));
-   BOOST_REQUIRE_EQUAL(wasm_assert_msg("min_rent_fee must be positive"),
-                       configbw(make_config([&](auto& c) { c.min_rent_fee = asset::from_string("0.0000 TST"); })));
-   BOOST_REQUIRE_EQUAL(wasm_assert_msg("min_rent_fee must be positive"),
-                       configbw(make_config([&](auto& c) { c.min_rent_fee = asset::from_string("-1.0000 TST"); })));
+   BOOST_REQUIRE_EQUAL(wasm_assert_msg("min_powerup_fee does not have a default value"),
+                       configbw(make_config([&](auto& c) { c.min_powerup_fee = {}; })));
+   BOOST_REQUIRE_EQUAL(wasm_assert_msg("min_powerup_fee must be positive"),
+                       configbw(make_config([&](auto& c) { c.min_powerup_fee = asset::from_string("0.0000 TST"); })));
+   BOOST_REQUIRE_EQUAL(wasm_assert_msg("min_powerup_fee must be positive"),
+                       configbw(make_config([&](auto& c) { c.min_powerup_fee = asset::from_string("-1.0000 TST"); })));
 
    // net assertions
    BOOST_REQUIRE_EQUAL(wasm_assert_msg("current_weight_ratio is too large"),
-                       configbw(make_config([](auto& c) { c.net.current_weight_ratio = rentbw_frac + 1; })));
+                       configbw(make_config([](auto& c) { c.net.current_weight_ratio = powerup_frac + 1; })));
    BOOST_REQUIRE_EQUAL(wasm_assert_msg("assumed_stake_weight/target_weight_ratio is too large"),
                        configbw(make_config([](auto& c) {
                           c.net.assumed_stake_weight = 100000;
                           c.net.target_weight_ratio  = 10;
                        })));
    BOOST_REQUIRE_EQUAL(wasm_assert_msg("weight can't grow over time"),
-                       configbw(make_config([](auto& c) { c.net.target_weight_ratio = rentbw_frac + 1; })));
+                       configbw(make_config([](auto& c) { c.net.target_weight_ratio = powerup_frac + 1; })));
    BOOST_REQUIRE_EQUAL(wasm_assert_msg("assumed_stake_weight does not have a default value"),
                        configbw(make_config([](auto& c) { c.net.assumed_stake_weight = {}; })));
    BOOST_REQUIRE_EQUAL(wasm_assert_msg("assumed_stake_weight must be at least 1; a much larger value is recommended"),
@@ -318,14 +318,14 @@ BOOST_FIXTURE_TEST_CASE(config_tests, rentbw_tester) try {
 
    // cpu assertions
    BOOST_REQUIRE_EQUAL(wasm_assert_msg("current_weight_ratio is too large"),
-                       configbw(make_config([](auto& c) { c.cpu.current_weight_ratio = rentbw_frac + 1; })));
+                       configbw(make_config([](auto& c) { c.cpu.current_weight_ratio = powerup_frac + 1; })));
    BOOST_REQUIRE_EQUAL(wasm_assert_msg("assumed_stake_weight/target_weight_ratio is too large"),
                        configbw(make_config([](auto& c) {
                           c.cpu.assumed_stake_weight = 100000;
                           c.cpu.target_weight_ratio  = 10;
                        })));
    BOOST_REQUIRE_EQUAL(wasm_assert_msg("weight can't grow over time"),
-                       configbw(make_config([](auto& c) { c.cpu.target_weight_ratio = rentbw_frac + 1; })));
+                       configbw(make_config([](auto& c) { c.cpu.target_weight_ratio = powerup_frac + 1; })));
    BOOST_REQUIRE_EQUAL(wasm_assert_msg("assumed_stake_weight does not have a default value"),
                        configbw(make_config([](auto& c) { c.cpu.assumed_stake_weight = {}; })));
    BOOST_REQUIRE_EQUAL(wasm_assert_msg("assumed_stake_weight must be at least 1; a much larger value is recommended"),
@@ -363,15 +363,15 @@ BOOST_FIXTURE_TEST_CASE(config_tests, rentbw_tester) try {
 } // config_tests
 FC_LOG_AND_RETHROW()
 
-BOOST_FIXTURE_TEST_CASE(weight_tests, rentbw_tester) try {
+BOOST_FIXTURE_TEST_CASE(weight_tests, powerup_tester) try {
    produce_block();
 
-   auto net_start  = (rentbw_frac * 11) / 100;
-   auto net_target = (rentbw_frac * 1) / 100;
-   auto cpu_start  = (rentbw_frac * 11) / 1000;
-   auto cpu_target = (rentbw_frac * 1) / 1000;
+   auto net_start  = (powerup_frac * 11) / 100;
+   auto net_target = (powerup_frac * 1) / 100;
+   auto cpu_start  = (powerup_frac * 11) / 1000;
+   auto cpu_target = (powerup_frac * 1) / 1000;
 
-   BOOST_REQUIRE_EQUAL("", configbw(make_config([&](rentbw_config& config) {
+   BOOST_REQUIRE_EQUAL("", configbw(make_config([&](powerup_config& config) {
                           config.net.current_weight_ratio = net_start;
                           config.net.target_weight_ratio  = net_target;
                           config.net.assumed_stake_weight = stake_weight;
@@ -390,7 +390,7 @@ BOOST_FIXTURE_TEST_CASE(weight_tests, rentbw_tester) try {
       auto state = get_state();
       BOOST_REQUIRE(near(           //
             state.net.weight_ratio, //
-            int64_t(state.net.assumed_stake_weight * eosio::chain::int128_t(rentbw_frac) /
+            int64_t(state.net.assumed_stake_weight * eosio::chain::int128_t(powerup_frac) /
                     (state.net.weight + state.net.assumed_stake_weight)),
             10));
    };
@@ -402,7 +402,7 @@ BOOST_FIXTURE_TEST_CASE(weight_tests, rentbw_tester) try {
          BOOST_REQUIRE_EQUAL("", configbw({}));
       } else if (i) {
          produce_block(fc::days(1) - fc::milliseconds(500));
-         BOOST_REQUIRE_EQUAL("", rentbwexec(config::system_account_name, 10));
+         BOOST_REQUIRE_EQUAL("", powerupexec(config::system_account_name, 10));
       }
       net = net_start + i * (net_target - net_start) / 10;
       cpu = cpu_start + i * (cpu_target - cpu_start) / 20;
@@ -415,7 +415,7 @@ BOOST_FIXTURE_TEST_CASE(weight_tests, rentbw_tester) try {
    {
       int i = 7;
       produce_block(fc::days(1) - fc::milliseconds(500));
-      BOOST_REQUIRE_EQUAL("", configbw(make_default_config([&](rentbw_config& config) {
+      BOOST_REQUIRE_EQUAL("", configbw(make_default_config([&](powerup_config& config) {
                              config.net.target_timestamp = control->head_block_time() + fc::days(30);
                              config.cpu.target_timestamp = control->head_block_time() + fc::days(40);
                           })));
@@ -429,7 +429,7 @@ BOOST_FIXTURE_TEST_CASE(weight_tests, rentbw_tester) try {
    for (int i = 0; i <= 5; ++i) {
       if (i) {
          produce_block(fc::days(1) - fc::milliseconds(500));
-         BOOST_REQUIRE_EQUAL("", rentbwexec(config::system_account_name, 10));
+         BOOST_REQUIRE_EQUAL("", powerupexec(config::system_account_name, 10));
       }
       net = net_start + i * (net_target - net_start) / 30;
       cpu = cpu_start + i * (cpu_target - cpu_start) / 40;
@@ -444,7 +444,7 @@ BOOST_FIXTURE_TEST_CASE(weight_tests, rentbw_tester) try {
       produce_block(fc::days(1) - fc::milliseconds(500));
       auto new_net_target = net_target / 10;
       auto new_cpu_target = cpu_target / 20;
-      BOOST_REQUIRE_EQUAL("", configbw(make_default_config([&](rentbw_config& config) {
+      BOOST_REQUIRE_EQUAL("", configbw(make_default_config([&](powerup_config& config) {
                              config.net.target_weight_ratio = new_net_target;
                              config.cpu.target_weight_ratio = new_cpu_target;
                           })));
@@ -460,7 +460,7 @@ BOOST_FIXTURE_TEST_CASE(weight_tests, rentbw_tester) try {
    for (int i = 0; i <= 10; ++i) {
       if (i) {
          produce_block(fc::days(1) - fc::milliseconds(500));
-         BOOST_REQUIRE_EQUAL("", rentbwexec(config::system_account_name, 10));
+         BOOST_REQUIRE_EQUAL("", powerupexec(config::system_account_name, 10));
       }
       net = net_start + i * (net_target - net_start) / (30 - 6);
       cpu = cpu_start + i * (cpu_target - cpu_start) / (40 - 6);
@@ -472,7 +472,7 @@ BOOST_FIXTURE_TEST_CASE(weight_tests, rentbw_tester) try {
    // Move transition time to immediate future
    {
       produce_block(fc::days(1) - fc::milliseconds(500));
-      BOOST_REQUIRE_EQUAL("", configbw(make_default_config([&](rentbw_config& config) {
+      BOOST_REQUIRE_EQUAL("", configbw(make_default_config([&](powerup_config& config) {
                              config.net.target_timestamp = control->head_block_time() + fc::milliseconds(1000);
                              config.cpu.target_timestamp = control->head_block_time() + fc::milliseconds(1000);
                           })));
@@ -481,7 +481,7 @@ BOOST_FIXTURE_TEST_CASE(weight_tests, rentbw_tester) try {
 
    // Verify targets hold as time advances
    for (int i = 0; i <= 10; ++i) {
-      BOOST_REQUIRE_EQUAL("", rentbwexec(config::system_account_name, 10));
+      BOOST_REQUIRE_EQUAL("", powerupexec(config::system_account_name, 10));
       BOOST_REQUIRE(near(get_state().net.weight_ratio, net_target, 1));
       BOOST_REQUIRE(near(get_state().cpu.weight_ratio, cpu_target, 1));
       check_weight();
@@ -492,50 +492,50 @@ FC_LOG_AND_RETHROW()
 
 BOOST_AUTO_TEST_CASE(rent_tests) try {
    {
-      rentbw_tester t;
+      powerup_tester t;
       t.produce_block();
 
-      BOOST_REQUIRE_EQUAL(t.wasm_assert_msg("rentbw hasn't been initialized"), //
-                          t.rentbw(N(bob111111111), N(alice1111111), 30, rentbw_frac / 4, rentbw_frac / 8,
+      BOOST_REQUIRE_EQUAL(t.wasm_assert_msg("powerup hasn't been initialized"), //
+                          t.powerup(N(bob111111111), N(alice1111111), 30, powerup_frac / 4, powerup_frac / 8,
                                    asset::from_string("1.000 TST")));
 
       BOOST_REQUIRE_EQUAL("", t.configbw(t.make_config([&](auto& config) {
-         config.net.current_weight_ratio = rentbw_frac;
-         config.net.target_weight_ratio  = rentbw_frac;
+         config.net.current_weight_ratio = powerup_frac;
+         config.net.target_weight_ratio  = powerup_frac;
          config.net.assumed_stake_weight = stake_weight;
          config.net.exponent             = 1;
          config.net.min_price            = asset::from_string("1000000.0000 TST");
          config.net.max_price            = asset::from_string("1000000.0000 TST");
 
-         config.cpu.current_weight_ratio = rentbw_frac;
-         config.cpu.target_weight_ratio  = rentbw_frac;
+         config.cpu.current_weight_ratio = powerup_frac;
+         config.cpu.target_weight_ratio  = powerup_frac;
          config.cpu.assumed_stake_weight = stake_weight;
          config.cpu.exponent             = 1;
          config.cpu.min_price            = asset::from_string("1000000.0000 TST");
          config.cpu.max_price            = asset::from_string("1000000.0000 TST");
 
-         config.rent_days    = 30;
-         config.min_rent_fee = asset::from_string("1.0000 TST");
+         config.powerup_days    = 30;
+         config.min_powerup_fee = asset::from_string("1.0000 TST");
       })));
 
       BOOST_REQUIRE_EQUAL(
             t.wasm_assert_msg("max_payment doesn't match core symbol"), //
-            t.rentbw(N(bob111111111), N(alice1111111), 30, rentbw_frac, rentbw_frac, asset::from_string("1.000 TST")));
+            t.powerup(N(bob111111111), N(alice1111111), 30, powerup_frac, powerup_frac, asset::from_string("1.000 TST")));
       BOOST_REQUIRE_EQUAL(
             t.wasm_assert_msg("market doesn't have resources available"), //
-            t.rentbw(N(bob111111111), N(alice1111111), 30, 0, rentbw_frac, asset::from_string("1.0000 TST")));
+            t.powerup(N(bob111111111), N(alice1111111), 30, 0, powerup_frac, asset::from_string("1.0000 TST")));
       BOOST_REQUIRE_EQUAL(
             t.wasm_assert_msg("market doesn't have resources available"), //
-            t.rentbw(N(bob111111111), N(alice1111111), 30, rentbw_frac, 0, asset::from_string("1.0000 TST")));
+            t.powerup(N(bob111111111), N(alice1111111), 30, powerup_frac, 0, asset::from_string("1.0000 TST")));
 
       BOOST_REQUIRE_EQUAL("", t.configbw(t.make_default_config([&](auto& config) {
          // weight = stake_weight
-         config.net.current_weight_ratio = rentbw_frac/2;
-         config.net.target_weight_ratio  = rentbw_frac/2;
+         config.net.current_weight_ratio = powerup_frac/2;
+         config.net.target_weight_ratio  = powerup_frac/2;
 
          // weight = stake_weight
-         config.cpu.current_weight_ratio = rentbw_frac/2;
-         config.cpu.target_weight_ratio  = rentbw_frac/2;
+         config.cpu.current_weight_ratio = powerup_frac/2;
+         config.cpu.target_weight_ratio  = powerup_frac/2;
       })));
 
       auto net_weight = stake_weight;
@@ -550,18 +550,18 @@ BOOST_AUTO_TEST_CASE(rent_tests) try {
       // (.2) * 1000000.0000 = 200000.0000
       //               total = 300000.0000
       t.transfer(config::system_account_name, N(aaaaaaaaaaaa), core_sym::from_string("300000.0000"));
-      t.check_rentbw(N(aaaaaaaaaaaa), N(aaaaaaaaaaaa), 30, rentbw_frac * .1, rentbw_frac * .2,
+      t.check_powerup(N(aaaaaaaaaaaa), N(aaaaaaaaaaaa), 30, powerup_frac * .1, powerup_frac * .2,
                      asset::from_string("300000.0000 TST"), net_weight * .1, cpu_weight * .2);
 
       // Start decay
       t.produce_block(fc::days(30) - fc::milliseconds(500));
-      BOOST_REQUIRE_EQUAL("", t.rentbwexec(config::system_account_name, 10));
+      BOOST_REQUIRE_EQUAL("", t.powerupexec(config::system_account_name, 10));
       BOOST_REQUIRE(near(t.get_state().net.adjusted_utilization, .1 * net_weight, 0));
       BOOST_REQUIRE(near(t.get_state().cpu.adjusted_utilization, .2 * cpu_weight, 0));
 
       // 2 days of decay from (10%, 20%) to (1.35%, 2.71%)
       t.produce_block(fc::days(2) - fc::milliseconds(500));
-      BOOST_REQUIRE_EQUAL("", t.rentbwexec(config::system_account_name, 10));
+      BOOST_REQUIRE_EQUAL("", t.powerupexec(config::system_account_name, 10));
       BOOST_REQUIRE(near(t.get_state().net.adjusted_utilization, int64_t(.1 * net_weight * exp(-2)),
                          int64_t(.1 * net_weight * exp(-2)) / 1000));
       BOOST_REQUIRE(near(t.get_state().cpu.adjusted_utilization, int64_t(.2 * cpu_weight * exp(-2)),
@@ -572,7 +572,7 @@ BOOST_AUTO_TEST_CASE(rent_tests) try {
       // (.02) * 1000000.0000                    = 20000.0000
       //                                   total = 40000.0000
       t.transfer(config::system_account_name, N(aaaaaaaaaaaa), core_sym::from_string("40000.0001"));
-      t.check_rentbw(N(aaaaaaaaaaaa), N(aaaaaaaaaaaa), 30, rentbw_frac * .02, rentbw_frac * .02,
+      t.check_powerup(N(aaaaaaaaaaaa), N(aaaaaaaaaaaa), 30, powerup_frac * .02, powerup_frac * .02,
                      asset::from_string("40000.0001 TST"), net_weight * .02, cpu_weight * .02);
    }
 
@@ -580,21 +580,21 @@ BOOST_AUTO_TEST_CASE(rent_tests) try {
       t.produce_block();
       BOOST_REQUIRE_EQUAL("", t.configbw(t.make_config([&](auto& config) {
          // weight = stake_weight * 3
-         config.net.current_weight_ratio = rentbw_frac / 4;
-         config.net.target_weight_ratio  = rentbw_frac / 4;
+         config.net.current_weight_ratio = powerup_frac / 4;
+         config.net.target_weight_ratio  = powerup_frac / 4;
          config.net.assumed_stake_weight = stake_weight;
          config.net.exponent             = 2;
          config.net.max_price            = asset::from_string("2000000.0000 TST");
 
          // weight = stake_weight * 4 / 2
-         config.cpu.current_weight_ratio = rentbw_frac / 5;
-         config.cpu.target_weight_ratio  = rentbw_frac / 5;
+         config.cpu.current_weight_ratio = powerup_frac / 5;
+         config.cpu.target_weight_ratio  = powerup_frac / 5;
          config.cpu.assumed_stake_weight = stake_weight / 2;
          config.cpu.exponent             = 3;
          config.cpu.max_price            = asset::from_string("6000000.0000 TST");
 
-         config.rent_days    = 30;
-         config.min_rent_fee = asset::from_string("1.0000 TST");
+         config.powerup_days    = 30;
+         config.min_powerup_fee = asset::from_string("1.0000 TST");
       })));
 
       if (rex)
@@ -609,94 +609,94 @@ BOOST_AUTO_TEST_CASE(rent_tests) try {
    auto cpu_weight = stake_weight * 4 / 2;
 
    {
-      rentbw_tester t;
+      powerup_tester t;
       init(t, false);
       BOOST_REQUIRE_EQUAL(
             t.wasm_assert_msg("days doesn't match configuration"), //
-            t.rentbw(N(bob111111111), N(alice1111111), 20, rentbw_frac, rentbw_frac, asset::from_string("1.0000 TST")));
+            t.powerup(N(bob111111111), N(alice1111111), 20, powerup_frac, powerup_frac, asset::from_string("1.0000 TST")));
       BOOST_REQUIRE_EQUAL(                                   //
             t.wasm_assert_msg("net_frac can't be negative"), //
-            t.rentbw(N(bob111111111), N(alice1111111), 30, -rentbw_frac, rentbw_frac,
+            t.powerup(N(bob111111111), N(alice1111111), 30, -powerup_frac, powerup_frac,
                      asset::from_string("1.0000 TST")));
       BOOST_REQUIRE_EQUAL(                                   //
             t.wasm_assert_msg("cpu_frac can't be negative"), //
-            t.rentbw(N(bob111111111), N(alice1111111), 30, rentbw_frac, -rentbw_frac,
+            t.powerup(N(bob111111111), N(alice1111111), 30, powerup_frac, -powerup_frac,
                      asset::from_string("1.0000 TST")));
       BOOST_REQUIRE_EQUAL(                                    //
             t.wasm_assert_msg("net can't be more than 100%"), //
-            t.rentbw(N(bob111111111), N(alice1111111), 30, rentbw_frac + 1, rentbw_frac,
+            t.powerup(N(bob111111111), N(alice1111111), 30, powerup_frac + 1, powerup_frac,
                      asset::from_string("1.0000 TST")));
       BOOST_REQUIRE_EQUAL(                                    //
             t.wasm_assert_msg("cpu can't be more than 100%"), //
-            t.rentbw(N(bob111111111), N(alice1111111), 30, rentbw_frac, rentbw_frac + 1,
+            t.powerup(N(bob111111111), N(alice1111111), 30, powerup_frac, powerup_frac + 1,
                      asset::from_string("1.0000 TST")));
       BOOST_REQUIRE_EQUAL(
             t.wasm_assert_msg("max_payment is less than calculated fee: 3000000.0000 TST"), //
-            t.rentbw(N(bob111111111), N(alice1111111), 30, rentbw_frac, rentbw_frac, asset::from_string("1.0000 TST")));
+            t.powerup(N(bob111111111), N(alice1111111), 30, powerup_frac, powerup_frac, asset::from_string("1.0000 TST")));
       BOOST_REQUIRE_EQUAL(t.wasm_assert_msg("can't channel fees to rex"), //
-                          t.rentbw(N(bob111111111), N(alice1111111), 30, rentbw_frac, rentbw_frac,
+                          t.powerup(N(bob111111111), N(alice1111111), 30, powerup_frac, powerup_frac,
                                    asset::from_string("3000000.0000 TST")));
    }
 
    // net:100%, cpu:100%
    {
-      rentbw_tester t;
+      powerup_tester t;
       init(t, true);
       t.transfer(config::system_account_name, N(aaaaaaaaaaaa), core_sym::from_string("3000000.0000"));
       BOOST_REQUIRE_EQUAL(
             t.wasm_assert_msg("calculated fee is below minimum; try renting more"),
-            t.rentbw(N(aaaaaaaaaaaa), N(bbbbbbbbbbbb), 30, 10, 10, asset::from_string("3000000.0000 TST")));
-      t.check_rentbw(N(aaaaaaaaaaaa), N(bbbbbbbbbbbb), 30, rentbw_frac, rentbw_frac,
+            t.powerup(N(aaaaaaaaaaaa), N(bbbbbbbbbbbb), 30, 10, 10, asset::from_string("3000000.0000 TST")));
+      t.check_powerup(N(aaaaaaaaaaaa), N(bbbbbbbbbbbb), 30, powerup_frac, powerup_frac,
                      asset::from_string("3000000.0000 TST"), net_weight, cpu_weight);
 
       BOOST_REQUIRE_EQUAL( //
             t.wasm_assert_msg("weight can't shrink below utilization"),
             t.configbw(t.make_default_config([&](auto& config) {
-               config.net.current_weight_ratio = rentbw_frac / 4 + 1;
-               config.net.target_weight_ratio  = rentbw_frac / 4 + 1;
-               config.cpu.current_weight_ratio = rentbw_frac / 5;
-               config.cpu.target_weight_ratio  = rentbw_frac / 5;
+               config.net.current_weight_ratio = powerup_frac / 4 + 1;
+               config.net.target_weight_ratio  = powerup_frac / 4 + 1;
+               config.cpu.current_weight_ratio = powerup_frac / 5;
+               config.cpu.target_weight_ratio  = powerup_frac / 5;
             })));
       BOOST_REQUIRE_EQUAL( //
             t.wasm_assert_msg("weight can't shrink below utilization"),
             t.configbw(t.make_default_config([&](auto& config) {
-               config.net.current_weight_ratio = rentbw_frac / 4;
-               config.net.target_weight_ratio  = rentbw_frac / 4;
-               config.cpu.current_weight_ratio = rentbw_frac / 5 + 1;
-               config.cpu.target_weight_ratio  = rentbw_frac / 5 + 1;
+               config.net.current_weight_ratio = powerup_frac / 4;
+               config.net.target_weight_ratio  = powerup_frac / 4;
+               config.cpu.current_weight_ratio = powerup_frac / 5 + 1;
+               config.cpu.target_weight_ratio  = powerup_frac / 5 + 1;
             })));
       BOOST_REQUIRE_EQUAL( //
             "",            //
             t.configbw(t.make_default_config([&](auto& config) {
-               config.net.current_weight_ratio = rentbw_frac / 4;
-               config.net.target_weight_ratio  = rentbw_frac / 4;
-               config.cpu.current_weight_ratio = rentbw_frac / 5;
-               config.cpu.target_weight_ratio  = rentbw_frac / 5;
+               config.net.current_weight_ratio = powerup_frac / 4;
+               config.net.target_weight_ratio  = powerup_frac / 4;
+               config.cpu.current_weight_ratio = powerup_frac / 5;
+               config.cpu.target_weight_ratio  = powerup_frac / 5;
             })));
    }
 
    // net:30%, cpu:40%, then net:5%, cpu:10%
    {
-      rentbw_tester t;
+      powerup_tester t;
       init(t, true);
       // (.3 ^ 2) * 2000000.0000 / 2 =  90000.0000
       // (.4 ^ 3) * 6000000.0000 / 3 = 128000.0000
       //                       total = 218000.0000
       t.transfer(config::system_account_name, N(aaaaaaaaaaaa), core_sym::from_string("218000.0001"));
-      t.check_rentbw(N(aaaaaaaaaaaa), N(bbbbbbbbbbbb), 30, rentbw_frac * .3, rentbw_frac * .4,
+      t.check_powerup(N(aaaaaaaaaaaa), N(bbbbbbbbbbbb), 30, powerup_frac * .3, powerup_frac * .4,
                      asset::from_string("218000.0001 TST"), net_weight * .3, cpu_weight * .4);
 
       // (.35 ^ 2) * 2000000.0000 / 2 -  90000.0000 =  32500.0000
       // (.5  ^ 3) * 6000000.0000 / 3 - 128000.0000 = 122000.0000
       //                                      total = 154500.0000
       t.transfer(config::system_account_name, N(aaaaaaaaaaaa), core_sym::from_string("154500.0000"));
-      t.check_rentbw(N(aaaaaaaaaaaa), N(bbbbbbbbbbbb), 30, rentbw_frac * .05, rentbw_frac * .10,
+      t.check_powerup(N(aaaaaaaaaaaa), N(bbbbbbbbbbbb), 30, powerup_frac * .05, powerup_frac * .10,
                      asset::from_string("154500.0000 TST"), net_weight * .05, cpu_weight * .10);
    }
 
    // net:50%, cpu:50% (but with non-zero min_price and also an exponent of 2 to simplify the math)
    {
-      rentbw_tester t;
+      powerup_tester t;
       init(t, true);
       BOOST_REQUIRE_EQUAL("", t.configbw(t.make_default_config([&](auto& config) {
          config.cpu.exponent             = 2;
@@ -726,29 +726,29 @@ BOOST_AUTO_TEST_CASE(rent_tests) try {
       // 4000000.0000 * .5 + (2000000.0000 / 2) * (.5 ^ 2) = 2250000.0000
       //                                             total = 2950000.0000
       t.transfer(config::system_account_name, N(aaaaaaaaaaaa), core_sym::from_string("2950000.0000"));
-      t.check_rentbw(N(aaaaaaaaaaaa), N(bbbbbbbbbbbb), 30, rentbw_frac * .5, rentbw_frac * .5,
+      t.check_powerup(N(aaaaaaaaaaaa), N(bbbbbbbbbbbb), 30, powerup_frac * .5, powerup_frac * .5,
                      asset::from_string("2950000.0000 TST"), net_weight * .5, cpu_weight * .5);
    }
 
    {
       // net:100%, cpu:100%
-      rentbw_tester t;
+      powerup_tester t;
       init(t, true);
       t.transfer(config::system_account_name, N(aaaaaaaaaaaa), core_sym::from_string("3000000.0000"));
-      t.check_rentbw(N(aaaaaaaaaaaa), N(bbbbbbbbbbbb), 30, rentbw_frac, rentbw_frac,
+      t.check_powerup(N(aaaaaaaaaaaa), N(bbbbbbbbbbbb), 30, powerup_frac, powerup_frac,
                      asset::from_string("3000000.0000 TST"), net_weight, cpu_weight);
 
       // No more available for 30 days
       BOOST_REQUIRE_EQUAL(t.wasm_assert_msg("market doesn't have enough resources available"), //
-                          t.rentbw(N(bob111111111), N(alice1111111), 30, rentbw_frac / 1000, rentbw_frac / 1000,
+                          t.powerup(N(bob111111111), N(alice1111111), 30, powerup_frac / 1000, powerup_frac / 1000,
                                    asset::from_string("1.0000 TST")));
       t.produce_block(fc::days(29));
       BOOST_REQUIRE_EQUAL(t.wasm_assert_msg("market doesn't have enough resources available"), //
-                          t.rentbw(N(bob111111111), N(alice1111111), 30, rentbw_frac / 1000, rentbw_frac / 1000,
+                          t.powerup(N(bob111111111), N(alice1111111), 30, powerup_frac / 1000, powerup_frac / 1000,
                                    asset::from_string("1.0000 TST")));
       t.produce_block(fc::days(1) - fc::milliseconds(1500));
       BOOST_REQUIRE_EQUAL(t.wasm_assert_msg("market doesn't have enough resources available"), //
-                          t.rentbw(N(bob111111111), N(alice1111111), 30, rentbw_frac / 1000, rentbw_frac / 1000,
+                          t.powerup(N(bob111111111), N(alice1111111), 30, powerup_frac / 1000, powerup_frac / 1000,
                                    asset::from_string("1.0000 TST")));
       t.produce_block(fc::milliseconds(500));
 
@@ -758,32 +758,32 @@ BOOST_AUTO_TEST_CASE(rent_tests) try {
       // (1.0 ^ 2) * 6000000.0000 = 6000000.0000
       //                    total = 8000000.0000
       t.transfer(config::system_account_name, N(aaaaaaaaaaaa), core_sym::from_string("8000000.0000"));
-      t.check_rentbw(N(aaaaaaaaaaaa), N(bbbbbbbbbbbb), 30, rentbw_frac, rentbw_frac,
+      t.check_powerup(N(aaaaaaaaaaaa), N(bbbbbbbbbbbb), 30, powerup_frac, powerup_frac,
                      asset::from_string("8000000.0000 TST"), 0, 0);
 
       // No more available for 30 days
       BOOST_REQUIRE_EQUAL(t.wasm_assert_msg("market doesn't have enough resources available"), //
-                          t.rentbw(N(bob111111111), N(alice1111111), 30, rentbw_frac / 1000, rentbw_frac / 1000,
+                          t.powerup(N(bob111111111), N(alice1111111), 30, powerup_frac / 1000, powerup_frac / 1000,
                                    asset::from_string("1.0000 TST")));
       t.produce_block(fc::days(29));
       BOOST_REQUIRE_EQUAL(t.wasm_assert_msg("market doesn't have enough resources available"), //
-                          t.rentbw(N(bob111111111), N(alice1111111), 30, rentbw_frac / 1000, rentbw_frac / 1000,
+                          t.powerup(N(bob111111111), N(alice1111111), 30, powerup_frac / 1000, powerup_frac / 1000,
                                    asset::from_string("1.0000 TST")));
       t.produce_block(fc::days(1) - fc::milliseconds(1000));
       BOOST_REQUIRE_EQUAL(t.wasm_assert_msg("market doesn't have enough resources available"), //
-                          t.rentbw(N(bob111111111), N(alice1111111), 30, rentbw_frac / 1000, rentbw_frac / 1000,
+                          t.powerup(N(bob111111111), N(alice1111111), 30, powerup_frac / 1000, powerup_frac / 1000,
                                    asset::from_string("1.0000 TST")));
 
       // Start decay
       t.produce_block(fc::milliseconds(1000));
-      BOOST_REQUIRE_EQUAL("", t.rentbwexec(config::system_account_name, 10));
-      BOOST_REQUIRE_EQUAL("", t.rentbwexec(config::system_account_name, 10));
+      BOOST_REQUIRE_EQUAL("", t.powerupexec(config::system_account_name, 10));
+      BOOST_REQUIRE_EQUAL("", t.powerupexec(config::system_account_name, 10));
       BOOST_REQUIRE(near(t.get_state().net.adjusted_utilization, net_weight, net_weight / 1000));
       BOOST_REQUIRE(near(t.get_state().cpu.adjusted_utilization, cpu_weight, cpu_weight / 1000));
 
       // 1 day of decay
       t.produce_block(fc::days(1) - fc::milliseconds(500));
-      BOOST_REQUIRE_EQUAL("", t.rentbwexec(config::system_account_name, 10));
+      BOOST_REQUIRE_EQUAL("", t.powerupexec(config::system_account_name, 10));
       BOOST_REQUIRE(near(t.get_state().net.adjusted_utilization, int64_t(net_weight * exp(-1)),
                          int64_t(net_weight * exp(-1)) / 1000));
       BOOST_REQUIRE(near(t.get_state().cpu.adjusted_utilization, int64_t(cpu_weight * exp(-1)),
@@ -791,7 +791,7 @@ BOOST_AUTO_TEST_CASE(rent_tests) try {
 
       // 1 day of decay
       t.produce_block(fc::days(1) - fc::milliseconds(500));
-      BOOST_REQUIRE_EQUAL("", t.rentbwexec(config::system_account_name, 10));
+      BOOST_REQUIRE_EQUAL("", t.powerupexec(config::system_account_name, 10));
       BOOST_REQUIRE(near(t.get_state().net.adjusted_utilization, int64_t(net_weight * exp(-2)),
                          int64_t(net_weight * exp(-2)) / 1000));
       BOOST_REQUIRE(near(t.get_state().cpu.adjusted_utilization, int64_t(cpu_weight * exp(-2)),
@@ -803,12 +803,12 @@ BOOST_AUTO_TEST_CASE(rent_tests) try {
       // [ ((e^-2) ^ 2)*(e^-2 - 0.0) + ((1.0) ^ 3)/3 - ((e^-2) ^ 3)/3 ] * 6000000.0000 = 2009915.0087
       //                                                                         total = 3028230.6476
       t.transfer(config::system_account_name, N(aaaaaaaaaaaa), core_sym::from_string("3028229.8795"));
-      t.check_rentbw(N(aaaaaaaaaaaa), N(bbbbbbbbbbbb), 30, rentbw_frac, rentbw_frac,
+      t.check_powerup(N(aaaaaaaaaaaa), N(bbbbbbbbbbbb), 30, powerup_frac, powerup_frac,
                      asset::from_string("3028229.8795 TST"), net_weight, cpu_weight);
    }
 
    {
-      rentbw_tester t;
+      powerup_tester t;
       init(t, true);
 
       // 10%, 20%
@@ -816,7 +816,7 @@ BOOST_AUTO_TEST_CASE(rent_tests) try {
       // (.2 ^ 3) * 6000000.0000 / 3 = 16000.0000
       //                       total = 26000.0000
       t.transfer(config::system_account_name, N(aaaaaaaaaaaa), core_sym::from_string("26000.0002"));
-      t.check_rentbw(N(aaaaaaaaaaaa), N(bbbbbbbbbbbb), 30, rentbw_frac * .1, rentbw_frac * .2,
+      t.check_powerup(N(aaaaaaaaaaaa), N(bbbbbbbbbbbb), 30, powerup_frac * .1, powerup_frac * .2,
                      asset::from_string("26000.0002 TST"), net_weight * .1, cpu_weight * .2);
 
       t.produce_block(fc::days(15) - fc::milliseconds(500));
@@ -826,18 +826,18 @@ BOOST_AUTO_TEST_CASE(rent_tests) try {
       // (.4 ^ 3) * 6000000.0000 / 3 - 16000.0000 = 112000.0000
       //                                    total = 192000.0000
       t.transfer(config::system_account_name, N(aaaaaaaaaaaa), core_sym::from_string("192000.0001"));
-      t.check_rentbw(N(aaaaaaaaaaaa), N(bbbbbbbbbbbb), 30, rentbw_frac * .2, rentbw_frac * .2,
+      t.check_powerup(N(aaaaaaaaaaaa), N(bbbbbbbbbbbb), 30, powerup_frac * .2, powerup_frac * .2,
                      asset::from_string("192000.0001 TST"), net_weight * .2, cpu_weight * .2);
 
       // Start decay
       t.produce_block(fc::days(15) - fc::milliseconds(1000));
-      BOOST_REQUIRE_EQUAL("", t.rentbwexec(config::system_account_name, 10));
+      BOOST_REQUIRE_EQUAL("", t.powerupexec(config::system_account_name, 10));
       BOOST_REQUIRE(near(t.get_state().net.adjusted_utilization, .3 * net_weight, 0));
       BOOST_REQUIRE(near(t.get_state().cpu.adjusted_utilization, .4 * cpu_weight, 0));
 
       // 1 day of decay from (30%, 40%) to (20%, 20%)
       t.produce_block(fc::days(1) - fc::milliseconds(500));
-      BOOST_REQUIRE_EQUAL("", t.rentbwexec(config::system_account_name, 10));
+      BOOST_REQUIRE_EQUAL("", t.powerupexec(config::system_account_name, 10));
       BOOST_REQUIRE(
             near(t.get_state().net.adjusted_utilization, int64_t(.1 * net_weight * exp(-1) + .2 * net_weight), 0));
       BOOST_REQUIRE(
@@ -845,7 +845,7 @@ BOOST_AUTO_TEST_CASE(rent_tests) try {
 
       // 2 days of decay from (30%, 40%) to (20%, 20%)
       t.produce_block(fc::days(1) - fc::milliseconds(500));
-      BOOST_REQUIRE_EQUAL("", t.rentbwexec(config::system_account_name, 10));
+      BOOST_REQUIRE_EQUAL("", t.powerupexec(config::system_account_name, 10));
       BOOST_REQUIRE(
             near(t.get_state().net.adjusted_utilization, int64_t(.1 * net_weight * exp(-2) + .2 * net_weight), 0));
       BOOST_REQUIRE(

--- a/tests/eosio.powerup_tests.cpp
+++ b/tests/eosio.powerup_tests.cpp
@@ -644,7 +644,7 @@ BOOST_AUTO_TEST_CASE(rent_tests) try {
       init(t, true);
       t.transfer(config::system_account_name, N(aaaaaaaaaaaa), core_sym::from_string("3000000.0000"));
       BOOST_REQUIRE_EQUAL(
-            t.wasm_assert_msg("calculated fee is below minimum; try renting more"),
+            t.wasm_assert_msg("calculated fee is below minimum; try powering up with more resources"),
             t.powerup(N(aaaaaaaaaaaa), N(bbbbbbbbbbbb), 30, 10, 10, asset::from_string("3000000.0000 TST")));
       t.check_powerup(N(aaaaaaaaaaaa), N(bbbbbbbbbbbb), 30, powerup_frac, powerup_frac,
                      asset::from_string("3000000.0000 TST"), net_weight, cpu_weight);


### PR DESCRIPTION
<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->

## Change Description
<!-- Describe your changes, their justification, AND their impact. Reference issues or pull requests where possible (use '#XX' or 'GH-XX' where XX is the issue or pull request number). -->
This is a renaming of `rentbw` to `powerup` per the request of the PBE team. These changes are mostly cosmetic renaming of tables and actions. There is also a commit of a new configuration and usage guide.

## Deployment Changes
- [ X] Deployment Changes
<!-- checked [x] = Deployment changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces a change to the contracts that causes deployment to change, please describe the impact. -->
This adds an abi that would need to be deployed to eosio.reserv for a no-op action to notify the account of the NET and CPU weight reserved by the account and the associated fee

## API Changes
- [ ] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions
- [ X] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
There was the addition of a configuration and usage guide docs/04_guides/08_configure-use-powerup-resource-model.md