### PR TITLE
Update eosio.token.hpp

### DIFF
--- a/contracts/eosio.token/include/eosio.token/eosio.token.hpp
+++ b/contracts/eosio.token/include/eosio.token/eosio.token.hpp
@@ -34,7 +34,7 @@ namespace eosio {
           *
           * @pre Token symbol has to be valid,
           * @pre Token symbol must not be already created,
-          * @pre maximum_supply has to be smaller than the maximum supply allowed by the system: 1^62 - 1.
+          * @pre maximum_supply has to be smaller than the maximum supply allowed by the system: 2^62 - 1 (uint64_t cast into int64_t).
           * @pre Maximum supply must be positive;
           */
          [[eosio::action]]


### PR DESCRIPTION
## Change Description
Typo in documentation. `maximum_supply` is uint64_t cast into `asset` which is int64_t, thus 2^62 - 1. Documentation said 1^62 - 1.


## Deployment Changes
- [ ] Deployment Changes
<!-- checked [x] = Deployment changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces a change to the contracts that causes deployment to change, please describe the impact. -->


## API Changes
- [ ] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions
- [x] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
