### PR TITLE
Remove definitions and functions that have moved to later versions of…

### DIFF
--- a/contracts/eosio.bios/include/eosio.bios/eosio.bios.hpp
+++ b/contracts/eosio.bios/include/eosio.bios/eosio.bios.hpp
@@ -6,37 +6,8 @@
 #include <eosio/fixed_bytes.hpp>
 #include <eosio/privileged.hpp>
 #include <eosio/producer_schedule.hpp>
+#include <eosio/system.hpp>
 
-// This header is needed until `is_feature_activiated` and `preactivate_feature` are added to `eosio.cdt`
-#include <eosio/../../capi/eosio/crypto.h>
-
-namespace eosio {
-   namespace internal_use_do_not_use {
-      extern "C" {
-         __attribute__((eosio_wasm_import))
-         bool is_feature_activated( const ::capi_checksum256* feature_digest );
-
-         __attribute__((eosio_wasm_import))
-         void preactivate_feature( const ::capi_checksum256* feature_digest );
-      }
-   }
-}
-
-namespace eosio {
-   bool is_feature_activated( const eosio::checksum256& feature_digest ) {
-      auto feature_digest_data = feature_digest.extract_as_byte_array();
-      return internal_use_do_not_use::is_feature_activated(
-         reinterpret_cast<const ::capi_checksum256*>( feature_digest_data.data() )
-      );
-   }
-
-   void preactivate_feature( const eosio::checksum256& feature_digest ) {
-      auto feature_digest_data = feature_digest.extract_as_byte_array();
-      internal_use_do_not_use::preactivate_feature(
-         reinterpret_cast<const ::capi_checksum256*>( feature_digest_data.data() )
-      );
-   }
-}
 
 namespace eosio {
 
@@ -50,14 +21,6 @@ namespace eosio {
 
       // explicit serialization macro is not necessary, used here only to improve compilation time
       EOSLIB_SERIALIZE( permission_level_weight, (permission)(weight) )
-   };
-
-   struct key_weight {
-      eosio::public_key  key;
-      uint16_t           weight;
-
-      // explicit serialization macro is not necessary, used here only to improve compilation time
-      EOSLIB_SERIALIZE( key_weight, (key)(weight) )
    };
 
    struct wait_weight {

--- a/contracts/eosio.system/include/eosio.system/native.hpp
+++ b/contracts/eosio.system/include/eosio.system/native.hpp
@@ -9,23 +9,6 @@
 #include <eosio/privileged.hpp>
 #include <eosio/producer_schedule.hpp>
 
-// This header is needed until `is_feature_activiated` and `preactivate_feature` are added to `eosio.cdt`
-#include <eosio/../../capi/eosio/crypto.h>
-
-namespace eosio {
-   namespace internal_use_do_not_use {
-      extern "C" {
-         __attribute__((eosio_wasm_import))
-         bool is_feature_activated( const ::capi_checksum256* feature_digest );
-
-         __attribute__((eosio_wasm_import))
-         void preactivate_feature( const ::capi_checksum256* feature_digest );
-      }
-   }
-
-   bool is_feature_activated( const eosio::checksum256& feature_digest );
-   void preactivate_feature( const eosio::checksum256& feature_digest );
-}
 
 namespace eosiosystem {
 
@@ -47,19 +30,6 @@ namespace eosiosystem {
 
       // explicit serialization macro is not necessary, used here only to improve compilation time
       EOSLIB_SERIALIZE( permission_level_weight, (permission)(weight) )
-   };
-
-   /**
-    * Weighted key.
-    *
-    * A weighted key is defined by a public key and an associated weight.
-    */
-   struct key_weight {
-      eosio::public_key  key;
-      uint16_t           weight;
-
-      // explicit serialization macro is not necessary, used here only to improve compilation time
-      EOSLIB_SERIALIZE( key_weight, (key)(weight) )
    };
 
    /**
@@ -86,7 +56,7 @@ namespace eosiosystem {
     */
    struct authority {
       uint32_t                              threshold = 0;
-      std::vector<key_weight>               keys;
+      std::vector<eosio::key_weight>        keys;
       std::vector<permission_level_weight>  accounts;
       std::vector<wait_weight>              waits;
 

--- a/contracts/eosio.system/src/native.cpp
+++ b/contracts/eosio.system/src/native.cpp
@@ -2,21 +2,6 @@
 
 #include <eosio/check.hpp>
 
-namespace eosio {
-   bool is_feature_activated( const eosio::checksum256& feature_digest ) {
-      auto feature_digest_data = feature_digest.extract_as_byte_array();
-      return internal_use_do_not_use::is_feature_activated(
-         reinterpret_cast<const ::capi_checksum256*>( feature_digest_data.data() )
-      );
-   }
-
-   void preactivate_feature( const eosio::checksum256& feature_digest ) {
-      auto feature_digest_data = feature_digest.extract_as_byte_array();
-      internal_use_do_not_use::preactivate_feature(
-         reinterpret_cast<const ::capi_checksum256*>( feature_digest_data.data() )
-      );
-   }
-}
 
 namespace eosiosystem {
 


### PR DESCRIPTION
… CDT.

<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->

## Change Description
<!-- Describe your changes, their justification, AND their impact. Reference issues or pull requests where possible (use '#XX' or 'GH-XX' where XX is the issue or pull request number). -->

Removes the  preactivate_feature() and is_feature_activated() functions from eosio.contracts. These functions have been moved CDT 1.6.x in a separate PR, and brings CDT 1.6 and eosio.contracts in line with later versions. This is related to cmake regression 3) in the issue: https://blockone.atlassian.net/browse/EPE-1161

## Deployment Changes
- [ ] Deployment Changes
<!-- checked [x] = Deployment changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces a change to the contracts that causes deployment to change, please describe the impact. -->


## API Changes
- [ ] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions
- [ ] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
