### PR TITLE
fixed small typo in the docstring

### DIFF
--- a/contracts/eosio.token/include/eosio.token/eosio.token.hpp
+++ b/contracts/eosio.token/include/eosio.token/eosio.token.hpp
@@ -45,7 +45,7 @@ namespace eosio {
           *
           * @param to - the account to issue tokens to, it must be the same as the issuer,
           * @param quantity - the amount of tokens to be issued,
-          * @memo - the memo string that accompanies the token issue transaction.
+          * @param memo - the memo string that accompanies the token issue transaction.
           */
          [[eosio::action]]
          void issue( const name& to, const asset& quantity, const string& memo );

--- a/contracts/eosio.token/include/eosio.token/eosio.token.hpp
+++ b/contracts/eosio.token/include/eosio.token/eosio.token.hpp
@@ -44,7 +44,7 @@ namespace eosio {
           *  This action issues to `to` account a `quantity` of tokens.
           *
           * @param to - the account to issue tokens to, it must be the same as the issuer,
-          * @param quntity - the amount of tokens to be issued,
+          * @param quantity - the amount of tokens to be issued,
           * @memo - the memo string that accompanies the token issue transaction.
           */
          [[eosio::action]]


### PR DESCRIPTION
Fixed small typo in the docstring of the issue action


## Change Description
I noticed a small typo in the docstring/comment description of the issue action while trying to understand the token contract, so I decided to fix it and make a PR.

